### PR TITLE
Travis CI - Reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 language: csharp
-solution: src/Promitor.sln
 dotnet: 2.1.302
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,3 @@ script:
  - cd ./src/Promitor.Scraper.Host
  - snyk test --packageManager=nuget --org=tomkerkhove-github-marketplace
  - snyk monitor --packageManager=nuget --org=tomkerkhove-github-marketplace
- - cd ..
- - cd ./Promitor.Integrations.AzureMonitor
- - snyk test --packageManager=nuget --org=tomkerkhove-github-marketplace
- - snyk monitor --packageManager=nuget --org=tomkerkhove-github-marketplace


### PR DESCRIPTION
- Remove Solution and do everything with dotnet to avoid restoring & building twice
- Only scan host