### PR TITLE
Extend code owners with people from hackaton

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,9 @@
 
 # These owners will be the default owners for everything in the repo.
 *       @tomkerkhove
+
+# Hackaton Codeowners
+docs/*  @brusmx
+deploy/*  @brusmx @jsturtevant
+charts/*  @brusmx @jsturtevant
+src/*   @brandonh-msft @jsturtevant


### PR DESCRIPTION
Every PR it assign people based on area:
- Docs - @brusmx
- Deploy & Kube chart - @brusmx @jsturtevant
- Code - @brandonh-msft @jsturtevant

This should be fine according to : https://help.github.com/en/articles/about-code-owners