### PR TITLE
 Provide capability to configure SAS tokens via raw value or environment variable & don't log raw configuration

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/StorageQueueMetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/StorageQueueMetricDefinition.cs
@@ -4,7 +4,7 @@ namespace Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes
     {
         public string AccountName { get; set; }
         public string QueueName { get; set; }
-        public string SasToken { get; set; }
+        public Secret SasToken { get; set; }
         public override ResourceType ResourceType { get; } = ResourceType.StorageQueue;
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/Secret.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/Secret.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Promitor.Core.Scraping.Configuration.Model.Metrics
+{
+    public class Secret
+    {
+        public string RawValue { get; set; }
+        public string EnvironmentVariable { get; set; }
+
+        /// <summary>
+        /// Provides the secret value based on the configured approach
+        /// </summary>
+        public string GetSecretValue()
+        {
+            if (string.IsNullOrWhiteSpace(EnvironmentVariable) == false)
+            {
+                var secretValue = Environment.GetEnvironmentVariable(EnvironmentVariable);
+                return secretValue;
+            }
+
+            if (string.IsNullOrWhiteSpace(RawValue) == false)
+            {
+                return RawValue;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Core/SecretDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Core/SecretDeserializer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.Core
+{
+    internal class SecretDeserializer : Deserializer<Secret>
+    {
+        internal SecretDeserializer(ILogger logger) : base(logger)
+        {
+        }
+
+        internal override Secret Deserialize(YamlMappingNode node)
+        {
+            var secret = new Secret();
+
+            if (node.Children.ContainsKey("rawValue"))
+            {
+                var rawValueNode = node.Children[new YamlScalarNode("rawValue")];
+                secret.RawValue = rawValueNode.ToString();
+            }
+
+            if (node.Children.ContainsKey("environmentVariable"))
+            {
+                var rawEnvironmentVariable = node.Children[new YamlScalarNode("environmentVariable")];
+                secret.EnvironmentVariable = rawEnvironmentVariable.ToString();
+            }
+
+            return secret;
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/StorageQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/StorageQueueScraper.cs
@@ -24,14 +24,17 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
             Guard.NotNull(metricDefinition, nameof(metricDefinition));
             Guard.NotNull(metricDefinition.AzureMetricConfiguration, nameof(metricDefinition.AzureMetricConfiguration));
+            Guard.NotNull(metricDefinition.SasToken, nameof(metricDefinition.SasToken));
             Guard.NotNullOrEmpty(metricDefinition.AzureMetricConfiguration.MetricName, nameof(metricDefinition.AzureMetricConfiguration.MetricName));
+
+            var sasToken = metricDefinition.SasToken.GetSecretValue();
 
             switch (metricDefinition.AzureMetricConfiguration.MetricName.ToLowerInvariant())
             {
                 case AzureStorageConstants.Queues.Metrics.TimeSpentInQueue:
-                    return await _azureStorageQueueClient.GetQueueMessageTimeSpentInQueueAsync(metricDefinition.AccountName, metricDefinition.QueueName, metricDefinition.SasToken);
+                    return await _azureStorageQueueClient.GetQueueMessageTimeSpentInQueueAsync(metricDefinition.AccountName, metricDefinition.QueueName, sasToken);
                 case AzureStorageConstants.Queues.Metrics.MessageCount:
-                    return await _azureStorageQueueClient.GetQueueMessageCountAsync(metricDefinition.AccountName, metricDefinition.QueueName, metricDefinition.SasToken);
+                    return await _azureStorageQueueClient.GetQueueMessageCountAsync(metricDefinition.AccountName, metricDefinition.QueueName, sasToken);
                 default:
                     throw new InvalidMetricNameException(metricDefinition.AzureMetricConfiguration.MetricName, metricDefinition.ResourceType.ToString());
             }

--- a/src/Promitor.Scraper.Host/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Promitor.Scraper.Host/Extensions/IServiceCollectionExtensions.cs
@@ -29,10 +29,10 @@ namespace Promitor.Scraper.Host.Extensions
             {
                 services.AddScheduler(builder =>
                 {
-                    builder.AddJob(sp => new MetricScrapingJob(metric,
+                    builder.AddJob(serviceProvider => new MetricScrapingJob(metric,
                         metricsProvider,
-                        sp.GetService<ILogger>(),
-                        sp.GetService<IExceptionTracker>()));
+                        serviceProvider.GetService<ILogger>(),
+                        serviceProvider.GetService<IExceptionTracker>()));
                     builder.UnobservedTaskExceptionHandler = (sender, exceptionEventArgs) => UnobservedJobHandlerHandler(sender, exceptionEventArgs, services);
                 });
             }

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/StorageQueueMetricValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/StorageQueueMetricValidator.cs
@@ -29,7 +29,8 @@ namespace Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes
                 yield return "No Azure Storage Queue Name is configured";
             }
 
-            if (string.IsNullOrWhiteSpace(metricDefinition.SasToken))
+            var configuredSasToken = metricDefinition.SasToken?.GetSecretValue();
+            if (string.IsNullOrWhiteSpace(configuredSasToken))
             {
                 yield return "No Azure Storage SAS Token is configured";
             }

--- a/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
+++ b/src/Promitor.Scraper.Host/Validation/Steps/MetricsDeclarationValidationStep.cs
@@ -27,9 +27,6 @@ namespace Promitor.Scraper.Host.Validation.Steps
 
         public ValidationResult Run()
         {
-            var rawMetricsConfiguration = _metricsDeclarationProvider.ReadRawDeclaration();
-            Logger.LogInformation("Following metrics configuration was configured:\n{Configuration}", rawMetricsConfiguration);
-
             var metricsDeclaration = _metricsDeclarationProvider.Get(applyDefaults: true);
 
             if (metricsDeclaration == null)

--- a/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Builders/MetricsDeclarationBuilder.cs
@@ -2,6 +2,7 @@
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
 using Promitor.Core.Scraping.Configuration.Serialization.Core;
 using Promitor.Integrations.AzureStorage;
@@ -124,13 +125,18 @@ namespace Promitor.Scraper.Tests.Unit.Builders
         public MetricsDeclarationBuilder WithAzureStorageQueueMetric(string metricName = "promitor", string metricDescription = "Description for a metric", string queueName = "promitor-queue", string accountName = "promitor-account", string sasToken = "?sig=promitor", string azureMetricName = AzureStorageConstants.Queues.Metrics.MessageCount)
         {
             var azureMetricConfiguration = CreateAzureMetricConfiguration(azureMetricName);
+            var secret = new Secret
+            {
+                RawValue = sasToken
+            };
+
             var metric = new StorageQueueMetricDefinition
             {
                 Name = metricName,
                 Description = metricDescription,
                 QueueName = queueName,
                 AccountName = accountName,
-                SasToken = sasToken,
+                SasToken = secret,
                 AzureMetricConfiguration = azureMetricConfiguration
             };
             _metrics.Add(metric);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
@@ -3,8 +3,8 @@ using System.ComponentModel;
 using System.Linq;
 using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.IdentityModel.Tokens;
 using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
 using Promitor.Core.Scraping.Configuration.Serialization.Core;
 using Xunit;
@@ -16,13 +16,13 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
     public class MetricsDeclarationWithAzureStorageQueueYamlSerializationTests : YamlSerializationTests<StorageQueueMetricDefinition>
     {
         [Theory]
-        [InlineData("promitor1", @"* */1 * * * *", @"* */2 * * * *")]
-        [InlineData(null, null, null)]
-        public void YamlSerialization_SerializeAndDeserializeValidConfigForAzureStorageQueue_SucceedsWithIdenticalOutput(string resourceGroupName, string defaultScrapingInterval, string metricScrapingInterval)
+        [InlineData("promitor1", @"* */1 * * * *", @"* */2 * * * *", "XYZ", null)]
+        [InlineData(null, null, null, null, "SAMPLE_SECRET")]
+        public void YamlSerialization_SerializeAndDeserializeValidConfigForAzureStorageQueue_SucceedsWithIdenticalOutput(string resourceGroupName, string defaultScrapingInterval, string metricScrapingInterval, string sasTokenRawValue, string sasTokenEnvironmentVariable)
         {
             // Arrange
             var azureMetadata = GenerateBogusAzureMetadata();
-            var azureStorageQueueMetricDefinition = GenerateBogusAzureStorageQueueMetricDefinition(resourceGroupName, metricScrapingInterval);
+            var azureStorageQueueMetricDefinition = GenerateBogusAzureStorageQueueMetricDefinition(resourceGroupName, metricScrapingInterval, sasTokenRawValue, sasTokenEnvironmentVariable);
             var metricDefaults = GenerateBogusMetricDefaults(defaultScrapingInterval);
             var scrapingConfiguration = new Core.Scraping.Configuration.Model.MetricsDeclaration
             {
@@ -51,20 +51,22 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             AssertAzureStorageQueueMetricDefinition(deserializedAzureStorageQueueMetricDefinition, azureStorageQueueMetricDefinition, deserializedMetricDefinition);
         }
 
-        private static void AssertAzureStorageQueueMetricDefinition(StorageQueueMetricDefinition deserializedServiceBusMetricDefinition, StorageQueueMetricDefinition serviceBusMetricDefinition, MetricDefinition deserializedMetricDefinition)
+        private static void AssertAzureStorageQueueMetricDefinition(StorageQueueMetricDefinition deserializedStorageQueueMetricDefinition, StorageQueueMetricDefinition storageQueueMetricDefinition, MetricDefinition deserializedMetricDefinition)
         {
-            Assert.NotNull(deserializedServiceBusMetricDefinition);
-            Assert.Equal(serviceBusMetricDefinition.AccountName, deserializedServiceBusMetricDefinition.AccountName);
-            Assert.Equal(serviceBusMetricDefinition.QueueName, deserializedServiceBusMetricDefinition.QueueName);
-            Assert.Equal(serviceBusMetricDefinition.SasToken, deserializedServiceBusMetricDefinition.SasToken);
+            Assert.NotNull(deserializedStorageQueueMetricDefinition);
+            Assert.Equal(storageQueueMetricDefinition.AccountName, deserializedStorageQueueMetricDefinition.AccountName);
+            Assert.Equal(storageQueueMetricDefinition.QueueName, deserializedStorageQueueMetricDefinition.QueueName);
+            Assert.NotNull(deserializedStorageQueueMetricDefinition.SasToken);
+            Assert.Equal(storageQueueMetricDefinition.SasToken.RawValue, deserializedStorageQueueMetricDefinition.SasToken.RawValue);
+            Assert.Equal(storageQueueMetricDefinition.SasToken.EnvironmentVariable, deserializedStorageQueueMetricDefinition.SasToken.EnvironmentVariable);
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration);
-            Assert.Equal(serviceBusMetricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
+            Assert.Equal(storageQueueMetricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration.Aggregation);
-            Assert.Equal(serviceBusMetricDefinition.AzureMetricConfiguration.Aggregation.Type, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Type);
-            Assert.Equal(serviceBusMetricDefinition.AzureMetricConfiguration.Aggregation.Interval, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Interval);
+            Assert.Equal(storageQueueMetricDefinition.AzureMetricConfiguration.Aggregation.Type, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Type);
+            Assert.Equal(storageQueueMetricDefinition.AzureMetricConfiguration.Aggregation.Interval, deserializedMetricDefinition.AzureMetricConfiguration.Aggregation.Interval);
         }
 
-        private StorageQueueMetricDefinition GenerateBogusAzureStorageQueueMetricDefinition(string resourceGroupName, string metricScrapingInterval)
+        private StorageQueueMetricDefinition GenerateBogusAzureStorageQueueMetricDefinition(string resourceGroupName, string metricScrapingInterval, string sasTokenRawValue, string sasTokenEnvironmentVariable)
         {
             var bogusScrapingInterval = GenerateBogusScrapingInterval(metricScrapingInterval);
             var bogusAzureMetricConfiguration = GenerateBogusAzureMetricConfiguration();
@@ -76,7 +78,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.ResourceType, faker => ResourceType.StorageQueue)
                 .RuleFor(metricDefinition => metricDefinition.AccountName, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.QueueName, faker => faker.Name.FirstName())
-                .RuleFor(metricDefinition => metricDefinition.SasToken, faker => $"?sig={Base64UrlEncoder.Encode(faker.Lorem.Sentence(wordCount: 3))}")
+                .RuleFor(metricDefinition => metricDefinition.SasToken, faker =>
+                {
+                    return new Secret
+                    {
+                        RawValue = sasTokenRawValue,
+                        EnvironmentVariable = sasTokenEnvironmentVariable
+                    };
+                })
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -8,5 +8,6 @@ services:
       - PROMITOR_AUTH_APPID=ceb249a3-44ce-4c90-8863-6776336f5b7e
       - PROMITOR_AUTH_APPKEY=ZgLy6zYNh9SEmIl0B+rv+ZuQQ2wJyQi/tTXnp2Wp9PM=
       - PROMITOR_TELEMETRY_INSTRUMENTATIONKEY=
+      - "SECRETS_STORAGEQUEUE_SAS=?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwdlacup&se=2019-07-28T02:33:14Z&st=2019-03-24T18:33:14Z&spr=https&sig=OiwNEYueCWlOhveapM1K6cRgV%2Be21gNhoq%2FDZqJEMZE%3D"
     ports:
       - "88"

--- a/src/metric-config.yaml
+++ b/src/metric-config.yaml
@@ -46,7 +46,8 @@ metrics:
     resourceType: StorageQueue
     accountName: promitor
     queueName: orders
-    sasToken: "?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwdlacup&se=2019-07-28T02:33:14Z&st=2019-03-24T18:33:14Z&spr=https&sig=OiwNEYueCWlOhveapM1K6cRgV%2Be21gNhoq%2FDZqJEMZE%3D"
+    sasToken:
+      rawValue: "?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwdlacup&se=2019-07-28T02:33:14Z&st=2019-03-24T18:33:14Z&spr=https&sig=OiwNEYueCWlOhveapM1K6cRgV%2Be21gNhoq%2FDZqJEMZE%3D"
     scraping:
       # Every 2 minutes
       schedule: "0 */2 * ? * *"
@@ -59,7 +60,8 @@ metrics:
     resourceType: StorageQueue
     accountName: promitor
     queueName: orders
-    sasToken: "?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwdlacup&se=2019-07-28T02:33:14Z&st=2019-03-24T18:33:14Z&spr=https&sig=OiwNEYueCWlOhveapM1K6cRgV%2Be21gNhoq%2FDZqJEMZE%3D"
+    sasToken:
+      environmentVariable: SECRETS_STORAGEQUEUE_SAS
     azureMetricConfiguration:
       metricName: TimeSpentInQueue
       aggregation:


### PR DESCRIPTION
- Provide capability to configure SAS tokens via raw value or environment variable
- Don't log raw configuration to leak configured raw SAS token

Relates to #530 & #514

### Metrics Configuration example

```yaml
metrics:
  - name: demo_azurestoragequeue_queue_size
    description: "Approximate amount of messages in 'orders' queue (determined with StorageQueue provider)"
    resourceType: StorageQueue
    accountName: promitor
    queueName: orders
    sasToken:
      rawValue: "?sv=<redacted>"
    azureMetricConfiguration:
      metricName: MessageCount
      aggregation:
        type: Total
  - name: demo_azurestoragequeue_queue_timespentinqueue
    description: "Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)"
    resourceType: StorageQueue
    accountName: promitor
    queueName: orders
    sasToken:
      environmentVariable: SECRETS_STORAGEQUEUE_SAS
    azureMetricConfiguration:
      metricName: TimeSpentInQueue
      aggregation:
        type: Total
```