### PR TITLE
Adding scraping interval to metricDefaults and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ __pycache__/
 # Local Jekyll output
 _site/*
 docs/_site/*
+*.orig

--- a/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
@@ -1,7 +1,11 @@
-﻿namespace Promitor.Core.Scraping.Configuration.Model
+﻿using System;
+
+namespace Promitor.Core.Scraping.Configuration.Model
 {
     public class MetricDefaults
     {
         public Aggregation Aggregation { get; set; } = new Aggregation();
+
+        public TimeSpan ScrapingInterval { get; set; }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Promitor.Core.Scraping.Configuration.Model
+﻿namespace Promitor.Core.Scraping.Configuration.Model
 {
     public class MetricDefaults
     {
         public Aggregation Aggregation { get; set; } = new Aggregation();
 
-        public TimeSpan ScrapingInterval { get; set; }
+        public Scraping Scraping { get; set; } = new Scraping();
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Promitor.Core.Scraping.Configuration.Model.Metrics
+﻿namespace Promitor.Core.Scraping.Configuration.Model.Metrics
 {
     public abstract class MetricDefinition
     {
@@ -31,8 +29,8 @@ namespace Promitor.Core.Scraping.Configuration.Model.Metrics
         public abstract ResourceType ResourceType { get; }
 
         /// <summary>
-        /// Gets or sets the scraping interval.
+        /// Gets or sets the scraping model.
         /// </summary>
-        public TimeSpan? ScrapingInterval { get; set; }
+        public Scraping Scraping { get; set; } = new Scraping();
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace Promitor.Core.Scraping.Configuration.Model.Metrics
+﻿using System;
+
+namespace Promitor.Core.Scraping.Configuration.Model.Metrics
 {
     public abstract class MetricDefinition
     {
@@ -27,5 +29,10 @@
         ///     Type of resource that is configured
         /// </summary>
         public abstract ResourceType ResourceType { get; }
+
+        /// <summary>
+        /// Gets or sets the scraping interval.
+        /// </summary>
+        public TimeSpan? ScrapingInterval { get; set; }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/Scraping.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Scraping.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Promitor.Core.Scraping.Configuration.Model
+{
+    public class Scraping
+    {
+        public TimeSpan? Interval { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
@@ -1,4 +1,6 @@
-﻿using GuardNet;
+﻿using System;
+using System.Collections.Generic;
+using GuardNet;
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using YamlDotNet.RepresentationModel;
@@ -37,6 +39,25 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.Core
                 Description = description?.ToString(),
                 AzureMetricConfiguration = azureMetricConfiguration
             };
+
+            if (metricNode.Children.ContainsKey(@"scraping"))
+            {
+                var scrapingNode = (YamlMappingNode)metricNode.Children[new YamlScalarNode(@"scraping")];
+                try
+                {
+                    var scrapingIntervalNode = scrapingNode?.Children[new YamlScalarNode(@"interval")];
+
+                    if (scrapingIntervalNode != null)
+                    {
+                        metricDefinition.Scraping.Interval = TimeSpan.Parse(scrapingIntervalNode.ToString());
+                    }
+                }
+                catch (KeyNotFoundException)
+                {
+                    // happens when the YAML doesn't have the properties in it which is fine because the object
+                    // will get a default interval of 'null'
+                }
+            }
 
             return metricDefinition;
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -67,7 +66,9 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
 
         private StorageQueueMetricDefinition GenerateBogusAzureStorageQueueMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
+            var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+
             var bogusGenerator = new Faker<StorageQueueMetricDefinition>()
                 .StrictMode(ensureRulesForAllProperties: true)
                 .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
@@ -78,10 +79,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.SasToken, faker => $"?sig={Base64UrlEncoder.Encode(faker.Lorem.Sentence(wordCount: 3))}")
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
-                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
+                .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
@@ -62,7 +62,9 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
         }
         private ContainerInstanceMetricDefinition GenerateBogusContainerInstanceMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
+            var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+
             var bogusGenerator = new Faker<ContainerInstanceMetricDefinition>()
                 .StrictMode(ensureRulesForAllProperties: true)
                 .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
@@ -71,10 +73,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.ContainerGroup, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
-                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
+                .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
@@ -58,7 +58,9 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
 
         private ContainerRegistryMetricDefinition GenerateBogusContainerRegistryMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
+            var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+
             var bogusGenerator = new Faker<ContainerRegistryMetricDefinition>()
                 .StrictMode(ensureRulesForAllProperties: true)
                 .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
@@ -67,10 +69,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.RegistryName, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
-                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
+                .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
@@ -15,14 +15,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
     public class MetricsDeclarationWithContainerRegistryYamlSerializationTests : YamlSerializationTests<ContainerRegistryMetricDefinition>
     {
         [Theory]
-        [InlineData("promitor1")]
-        [InlineData(null)]
-        public void YamlSerialization_SerializeAndDeserializeValidConfigForContainerRegistry_SucceedsWithIdenticalOutput(string resourceGroupName)
+        [InlineData("promitor1", @"01:00", @"2:00")]
+        [InlineData(null, null, null)]
+        public void YamlSerialization_SerializeAndDeserializeValidConfigForContainerRegistry_SucceedsWithIdenticalOutput(string resourceGroupName, string defaultScrapingInterval, string metricScrapingInterval)
         {
             // Arrange
             var azureMetadata = GenerateBogusAzureMetadata();
-            var containerRegistryMetricDefinition = GenerateBogusContainerRegistryMetricDefinition(resourceGroupName);
-            var metricDefaults = GenerateBogusMetricDefaults();
+            var containerRegistryMetricDefinition = GenerateBogusContainerRegistryMetricDefinition(resourceGroupName, metricScrapingInterval);
+            var metricDefaults = GenerateBogusMetricDefaults(defaultScrapingInterval);
             var scrapingConfiguration = new Core.Scraping.Configuration.Model.MetricsDeclaration
             {
                 AzureMetadata = azureMetadata,
@@ -56,7 +56,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             Assert.Equal(serviceBusMetricDefinition.RegistryName, deserializedServiceBusMetricDefinition.RegistryName);
         }
 
-        private ContainerRegistryMetricDefinition GenerateBogusContainerRegistryMetricDefinition(string resourceGroupName)
+        private ContainerRegistryMetricDefinition GenerateBogusContainerRegistryMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
             var bogusGenerator = new Faker<ContainerRegistryMetricDefinition>()
@@ -67,7 +67,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.RegistryName, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
+                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName)
+                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
@@ -59,7 +59,9 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
 
         private ServiceBusQueueMetricDefinition GenerateBogusServiceBusMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
+            var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
+
             var bogusGenerator = new Faker<ServiceBusQueueMetricDefinition>()
                 .StrictMode(ensureRulesForAllProperties: true)
                 .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
@@ -69,10 +71,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.QueueName, faker => faker.Name.FirstName())
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
-                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
-                .Ignore(metricDefinition  => metricDefinition.ResourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
+                .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -64,8 +63,10 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
 
         private VirtualMachineMetricDefinition GenerateBogusVirtualMachineMetricDefinition(string resourceGroupName, string metricScrapingInterval)
         {
+            var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
-            Faker<VirtualMachineMetricDefinition> bogusGenerator = new Faker<VirtualMachineMetricDefinition>()
+
+            var bogusGenerator = new Faker<VirtualMachineMetricDefinition>()
                 .StrictMode(ensureRulesForAllProperties: true)
                 .RuleFor(metricDefinition => metricDefinition.Name, faker => faker.Name.FirstName())
                 .RuleFor(metricDefinition => metricDefinition.Description, faker => faker.Lorem.Sentence(wordCount: 6))
@@ -73,10 +74,8 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.VirtualMachineName, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
-                .RuleFor(metricDefinition => metricDefinition.ScrapingInterval, faker =>
-                    string.IsNullOrWhiteSpace(metricScrapingInterval) ? (TimeSpan?)null : TimeSpan.Parse(metricScrapingInterval))
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName)
-                .Ignore(metricDefinition => metricDefinition.ScrapingInterval);
+                .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
@@ -70,7 +70,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
 
             if (!string.IsNullOrWhiteSpace(defaultScrapingInterval))
             {
-                metricDefaults.ScrapingInterval = TimeSpan.Parse(defaultScrapingInterval);
+                metricDefaults.Scraping.Interval = TimeSpan.Parse(defaultScrapingInterval);
             }
 
             return metricDefaults;
@@ -83,6 +83,15 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metadata => metadata.TenantId, faker => faker.Finance.Account())
                 .RuleFor(metadata => metadata.ResourceGroupName, faker => faker.Name.FirstName())
                 .RuleFor(metadata => metadata.SubscriptionId, faker => faker.Finance.Account());
+
+            return bogusGenerator.Generate();
+        }
+
+        protected Scraping GenerateBogusScrapingInterval(string testInterval)
+        {
+            var bogusGenerator = new Faker<Scraping>()
+                .RuleFor(scraping => scraping.Interval, faker =>
+                    string.IsNullOrWhiteSpace(testInterval) ? (TimeSpan?)null : TimeSpan.Parse(testInterval));
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
@@ -56,7 +56,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             return bogusMetricConfiguration;
         }
 
-        protected MetricDefaults GenerateBogusMetricDefaults()
+        protected MetricDefaults GenerateBogusMetricDefaults(string defaultScrapingInterval)
         {
             var bogusAggregationGenerator = new Faker<Aggregation>()
                 .StrictMode(ensureRulesForAllProperties: true)
@@ -65,8 +65,13 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             var generatedAggregation = bogusAggregationGenerator.Generate();
             var metricDefaults = new MetricDefaults
             {
-                Aggregation = generatedAggregation
+                Aggregation = generatedAggregation,
             };
+
+            if (!string.IsNullOrWhiteSpace(defaultScrapingInterval))
+            {
+                metricDefaults.ScrapingInterval = TimeSpan.Parse(defaultScrapingInterval);
+            }
 
             return metricDefaults;
         }


### PR DESCRIPTION
Partial fix for #258, #259

This adds the YAML configuration support for `metricDefaults.scraping.interval` and `<metric>.scraping.interval`. 

As of this PR, however, `metricDefault` does **not** fill out the metric scraping interval if it is not supplied; this work must be done in the scraper and only makes sense after we have fully rid ourselves of the `CronSchedule` Environment parameter. This will be done in a future PR.