### PR TITLE
Virtual machine metrics

### DIFF
--- a/docs/configuration/metrics/index.md
+++ b/docs/configuration/metrics/index.md
@@ -56,6 +56,7 @@ We also provide a simplified way to configure the following Azure resources:
 - [Azure Container Instances](container-instances)
 - [Azure Service Bus Queue](service-bus-queue)
 - [Azure Storage Queue](storage-queue)
+- [Azure Virtual Machine](virtual-machine)
 
 Want to help out? Create an issue and [contribute a new scraper](https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md).
 

--- a/docs/configuration/metrics/virtual-machine.md
+++ b/docs/configuration/metrics/virtual-machine.md
@@ -14,7 +14,7 @@ All supported metrics are documented in the official [Azure Monitor documentatio
 Example:
 ```yaml
 name: demo_virtualmachine_percentage_cpu
-description: "Average percentage cpu usage of our 'promitor-virtual-machine'"
+description: "Average percentage cpu usage of our 'promitor-virtual-machine' virtual machine"
 resourceType: VirtualMachine
 virtualMachineName: promitor-virtual-machine
 azureMetricConfiguration:

--- a/docs/configuration/metrics/virtual-machine.md
+++ b/docs/configuration/metrics/virtual-machine.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Azure Virtual Machine Declaration
+---
+
+## Azure Virtual Machine
+You can declare to scrape an Azure Virtual Machine via the `VirtualMachine` resource type.
+
+The following fields need to be provided:
+- `virtualMachineName` - The name of the virtual machine
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcomputevirtualmachines).
+
+Example:
+```yaml
+name: demo_virtualmachine_percentage_cpu
+description: "Average percentage cpu usage of our 'promitor-virtual-machine'"
+resourceType: VirtualMachine
+virtualMachineName: promitor-virtual-machine
+azureMetricConfiguration:
+  metricName: Percentage CPU
+  aggregation:
+    type: Average
+```
+
+[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to introduction](/)

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/VirtualMachineMetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/VirtualMachineMetricDefinition.cs
@@ -1,0 +1,8 @@
+namespace Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes
+{
+    public class VirtualMachineMetricDefinition : MetricDefinition
+    {
+        public string VirtualMachineName { get; set; }
+        public override ResourceType ResourceType { get; set; } = ResourceType.VirtualMachine;
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/VirtualMachineMetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/VirtualMachineMetricDefinition.cs
@@ -3,6 +3,6 @@ namespace Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes
     public class VirtualMachineMetricDefinition : MetricDefinition
     {
         public string VirtualMachineName { get; set; }
-        public override ResourceType ResourceType { get; set; } = ResourceType.VirtualMachine;
+        public override ResourceType ResourceType { get; } = ResourceType.VirtualMachine;
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/ResourceType.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/ResourceType.cs
@@ -6,6 +6,7 @@
         ServiceBusQueue = 1,
         Generic = 2,
         StorageQueue = 3,
-        ContainerInstance = 4
+        ContainerInstance = 4,
+        VirtualMachine = 5
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializers/VirtualMachineMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializers/VirtualMachineMetricDeserializer.cs
@@ -14,7 +14,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.Deserializers
             var metricDefinition = base.DeserializeMetricDefinition<VirtualMachineMetricDefinition>(metricNode);
             var virtualMachineName = metricNode.Children[new YamlScalarNode("virtualMachineName")];
 
-            metricDefinition.virtualMachineName = virtualMachineName?.ToString();
+            metricDefinition.VirtualMachineName = virtualMachineName?.ToString();
 
             return metricDefinition;
         }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializers/VirtualMachineMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializers/VirtualMachineMetricDeserializer.cs
@@ -1,0 +1,22 @@
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.Deserializers
+{
+    internal class VirtualMachineMetricDeserializer : GenericAzureMetricDeserializer
+    {
+        /// <summary>Deserializes the specified Virtual Machine metric node from the YAML configuration file.</summary>
+        /// <param name="metricNode">The metric node containing 'virtualMachineName' parameter pointing to an instance of a Virtual Machine</param>
+        /// <returns>A new <see cref="MetricDefinition"/> object (strongly typed as a <see cref="VirtualMachineMetricDefinition"/>) </returns>
+        internal override MetricDefinition Deserialize(YamlMappingNode metricNode)
+        {
+            var metricDefinition = base.DeserializeMetricDefinition<VirtualMachineMetricDefinition>(metricNode);
+            var virtualMachineName = metricNode.Children[new YamlScalarNode("virtualMachineName")];
+
+            metricDefinition.virtualMachineName = virtualMachineName?.ToString();
+
+            return metricDefinition;
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
@@ -18,7 +18,7 @@ namespace Promitor.Core.Scraping.Factories
                 case Configuration.Model.ResourceType.ContainerInstance:
                     return new ContainerInstanceMetricDeserializer();
                 case Configuration.Model.ResourceType.VirtualMachine:
-                    return new VirtualMachineMetric();
+                    return new VirtualMachineMetricDeserializer();
             }
 
             throw new ArgumentOutOfRangeException($@"Resource Type {resource} not supported.");

--- a/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
@@ -17,6 +17,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new StorageQueueMetricDeserializer();
                 case Configuration.Model.ResourceType.ContainerInstance:
                     return new ContainerInstanceMetricDeserializer();
+                case Configuration.Model.ResourceType.VirtualMachine:
+                    return new VirtualMachineMetric();
             }
 
             throw new ArgumentOutOfRangeException($@"Resource Type {resource} not supported.");

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -35,6 +35,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new StorageQueueScraper(azureMetadata, metricDefaults, azureMonitorClient, logger, exceptionTracker);
                 case ResourceType.ContainerInstance:
                     return new ContainerInstanceScraper(azureMetadata, metricDefaults, azureMonitorClient, logger, exceptionTracker);
+                case ResourceType.VirtualMachine:
+                    return new VirtualMachineScraper(azureMetadata, metricDefaults, azureMonitorClient, logger, exceptionTracker);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.Monitor.Fluent.Models;
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Telemetry.Interfaces;
+using Promitor.Integrations.AzureMonitor;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class VirtualMachineScraper : Scraper<VirtualMachineMetricDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ServiceBus/namespaces/{2}";
+
+        public VirtualMachineScraper(AzureMetadata azureMetadata, MetricDefaults metricDefaults, AzureMonitorClient azureMonitorClient, ILogger logger, IExceptionTracker exceptionTracker)
+            : base(azureMetadata, metricDefaults, azureMonitorClient, logger, exceptionTracker)
+        {
+        }
+
+        protected override async Task<double> ScrapeResourceAsync(VirtualMachineMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        {
+            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.VirtualMachineName);
+
+            var filter = $"EntityName eq '{metricDefinition.VirtualMachineName}'";
+            var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
+            var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, filter);
+
+            return foundMetricValue;
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
@@ -11,7 +11,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
 {
     internal class VirtualMachineScraper : Scraper<VirtualMachineMetricDefinition>
     {
-        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ServiceBus/namespaces/{2}";
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Compute/virtualMachines/{2}";
 
         public VirtualMachineScraper(AzureMetadata azureMetadata, MetricDefaults metricDefaults, AzureMonitorClient azureMonitorClient, ILogger logger, IExceptionTracker exceptionTracker)
             : base(azureMetadata, metricDefaults, azureMonitorClient, logger, exceptionTracker)
@@ -22,9 +22,8 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
             var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.VirtualMachineName);
 
-            var filter = $"EntityName eq '{metricDefinition.VirtualMachineName}'";
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
-            var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, filter);
+            var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
             return foundMetricValue;
         }

--- a/src/Promitor.Scraper.Host/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Scraper.Host/Validation/Factories/MetricValidatorFactory.cs
@@ -19,6 +19,8 @@ namespace Promitor.Scraper.Host.Validation.Factories
                     return new StorageQueueMetricValidator();
                 case ResourceType.ContainerInstance:
                     return new ContainerInstanceMetricValidator();
+                case ResourceType.VirtualMachine:
+                    return new VirtualMachineMetricValidator();
             }
 
             throw new ArgumentOutOfRangeException(nameof(resourceType), $"No validation rules are defined for metric type '{resourceType}'");

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
@@ -48,7 +48,7 @@ namespace Promitor.Scraper.Host.Validation.MetricDefinitions
             {
                 errorMessages.Add("No metric name is configured");
             }
-            
+
             var metricDefinitionValidationErrors = MetricValidatorFactory
                 .GetValidatorFor(metric.ResourceType)
                 .Validate(metric);

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/MetricsValidator.cs
@@ -48,7 +48,7 @@ namespace Promitor.Scraper.Host.Validation.MetricDefinitions
             {
                 errorMessages.Add("No metric name is configured");
             }
-
+            
             var metricDefinitionValidationErrors = MetricValidatorFactory
                 .GetValidatorFor(metric.ResourceType)
                 .Validate(metric);

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/VirtualMachineMetricValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/VirtualMachineMetricValidator.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
+using GuardNet;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
-using Promitor.Scraper.Host.Validation.MetricDefinitions.Interfaces;
 
 namespace Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes
 {
-    public class VirtualMachineMetricValidator : IMetricValidator<VirtualMachineMetricDefinition>
+    internal class VirtualMachineMetricValidator : MetricValidator<VirtualMachineMetricDefinition>
     {
-        public List<string> Validate(VirtualMachineMetricDefinition virtualMachineMetricDefinition)
+        protected override IEnumerable<string> Validate(VirtualMachineMetricDefinition virtualMachineMetricDefinition)
         {
+            Guard.NotNull(virtualMachineMetricDefinition, nameof(virtualMachineMetricDefinition));
+
             var errorMessages = new List<string>();
 
             if (string.IsNullOrWhiteSpace(virtualMachineMetricDefinition.VirtualMachineName))

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/VirtualMachineMetricValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/VirtualMachineMetricValidator.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Scraper.Host.Validation.MetricDefinitions.Interfaces;
+
+namespace Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes
+{
+    public class VirtualMachineMetricValidator : IMetricValidator<VirtualMachineMetricDefinition>
+    {
+        public List<string> Validate(VirtualMachineMetricDefinition virtualMachineMetricDefinition)
+        {
+            var errorMessages = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(virtualMachineMetricDefinition.VirtualMachineName))
+            {
+                errorMessages.Add("No virtual machine name is configured");
+            }
+
+            return errorMessages;
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
@@ -96,6 +96,23 @@ namespace Promitor.Scraper.Tests.Unit.Builders
             return this;
         }
 
+        public MetricsDeclarationBuilder WithVirtualMachineMetric(string metricName = "promitor-virtual-machine", string metricDescription = "Description for a metric", string virtualMachineName = "promitor-virtual-machine-name",  string azureMetricName = "Total")
+        {
+            var azureMetricConfiguration = CreateAzureMetricConfiguration(azureMetricName);
+            var metric = new VirtualMachineMetricDefinition
+            {
+                ResourceType = ResourceType.VirtualMachine,
+                Name = metricName,
+                Description = metricDescription,
+                VirtualMachineName = virtualMachineName,
+                AzureMetricConfiguration = azureMetricConfiguration
+            };
+
+            _metrics.Add(metric);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithGenericMetric(string metricName = "foo", string metricDescription = "Description for a metric", string resourceUri = "Microsoft.ServiceBus/namespaces/promitor-messaging", string filter = "EntityName eq \'orders\'", string azureMetricName = "Total")
         {
             var azureMetricConfiguration = CreateAzureMetricConfiguration(azureMetricName);

--- a/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
@@ -101,7 +101,6 @@ namespace Promitor.Scraper.Tests.Unit.Builders
             var azureMetricConfiguration = CreateAzureMetricConfiguration(azureMetricName);
             var metric = new VirtualMachineMetricDefinition
             {
-                ResourceType = ResourceType.VirtualMachine,
                 Name = metricName,
                 Description = metricDescription,
                 VirtualMachineName = virtualMachineName,

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
@@ -5,7 +5,7 @@ using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
 using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
-using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.Core;
 using Xunit;
 using MetricDefinition = Promitor.Core.Scraping.Configuration.Model.Metrics.MetricDefinition;
 
@@ -44,8 +44,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             Assert.Single(deserializedConfiguration.Metrics);
             var deserializedMetricDefinition = deserializedConfiguration.Metrics.FirstOrDefault();
             AssertMetricDefinition(deserializedMetricDefinition, virtualMachineMetricDefinition);
-            var deserializedServiceBusMetricDefinition = deserializedMetricDefinition as VirtualMachineMetricDefinition;
-            AssertVirtualMachineMetricDefinition(deserializedServiceBusMetricDefinition, virtualMachineMetricDefinition, deserializedMetricDefinition);
+            var deserializedVirtualMachineMetricDefinition = deserializedMetricDefinition as VirtualMachineMetricDefinition;
+            AssertVirtualMachineMetricDefinition(deserializedVirtualMachineMetricDefinition, virtualMachineMetricDefinition, deserializedMetricDefinition);
         }
 
         private static void AssertVirtualMachineMetricDefinition(VirtualMachineMetricDefinition deserializedVirtualMachineMetricDefinition, VirtualMachineMetricDefinition virtualMachineMetricDefinition, MetricDefinition deserializedMetricDefinition)

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Bogus;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+using MetricDefinition = Promitor.Core.Scraping.Configuration.Model.Metrics.MetricDefinition;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
+{
+    [Category("Unit")]
+    public class MetricsDeclarationWithVirtualMachineYamlSerializationTests : YamlSerializationTests<VirtualMachineMetricDefinition>
+    {
+        [Fact]
+        public void YamlSerialization_SerializeAndDeserializeValidConfigForVirtualMachine_SucceedsWithIdenticalOutput()
+        {
+            // Arrange
+            var azureMetadata = GenerateBogusAzureMetadata();
+            var virtualMachineMetricDefinition = GenerateBogusVirtualMachineMetricDefinition();
+            var metricDefaults = GenerateBogusMetricDefaults();
+            var scrapingConfiguration = new Core.Scraping.Configuration.Model.MetricsDeclaration
+            {
+                AzureMetadata = azureMetadata,
+                MetricDefaults = metricDefaults,
+                Metrics = new List<MetricDefinition>
+                {
+                    virtualMachineMetricDefinition
+                }
+            };
+            var configurationSerializer = new ConfigurationSerializer(NullLogger.Instance);
+
+            // Act
+            var serializedConfiguration = configurationSerializer.Serialize(scrapingConfiguration);
+            var deserializedConfiguration = configurationSerializer.Deserialize(serializedConfiguration);
+
+            // Assert
+            Assert.NotNull(deserializedConfiguration);
+            AssertAzureMetadata(deserializedConfiguration, azureMetadata);
+            AssertMetricDefaults(deserializedConfiguration, metricDefaults);
+            Assert.NotNull(deserializedConfiguration.Metrics);
+            Assert.Single(deserializedConfiguration.Metrics);
+            var deserializedMetricDefinition = deserializedConfiguration.Metrics.FirstOrDefault();
+            AssertMetricDefinition(deserializedMetricDefinition, virtualMachineMetricDefinition);
+            var deserializedServiceBusMetricDefinition = deserializedMetricDefinition as VirtualMachineMetricDefinition;
+            AssertVirtualMachineMetricDefinition(deserializedServiceBusMetricDefinition, virtualMachineMetricDefinition, deserializedMetricDefinition);
+        }
+
+        private static void AssertVirtualMachineMetricDefinition(VirtualMachineMetricDefinition deserializedVirtualMachineMetricDefinition, VirtualMachineMetricDefinition virtualMachineMetricDefinition, MetricDefinition deserializedMetricDefinition)
+        {
+            Assert.NotNull(deserializedVirtualMachineMetricDefinition);
+            Assert.Equal(virtualMachineMetricDefinition.VirtualMachineName, deserializedVirtualMachineMetricDefinition.VirtualMachineName);
+            Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
+            Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration.Aggregation);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.Aggregation.Type, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Type);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.Aggregation.Interval, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Interval);
+        }
+        private VirtualMachineMetricDefinition GenerateBogusVirtualMachineMetricDefinition()
+        {
+            var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+            var bogusGenerator = new Faker<VirtualMachineMetricDefinition>()
+                .StrictMode(ensureRulesForAllProperties: true)
+                .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
+                .RuleFor(metricDefinition => metricDefinition.Description, faker => faker.Lorem.Sentence(wordCount: 6))
+                .RuleFor(metricDefinition => metricDefinition.ResourceType, faker => ResourceType.VirtualMachine)
+                .RuleFor(metricDefinition => metricDefinition.VirtualMachineName, faker => faker.Name.LastName())
+                .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration);
+
+            return bogusGenerator.Generate();
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/VirtualMachineMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/VirtualMachineMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Bogus;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+using MetricDefinition = Promitor.Core.Scraping.Configuration.Model.Metrics.MetricDefinition;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
+{
+    [Category("Unit")]
+    public class MetricsDeclarationWithVirtualMachineYamlSerializationTests : YamlSerializationTests<VirtualMachineMetricDefinition>
+    {
+        [Fact]
+        public void YamlSerialization_SerializeAndDeserializeValidConfigForVirtualMachine_SucceedsWithIdenticalOutput()
+        {
+            // Arrange
+            var azureMetadata = GenerateBogusAzureMetadata();
+            var virtualMachineMetricDefinition = GenerateBogusVirtualMachineMetricDefinition();
+            var metricDefaults = GenerateBogusMetricDefaults();
+            var scrapingConfiguration = new Core.Scraping.Configuration.Model.MetricsDeclaration
+            {
+                AzureMetadata = azureMetadata,
+                MetricDefaults = metricDefaults,
+                Metrics = new List<MetricDefinition>
+                {
+                    virtualMachineMetricDefinition
+                }
+            };
+            var configurationSerializer = new ConfigurationSerializer(NullLogger.Instance);
+
+            // Act
+            var serializedConfiguration = configurationSerializer.Serialize(scrapingConfiguration);
+            var deserializedConfiguration = configurationSerializer.Deserialize(serializedConfiguration);
+
+            // Assert
+            Assert.NotNull(deserializedConfiguration);
+            AssertAzureMetadata(deserializedConfiguration, azureMetadata);
+            AssertMetricDefaults(deserializedConfiguration, metricDefaults);
+            Assert.NotNull(deserializedConfiguration.Metrics);
+            Assert.Single(deserializedConfiguration.Metrics);
+            var deserializedMetricDefinition = deserializedConfiguration.Metrics.FirstOrDefault();
+            AssertMetricDefinition(deserializedMetricDefinition, virtualMachineMetricDefinition);
+            var deserializedServiceBusMetricDefinition = deserializedMetricDefinition as VirtualMachineMetricDefinition;
+            AssertVirtualMachineMetricDefinition(deserializedServiceBusMetricDefinition, virtualMachineMetricDefinition, deserializedMetricDefinition);
+        }
+
+        private static void AssertVirtualMachineMetricDefinition(VirtualMachineMetricDefinition deserializedVirtualMachineMetricDefinition, VirtualMachineMetricDefinition virtualMachineMetricDefinition, MetricDefinition deserializedMetricDefinition)
+        {
+            Assert.NotNull(deserializedVirtualMachineMetricDefinition);
+            Assert.Equal(virtualMachineMetricDefinition.VirtualMachineName, deserializedVirtualMachineMetricDefinition.VirtualMachineName);
+            Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
+            Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration.Aggregation);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.Aggregation.Type, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Type);
+            Assert.Equal(virtualMachineMetricDefinition.AzureMetricConfiguration.Aggregation.Interval, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Interval);
+        }
+        private VirtualMachineMetricDefinition GenerateBogusVirtualMachineMetricDefinition()
+        {
+            var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+            var bogusGenerator = new Faker<VirtualMachineMetricDefinition>()
+                .StrictMode(ensureRulesForAllProperties: true)
+                .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
+                .RuleFor(metricDefinition => metricDefinition.Description, faker => faker.Lorem.Sentence(wordCount: 6))
+                .RuleFor(metricDefinition => metricDefinition.ResourceType, faker => ResourceType.VirtualMachine)
+                .RuleFor(metricDefinition => metricDefinition.VirtualMachineName, faker => faker.Name.LastName())
+                .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration);
+
+            return bogusGenerator.Generate();
+        }
+    }
+}


### PR DESCRIPTION
Provides support for scraping Azure Virtual Machines

Example configuration:

```yaml
name: demo_virtualmachine_percentage_cpu
description: "Average percentage cpu usage of our 'promitor-virtual-machine' virtual machine"
resourceType: VirtualMachine
virtualMachineName: promitor-virtual-machine
azureMetricConfiguration:
  metricName: Percentage CPU
  aggregation:
    type: Average
```
Closes #309 
