### PR TITLE
Update Guard.NET to v1.2 & Microsoft.AspNetCore.App to v2.1.4

### DIFF
--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -7,12 +7,11 @@ using Microsoft.Azure.Management.Monitor.Fluent;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using GuardNet;
 using Promitor.Integrations.AzureMonitor.Exceptions;
 
 namespace Promitor.Integrations.AzureMonitor
 {
-    using Guard;
-
     public class AzureMonitorClient
     {
         private readonly IAzure _authenticatedAzureSubscription;

--- a/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricInformationNotFoundException.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricInformationNotFoundException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+using GuardNet;
 
 namespace Promitor.Integrations.AzureMonitor.Exceptions
 {
-    using Guard;
-
     public class MetricInformationNotFoundException : Exception
     {
         /// <summary>

--- a/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricNotFoundException.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricNotFoundException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
+using GuardNet;
 
 namespace Promitor.Integrations.AzureMonitor.Exceptions
 {
-    using Guard;
-    
     public class MetricNotFoundException : Exception
     {
         /// <summary>

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.15.1" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.15.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.NET" Version="1.0.0.2" />
+    <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.15.1" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.15.1" />

--- a/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetadataDeserializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetadataDeserializer.cs
@@ -1,4 +1,5 @@
 ﻿using Promitor.Scraper.Host.Configuration.Model;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
@@ -7,7 +8,7 @@ namespace Promitor.Scraper.Host.Configuration.Serialization
     {
         internal override AzureMetadata Deserialize(YamlMappingNode node)
         {
-            Guard.Guard.NotNull(node, nameof(node));
+            Guard.NotNull(node, nameof(node));
 
             var tenantId = node.Children[new YamlScalarNode("tenantId")];
             var subscriptionId = node.Children[new YamlScalarNode("subscriptionId")];

--- a/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetricConfigurationDeserializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetricConfigurationDeserializer.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Promitor.Scraper.Host.Configuration.Model;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
 {
-    using Guard;
-
     internal class AzureMetricConfigurationDeserializer:Deserializer<AzureMetricConfiguration>
     {
         internal override AzureMetricConfiguration Deserialize(YamlMappingNode node)

--- a/src/Promitor.Scraper.Host/Configuration/Serialization/ConfigurationSerializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/ConfigurationSerializer.cs
@@ -4,12 +4,11 @@ using System.Linq;
 using Promitor.Scraper.Host.Configuration.Model;
 using Promitor.Scraper.Host.Configuration.Model.Metrics;
 using Promitor.Scraper.Host.Serialization;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
 {
-    using Guard;
-
     public class ConfigurationSerializer
     {
         public static MetricsDeclaration Deserialize(string rawMetricsDeclaration)

--- a/src/Promitor.Scraper.Host/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/Deserializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
@@ -10,7 +11,7 @@ namespace Promitor.Scraper.Host.Configuration.Serialization
 
         internal List<TObject> Deserialize(YamlSequenceNode nodes)
         {
-            Guard.Guard.NotNull(nodes, nameof(nodes));
+            Guard.NotNull(nodes, nameof(nodes));
 
             var deserializedObjects = new List<TObject>();
             foreach (var item in nodes)

--- a/src/Promitor.Scraper.Host/Configuration/Serialization/MetricsDeserializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/MetricsDeserializer.cs
@@ -2,6 +2,7 @@
 using Promitor.Scraper.Host.Configuration.Model;
 using Promitor.Scraper.Host.Configuration.Model.Metrics;
 using Promitor.Scraper.Host.Configuration.Model.Metrics.ResouceTypes;
+using GuardNet;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
@@ -58,7 +59,7 @@ namespace Promitor.Scraper.Host.Configuration.Serialization
         private static TMetricDefinition DeserializeMetricDefinition<TMetricDefinition>(YamlMappingNode metricNode)
             where TMetricDefinition : MetricDefinition, new()
         {
-            Guard.Guard.NotNull(metricNode, nameof(metricNode));
+            Guard.NotNull(metricNode, nameof(metricNode));
 
             var name = metricNode.Children[new YamlScalarNode("name")];
             var description = metricNode.Children[new YamlScalarNode("description")];

--- a/src/Promitor.Scraper.Host/Dockerfile
+++ b/src/Promitor.Scraper.Host/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.401-sdk AS build
+FROM microsoft/dotnet:2.1.402-sdk AS build
 WORKDIR /src
 COPY Promitor.Scraper.Host/* Promitor.Scraper.Host/
 COPY Promitor.Core.Telemetry/* Promitor.Core.Telemetry/
@@ -6,7 +6,7 @@ COPY Promitor.Integrations.AzureMonitor/* Promitor.Integrations.AzureMonitor/
 RUN dotnet --info
 RUN dotnet publish Promitor.Scraper.Host/Promitor.Scraper.Host.csproj --configuration release -o app
 
-FROM microsoft/dotnet:2.1.3-aspnetcore-runtime as runtime
+FROM microsoft/dotnet:2.1.4-aspnetcore-runtime as runtime
 WORKDIR /app
 EXPOSE 80
 COPY --from=build /src/Promitor.Scraper.Host/app .

--- a/src/Promitor.Scraper.Host/Docs/Open-Api.xml
+++ b/src/Promitor.Scraper.Host/Docs/Open-Api.xml
@@ -62,6 +62,7 @@
             </summary>
             <param name="azureMetadata">Metadata concerning the Azure resources</param>
             <param name="metricDefinitionResourceType">Resource type to scrape</param>
+            <param name="exceptionTracker">Tracker used to log exceptions</param>
         </member>
         <member name="M:Promitor.Scraper.Host.Scraping.ScrapeEndpoint.GetBasePath(Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>

--- a/src/Promitor.Scraper.Host/Promitor.Scraper.Host.csproj
+++ b/src/Promitor.Scraper.Host/Promitor.Scraper.Host.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="Prometheus.Client.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Shuttle.Core.Cron" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />

--- a/src/Promitor.Scraper.Host/Scraping/Scraper.cs
+++ b/src/Promitor.Scraper.Host/Scraping/Scraper.cs
@@ -7,6 +7,7 @@ using Promitor.Integrations.AzureMonitor;
 using Promitor.Scraper.Host.Configuration.Model;
 using Promitor.Scraper.Host.Configuration.Model.Metrics;
 using Promitor.Scraper.Host.Scraping.Interfaces;
+using GuardNet;
 
 namespace Promitor.Scraper.Host.Scraping
 {
@@ -27,7 +28,7 @@ namespace Promitor.Scraper.Host.Scraping
         /// <param name="exceptionTracker">Exception tracker</param>
         protected Scraper(AzureMetadata azureMetadata, AzureCredentials azureCredentials, IExceptionTracker exceptionTracker)
         {
-            Guard.Guard.NotNull(exceptionTracker, nameof(exceptionTracker));
+            Guard.NotNull(exceptionTracker, nameof(exceptionTracker));
 
             _exceptionTracker = exceptionTracker;
 

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
@@ -4,6 +4,7 @@ using Promitor.Scraper.Host.Configuration.Model;
 using Promitor.Scraper.Host.Configuration.Model.Metrics;
 using Promitor.Scraper.Host.Configuration.Model.Metrics.ResouceTypes;
 using Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes;
+using GuardNet;
 
 namespace Promitor.Scraper.Host.Validation.MetricDefinitions
 {
@@ -11,7 +12,7 @@ namespace Promitor.Scraper.Host.Validation.MetricDefinitions
     {
         public List<string> Validate(List<MetricDefinition> metrics)
         {
-            Guard.Guard.NotNull(metrics, nameof(metrics));
+            Guard.NotNull(metrics, nameof(metrics));
 
             var errorMessages = new List<string>();
 
@@ -26,7 +27,7 @@ namespace Promitor.Scraper.Host.Validation.MetricDefinitions
 
         public List<string> Validate(MetricDefinition metric)
         {
-            Guard.Guard.NotNull(metric, nameof(metric));
+            Guard.NotNull(metric, nameof(metric));
 
             var errorMessages = new List<string>();
 


### PR DESCRIPTION
This PR closes the security vulnerability in Microsoft.AspNetCore.App v2.1.3 and closes #167 