### PR TITLE
Support no messages available with TimeSpentInQueue & Storage scraper

### DIFF
--- a/src/Promitor.Integrations.AzureStorage/AzureStorageQueueClient.cs
+++ b/src/Promitor.Integrations.AzureStorage/AzureStorageQueueClient.cs
@@ -49,8 +49,13 @@ namespace Promitor.Integrations.AzureStorage
         {
             var queue = await GetQueueReference(accountName, queueName, sasToken);
 
-            var msg = await queue.PeekMessageAsync();
-            var timeSpentInQueue = msg.InsertionTime.HasValue ? DateTime.UtcNow - msg.InsertionTime.Value.UtcDateTime : TimeSpan.Zero;
+            var message = await queue.PeekMessageAsync();
+
+            TimeSpan timeSpentInQueue = TimeSpan.Zero;
+            if (message?.InsertionTime.HasValue == true)
+            {
+                timeSpentInQueue = DateTime.UtcNow - message.InsertionTime.Value.UtcDateTime;
+            }
 
             return timeSpentInQueue.TotalSeconds;
         }


### PR DESCRIPTION
Support no messages available with TimeSpentInQueue & Storage scraper by tracking 0 seconds if no messages are available.

Fixes #495

## Samples
When one or more messages are queued:
```
# HELP demo_azurestoragequeue_queue_timespentinqueue Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)
# TYPE demo_azurestoragequeue_queue_timespentinqueue gauge
demo_azurestoragequeue_queue_timespentinqueue 15.212368 1554629347212
```

When no message is in queue:
```
# HELP demo_azurestoragequeue_queue_timespentinqueue Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)
# TYPE demo_azurestoragequeue_queue_timespentinqueue gauge
demo_azurestoragequeue_queue_timespentinqueue 0 1554629307416
```