### PR TITLE
Upgrade to .NET 2.2.1 to mitigate CVE-2019-0548 & CVE-2019-0564

### DIFF
--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.18.0" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.18.0" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />

--- a/src/Promitor.Scraper.Host/Dockerfile
+++ b/src/Promitor.Scraper.Host/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2.100-sdk AS build
+FROM microsoft/dotnet:2.2.102-sdk AS build
 WORKDIR /src
 COPY Promitor.Core/* Promitor.Core/
 COPY Promitor.Core.Scraping/* Promitor.Core.Scraping/
@@ -8,7 +8,7 @@ COPY Promitor.Scraper.Host/* Promitor.Scraper.Host/
 RUN dotnet --info
 RUN dotnet publish Promitor.Scraper.Host/Promitor.Scraper.Host.csproj --configuration release -o app
 
-FROM microsoft/dotnet:2.2.0-aspnetcore-runtime as runtime
+FROM microsoft/dotnet:2.2.1-aspnetcore-runtime as runtime
 WORKDIR /app
 COPY --from=build /src/Promitor.Scraper.Host/app .
 

--- a/src/Promitor.Scraper.Host/Promitor.Scraper.Host.csproj
+++ b/src/Promitor.Scraper.Host/Promitor.Scraper.Host.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
     <PackageReference Include="Prometheus.Client.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Shuttle.Core.Cron" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />


### PR DESCRIPTION
Upgrade to .NET 2.2.1 to mitigate CVE-2019-0548 & CVE-2019-0564

Closes #267