### PR TITLE
Fix license on docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,4 +56,4 @@ And there is more on the way - Check our [backlog](https://github.com/tomkerkhov
 We'd like to thank all the services, tooling & NuGet packages that support us - [Thank you](thank-you)!
 
 # License Information
-This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.
+This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Tom Kerkhove is the original author of this web application.


### PR DESCRIPTION
Fix license on docs page to mention Tom instead of Codit.

Fixes #480