### PR TITLE
Be more resilient when deserializing aggregation enum

### DIFF
--- a/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetricConfigurationDeserializer.cs
+++ b/src/Promitor.Scraper.Host/Configuration/Serialization/AzureMetricConfigurationDeserializer.cs
@@ -1,28 +1,34 @@
-﻿using System;
+﻿using GuardNet;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Promitor.Scraper.Host.Configuration.Model;
-using GuardNet;
+using System;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Scraper.Host.Configuration.Serialization
 {
-    internal class AzureMetricConfigurationDeserializer:Deserializer<AzureMetricConfiguration>
+    internal class AzureMetricConfigurationDeserializer : Deserializer<AzureMetricConfiguration>
     {
+        private readonly YamlScalarNode _metricNode = new YamlScalarNode("metricName");
+        private readonly YamlScalarNode _aggregationNode = new YamlScalarNode("aggregation"); 
+        
         internal override AzureMetricConfiguration Deserialize(YamlMappingNode node)
         {
-            Guard.NotNull(node, nameof(node));
+            Guard.NotNull(node, nameof(node)); 
+            
+            var metricName = node.Children[_metricNode];
+            AggregationType aggregationType = AggregationType.None;
 
-            var metricName = node.Children[new YamlScalarNode("metricName")];
-            var rawAggregation = node.Children[new YamlScalarNode("aggregation")];
-
-            Enum.TryParse(rawAggregation?.ToString(), out AggregationType aggregationType);
+            if (node.Children.ContainsKey(_aggregationNode))
+            {
+                var rawAggregation = node.Children[_aggregationNode];
+                Enum.TryParse(rawAggregation?.ToString(), out aggregationType);
+            }
 
             var azureMetricConfiguration = new AzureMetricConfiguration
             {
                 MetricName = metricName?.ToString(),
                 Aggregation = aggregationType
             };
-
             return azureMetricConfiguration;
         }
     }


### PR DESCRIPTION
When a yaml configuration is presented without aggregation type for `azureMetricConfiguration`, the deserializer would fail. This changes the behavior to fallback to the default value (None).

Sample failing yaml:
```yml
azureMetadata:
  resourceGroupName: Rhiannon
  subscriptionId: 75226421
  tenantId: 01079505
metrics:
- namespace: Ernser
  queueName: Polly
  resourceType: ServiceBusQueue
  azureMetricConfiguration:
    metricName: Demetrius
  description: Eligendi minima est dolorum explicabo rem.
  name: Gaston
```

Fixes #159, which would occur when Bogus generates data with an aggregation set to `None`.
