### PR TITLE
Make the HTTP port configurable

### DIFF
--- a/deploy/kubernetes-spec.yaml
+++ b/deploy/kubernetes-spec.yaml
@@ -19,6 +19,9 @@ spec:
         - name: containo-orders-api
           image: tomkerkhove/promitor-scraper:0.3.0
           env:
+          - name:  PROMITOR_HTTP_PORT
+            # Optional - Defines the port number on which HTTP traffic will be served.Provide the Azure AD App Id (default is 80)
+            value: "88"
           - name:  PROMITOR_AUTH_APPID
             # Provide the Azure AD App Id
             # See documentation for more information - https://promitor.io/configuration/#authentication-with-azure-monitor
@@ -75,7 +78,7 @@ spec:
   ports:
   - protocol: TCP
     port: 1337
-    targetPort: 80
+    targetPort: 88
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -5,6 +5,10 @@ title: General Configuration
 
 Here is an overview of how you can configure Promitor.
 
+# Runtime
+The Promitor runtime is flexible and allows you to configure it to meet your needs:
+- **PROMITOR_HTTP_PORT** - Defines the port to serve HTTP traffic _(default 80)_
+
 # Scraping
 Promitor automatically scrapes Azure Monitor and makes the information available based on the metrics configuration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ And there is more on the way - Check our [backlog](https://github.com/tomkerkhov
     - [Running Promitor on Docker](deployment#docker)
     - [Running Promitor on Kubernetes](deployment#kubernetes)
 - **Configuration**
+    - [Runtime](configuration#runtime)
     - [Scraping](configuration#scraping)
     - [Authentication with Azure Monitor](configuration#authentication-with-azure-monitor)
     - [Metrics Declaration](configuration/metrics)

--- a/src/Promitor.Core/EnvironmentVariables.cs
+++ b/src/Promitor.Core/EnvironmentVariables.cs
@@ -2,6 +2,11 @@
 {
     public class EnvironmentVariables
     {
+        public class Runtime
+        {
+            public const string HttpPort = "PROMITOR_HTTP_PORT";
+        }
+
         public class Authentication
         {
             public const string ApplicationId = "PROMITOR_AUTH_APPID";

--- a/src/Promitor.Scraper.Host/Dockerfile
+++ b/src/Promitor.Scraper.Host/Dockerfile
@@ -10,7 +10,6 @@ RUN dotnet publish Promitor.Scraper.Host/Promitor.Scraper.Host.csproj --configur
 
 FROM microsoft/dotnet:2.1.6-aspnetcore-runtime as runtime
 WORKDIR /app
-EXPOSE 80
 COPY --from=build /src/Promitor.Scraper.Host/app .
 
 ENTRYPOINT ["dotnet", "Promitor.Scraper.Host.dll"]

--- a/src/Promitor.Scraper.Host/Program.cs
+++ b/src/Promitor.Scraper.Host/Program.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.AspNetCore;
+﻿using System;
+using System.Net;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.Management.ContainerInstance.Fluent.Models;
+using Promitor.Core;
 
 namespace Promitor.Scraper.Host
 {
@@ -7,7 +11,15 @@ namespace Promitor.Scraper.Host
     {
         public static IWebHost BuildWebHost(string[] args)
         {
+            var httpPort = DetermineHttpPort();
+            var endpointUrl = $"http://+:{httpPort}";
+
             return WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(kestrelServerOptions =>
+                {
+                    kestrelServerOptions.AddServerHeader = false;
+                })
+                .UseUrls(endpointUrl)
                 .UseStartup<Startup>()
                 .Build();
         }
@@ -15,6 +27,17 @@ namespace Promitor.Scraper.Host
         public static void Main(string[] args)
         {
             BuildWebHost(args).Run();
+        }
+
+        private static int DetermineHttpPort()
+        {
+            var rawConfiguredHttpPort = Environment.GetEnvironmentVariable(EnvironmentVariables.Runtime.HttpPort);
+            if (int.TryParse(rawConfiguredHttpPort, out int configuredHttpPort))
+            {
+                return configuredHttpPort;
+            }
+
+            return 80;
         }
     }
 }

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -4,8 +4,9 @@ services:
   promitor.scraper:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - PROMITOR_HTTP_PORT=88
       - PROMITOR_AUTH_APPID=<PROMITOR_AUTH_APPID>
       - PROMITOR_AUTH_APPKEY=<PROMITOR_AUTH_APPKEY>
       - PROMITOR_TELEMETRY_INSTRUMENTATIONKEY=
     ports:
-      - "80"
+      - "88"


### PR DESCRIPTION
- Make the HTTP port configurable via `PROMITOR_HTTP_PORT` environment variable
- No longer pass `Server` HTTP header

Closes #238 	