### PR TITLE
Insights on ARM Throttling & API consumption

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ And there is more on the way - Check our [backlog](https://github.com/tomkerkhov
     - [Authentication with Azure Monitor](configuration#authentication-with-azure-monitor)
     - [Telemetry](configuration#telemetry)
 - **Operations**
+    - [Azure Resource Manager API Consumption & Throttling](operations#azure-resource-manager-api-consumption-&-throttling)
     - [Health](operations#health)
 
 # Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ And there is more on the way - Check our [backlog](https://github.com/tomkerkhov
     - [Authentication with Azure Monitor](configuration#authentication-with-azure-monitor)
     - [Telemetry](configuration#telemetry)
 - **Operations**
-    - [Azure Resource Manager API Consumption & Throttling](operations#azure-resource-manager-api---consumption--throttling)
+    - [Azure Resource Manager API - Consumption & Throttling](operations#azure-resource-manager-api---consumption--throttling)
     - [Health](operations#health)
 
 # Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ And there is more on the way - Check our [backlog](https://github.com/tomkerkhov
     - [Authentication with Azure Monitor](configuration#authentication-with-azure-monitor)
     - [Telemetry](configuration#telemetry)
 - **Operations**
-    - [Azure Resource Manager API Consumption & Throttling](operations#azure-resource-manager-api-consumption-&-throttling)
+    - [Azure Resource Manager API Consumption & Throttling](operations#azure-resource-manager-api---consumption--throttling)
     - [Health](operations#health)
 
 # Support

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -5,6 +5,15 @@ title: Operating Promitor
 
 Here is an overview of how you can operate Promitor. 
 
+# Azure Resource Manager API Consumption & Throttling
+Promitor exposes runtime metrics to provide insights on the API consumption of Azure Resource Manager API:
+
+- `promitor_ratelimit_arm_subscription` - Indication how many calls are still available before Azure Resource Manager is going to throttle us.
+Metric provides following labels:
+    - `tenant_id` - _Id of the tenant that is being interacted with_
+    - `subscription_id` - _Id of the subscription that is being interacted with_
+    - `app_id` - _Id of the application that is being used to interact with API_
+
 # Health
 Promitor provides a basic health endpoint that indicates the state of the scraper.
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -3,16 +3,7 @@ layout: default
 title: Operating Promitor
 ---
 
-Here is an overview of how you can operate Promitor. 
-
-# Azure Resource Manager API Consumption & Throttling
-Promitor exposes runtime metrics to provide insights on the API consumption of Azure Resource Manager API:
-
-- `promitor_ratelimit_arm_subscription` - Indication how many calls are still available before Azure Resource Manager is going to throttle us.
-Metric provides following labels:
-    - `tenant_id` - _Id of the tenant that is being interacted with_
-    - `subscription_id` - _Id of the subscription that is being interacted with_
-    - `app_id` - _Id of the application that is being used to interact with API_
+Here is an overview of how you can operate Promitor.
 
 # Health
 Promitor provides a basic health endpoint that indicates the state of the scraper.
@@ -30,5 +21,14 @@ Health is currently indicated via the HTTP response status:
 - `503 Service Unavailable` - The scraper is unhealthy
 
 In the future, the endpoint will be more advanced by giving detailed status on dependencies as well.
+
+# Azure Resource Manager API - Consumption & Throttling
+Promitor exposes runtime metrics to provide insights on the API consumption of Azure Resource Manager API:
+
+- `promitor_ratelimit_arm_subscription` - Indication how many calls are still available before Azure Resource Manager is going to throttle us.
+Metric provides following labels:
+    - `tenant_id` - _Id of the tenant that is being interacted with_
+    - `subscription_id` - _Id of the subscription that is being interacted with_
+    - `app_id` - _Id of the application that is being used to interact with API_
 
 [&larr; back](/)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -25,7 +25,7 @@ In the future, the endpoint will be more advanced by giving detailed status on d
 # Azure Resource Manager API - Consumption & Throttling
 Promitor exposes runtime metrics to provide insights on the API consumption of Azure Resource Manager API:
 
-- `promitor_ratelimit_arm_subscription` - Indication how many calls are still available before Azure Resource Manager is going to throttle us.
+- `promitor_ratelimit_arm` - Indication how many calls are still available before Azure Resource Manager is going to throttle us.
 Metric provides following labels:
     - `tenant_id` - _Id of the tenant that is being interacted with_
     - `subscription_id` - _Id of the subscription that is being interacted with_

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -82,7 +82,7 @@ namespace Promitor.Core.Scraping
 
                 _logger.LogInformation("Found value '{MetricValue}' for metric '{MetricName}' with aggregation interval '{AggregationInterval}'", foundMetricValue, metricDefinition.Name, aggregationInterval);
 
-                var metricsTimestampFeatureFlag = FeatureFlag.IsActive("METRICSTIMESTAMP", defaultFlagState: true);
+                var metricsTimestampFeatureFlag = FeatureFlag.IsActive(FeatureFlag.Names.MetricsTimestamp, defaultFlagState: true);
 
                 var gauge = Metrics.CreateGauge(metricDefinition.Name, metricDefinition.Description, includeTimestamp: metricsTimestampFeatureFlag);
                 gauge.Set(foundMetricValue);

--- a/src/Promitor.Core.Telemetry.Metrics/Interfaces/IRuntimeMetricsCollector.cs
+++ b/src/Promitor.Core.Telemetry.Metrics/Interfaces/IRuntimeMetricsCollector.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Promitor.Core.Telemetry.Metrics.Interfaces
+{
+    public interface IRuntimeMetricsCollector
+    {
+        /// <summary>
+        ///     Sets a new value for a measurement on a gauge
+        /// </summary>
+        /// <param name="name">Name of the metric</param>
+        /// <param name="description">Description of the metric</param>
+        /// <param name="value">New measured value</param>
+        /// <param name="labels">Labels that are applicable for this measurement</param>
+        void SetGaugeMeasurement(string name, string description, double value, Dictionary<string, string> labels);
+    }
+}

--- a/src/Promitor.Core.Telemetry.Metrics/Promitor.Core.Telemetry.Metrics.csproj
+++ b/src/Promitor.Core.Telemetry.Metrics/Promitor.Core.Telemetry.Metrics.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RuntimeFrameworkVersion>2.2.3</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Prometheus.Client" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Promitor.Core\Promitor.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricNames.cs
+++ b/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricNames.cs
@@ -2,6 +2,6 @@
 {
     public static class RuntimeMetricNames
     {
-        public static string RateLimitingForArm { get; } = "ratelimit_arm_subscription";
+        public static string RateLimitingForArm { get; } = "ratelimit_arm";
     }
 }

--- a/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricNames.cs
+++ b/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricNames.cs
@@ -1,0 +1,7 @@
+﻿namespace Promitor.Core.Telemetry.Metrics
+{
+    public static class RuntimeMetricNames
+    {
+        public static string RateLimitingForArm { get; } = "ratelimit_arm_subscription";
+    }
+}

--- a/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricsCollector.cs
+++ b/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricsCollector.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Promitor.Core.Infrastructure;
+using Promitor.Core.Telemetry.Metrics.Interfaces;
+
+namespace Promitor.Core.Telemetry.Metrics
+{
+    public class RuntimeMetricsCollector : IRuntimeMetricsCollector
+    {
+        /// <summary>
+        /// Sets a new value for a measurement on a gauge
+        /// </summary>
+        /// <param name="name">Name of the metric</param>
+        /// <param name="description">Description of the metric</param>
+        /// <param name="value">New measured value</param>
+        /// <param name="labels">Labels that are applicable for this measurement</param>
+        public void SetGaugeMeasurement(string name, string description, double value, Dictionary<string, string> labels)
+        {
+            var metricsTimestampFeatureFlag = FeatureFlag.IsActive(FeatureFlag.Names.MetricsTimestamp, defaultFlagState: true);
+
+            var gauge = Prometheus.Client.Metrics.CreateGauge($"promitor_{name}", help: description, includeTimestamp: metricsTimestampFeatureFlag, labelNames: labels.Keys.ToArray());
+            gauge.WithLabels(labels.Values.ToArray()).Set(value);
+        }
+    }
+}

--- a/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricsCollector.cs
+++ b/src/Promitor.Core.Telemetry.Metrics/RuntimeMetricsCollector.cs
@@ -16,7 +16,7 @@ namespace Promitor.Core.Telemetry.Metrics
         /// <param name="labels">Labels that are applicable for this measurement</param>
         public void SetGaugeMeasurement(string name, string description, double value, Dictionary<string, string> labels)
         {
-            var metricsTimestampFeatureFlag = FeatureFlag.IsActive(FeatureFlag.Names.MetricsTimestamp, defaultFlagState: true);
+            var metricsTimestampFeatureFlag = FeatureFlag.IsActive(FeatureFlag.Names.MetricsTimestamp);
 
             var gauge = Prometheus.Client.Metrics.CreateGauge($"promitor_{name}", help: description, includeTimestamp: metricsTimestampFeatureFlag, labelNames: labels.Keys.ToArray());
             gauge.WithLabels(labels.Values.ToArray()).Set(value);

--- a/src/Promitor.Core/Infrastructure/FeatureFlag.cs
+++ b/src/Promitor.Core/Infrastructure/FeatureFlag.cs
@@ -21,5 +21,10 @@ namespace Promitor.Core.Infrastructure
 
             return defaultFlagState;
         }
+
+        public static class Names
+        {
+            public static string MetricsTimestamp { get; } = "METRICSTIMESTAMP";
+        }
     }
 }

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Promitor.Core.Telemetry.Metrics\Promitor.Core.Telemetry.Metrics.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Promitor.Integrations.AzureMonitor/RequestHandlers/AzureResourceManagerThrottlingRequestHandler.cs
+++ b/src/Promitor.Integrations.AzureMonitor/RequestHandlers/AzureResourceManagerThrottlingRequestHandler.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Telemetry.Metrics;
+using Promitor.Core.Telemetry.Metrics.Interfaces;
+
+namespace Promitor.Integrations.AzureMonitor.RequestHandlers
+{
+    /// <summary>
+    ///     Request handler to provide insights on the current api consumption and throttling of Azure Resource Manager
+    /// </summary>
+    public class AzureResourceManagerThrottlingRequestHandler : DelegatingHandlerBase
+    {
+        private readonly ILogger _logger;
+        private readonly Dictionary<string, string> _metricLabels;
+        private readonly IRuntimeMetricsCollector _metricsCollector;
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="tenantId">Id of the tenant that is being interacted with via Azure Resource Manager</param>
+        /// <param name="subscriptionId">Id of the subscription that is being interacted with via Azure Resource Manager</param>
+        /// <param name="applicationId">Id of the application that is being used to interact with Azure Resource Manager</param>
+        /// <param name="metricsCollector">Metrics collector to write metrics to</param>
+        /// <param name="logger">Logger to write telemetry to</param>
+        public AzureResourceManagerThrottlingRequestHandler(string tenantId, string subscriptionId, string applicationId, IRuntimeMetricsCollector metricsCollector, ILogger logger)
+        {
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
+            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(applicationId, nameof(applicationId));
+            Guard.NotNull(metricsCollector, nameof(metricsCollector));
+            Guard.NotNull(logger, nameof(logger));
+
+            _logger = logger;
+            _metricsCollector = metricsCollector;
+
+            _metricLabels = new Dictionary<string, string>
+            {
+                {"tenant_id", tenantId},
+                {"subscription_id", subscriptionId},
+                {"app_id", applicationId}
+            };
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+
+            MeasureArmRateLimiting(response);
+
+            if ((int) response.StatusCode == 429)
+                LogArmThrottling();
+
+            return response;
+        }
+
+        private void MeasureArmRateLimiting(HttpResponseMessage response)
+        {
+            // Source: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-request-limits
+            if (response.Headers.Contains("x-ms-ratelimit-remaining-subscription-reads"))
+            {
+                var remainingApiCalls = response.Headers.GetValues("x-ms-ratelimit-remaining-subscription-reads").FirstOrDefault();
+                var subscriptionReadLimit = Convert.ToInt16(remainingApiCalls);
+                _metricsCollector.SetGaugeMeasurement(RuntimeMetricNames.RateLimitingForArm, "Indication how many calls are still available before Azure Resource Manager is going to throttle us.", subscriptionReadLimit, _metricLabels);
+            }
+        }
+
+        private void LogArmThrottling()
+        {
+            _logger.LogWarning("Azure subscription rate limit reached.");
+        }
+    }
+}

--- a/src/Promitor.Scraper.Host/Dockerfile
+++ b/src/Promitor.Scraper.Host/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /src
 COPY Promitor.Core/* Promitor.Core/
 COPY Promitor.Core.Scraping/* Promitor.Core.Scraping/
 COPY Promitor.Core.Telemetry/* Promitor.Core.Telemetry/
+COPY Promitor.Core.Telemetry.Metrics/* Promitor.Core.Telemetry.Metrics/
 COPY Promitor.Integrations.AzureMonitor/* Promitor.Integrations.AzureMonitor/
 COPY Promitor.Integrations.AzureStorage/* Promitor.Integrations.AzureStorage/
 COPY Promitor.Scraper.Host/* Promitor.Scraper.Host/

--- a/src/Promitor.Scraper.Host/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Promitor.Scraper.Host/Extensions/IServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Core.Telemetry.Interfaces;
+using Promitor.Core.Telemetry.Metrics.Interfaces;
 using Promitor.Scraper.Host.Scheduling;
 using Swashbuckle.AspNetCore.Swagger;
 
@@ -31,6 +32,7 @@ namespace Promitor.Scraper.Host.Extensions
                 {
                     builder.AddJob(serviceProvider => new MetricScrapingJob(metric,
                         metricsProvider,
+                        serviceProvider.GetService<IRuntimeMetricsCollector>(),
                         serviceProvider.GetService<ILogger>(),
                         serviceProvider.GetService<IExceptionTracker>()));
                     builder.UnobservedTaskExceptionHandler = (sender, exceptionEventArgs) => UnobservedJobHandlerHandler(sender, exceptionEventArgs, services);

--- a/src/Promitor.Scraper.Host/Scheduling/MetricScrapingJob.cs
+++ b/src/Promitor.Scraper.Host/Scheduling/MetricScrapingJob.cs
@@ -9,6 +9,7 @@ using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Core.Scraping.Factories;
 using Promitor.Core.Telemetry.Interfaces;
+using Promitor.Core.Telemetry.Metrics.Interfaces;
 
 namespace Promitor.Scraper.Host.Scheduling
 {
@@ -16,11 +17,13 @@ namespace Promitor.Scraper.Host.Scheduling
     {
         private readonly MetricDefinition _metric;
         private readonly IMetricsDeclarationProvider _metricsDeclarationProvider;
+        private readonly IRuntimeMetricsCollector _runtimeMetricsCollector;
         private readonly IExceptionTracker _exceptionTracker;
         private readonly ILogger _logger;
 
         public MetricScrapingJob(MetricDefinition metric,
             IMetricsDeclarationProvider metricsDeclarationProvider,
+            IRuntimeMetricsCollector runtimeMetricsCollector,
             ILogger logger, IExceptionTracker exceptionTracker)
         {
             Guard.NotNull(metric, nameof(metric));
@@ -29,6 +32,7 @@ namespace Promitor.Scraper.Host.Scheduling
 
             _metric = metric;
             _metricsDeclarationProvider = metricsDeclarationProvider;
+            _runtimeMetricsCollector = runtimeMetricsCollector;
             _exceptionTracker = exceptionTracker;
             _logger = logger;
 
@@ -66,7 +70,7 @@ namespace Promitor.Scraper.Host.Scheduling
         {
             _logger.LogInformation("Scraping '{MetricName}' for resource type '{ResourceType}'", metricDefinitionDefinition.Name, metricDefinitionDefinition.ResourceType);
 
-            var scraper = MetricScraperFactory.CreateScraper(metricDefinitionDefinition.ResourceType, azureMetadata, _logger, _exceptionTracker);
+            var scraper = MetricScraperFactory.CreateScraper(metricDefinitionDefinition.ResourceType, azureMetadata, _runtimeMetricsCollector, _logger, _exceptionTracker);
             await scraper.ScrapeAsync(metricDefinitionDefinition);
         }
     }

--- a/src/Promitor.Scraper.Host/Startup.cs
+++ b/src/Promitor.Scraper.Host/Startup.cs
@@ -8,6 +8,8 @@ using Promitor.Core.Scraping.Configuration.Providers;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Core.Telemetry;
 using Promitor.Core.Telemetry.Interfaces;
+using Promitor.Core.Telemetry.Metrics;
+using Promitor.Core.Telemetry.Metrics.Interfaces;
 using Promitor.Scraper.Host.Extensions;
 
 namespace Promitor.Scraper.Host
@@ -42,6 +44,7 @@ namespace Promitor.Scraper.Host
             services.AddTransient<IExceptionTracker, ApplicationInsightsTelemetry>();
             services.AddTransient<ILogger, RuntimeLogger>();
             services.AddTransient<IMetricsDeclarationProvider, MetricsDeclarationProvider>();
+            services.AddTransient<IRuntimeMetricsCollector, RuntimeMetricsCollector>();
 
             services.AddMvc()
                     .AddJsonOptions(jsonOptions =>

--- a/src/Promitor.sln
+++ b/src/Promitor.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{1C184D
 		metric-config.yaml = metric-config.yaml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Promitor.Core.Telemetry.Metrics", "Promitor.Core.Telemetry.Metrics\Promitor.Core.Telemetry.Metrics.csproj", "{3AB59144-8090-4AF3-9322-E357B2CAF11F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +80,10 @@ Global
 		{F929434C-07FB-4B55-A8EE-5C77D8B49809}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F929434C-07FB-4B55-A8EE-5C77D8B49809}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F929434C-07FB-4B55-A8EE-5C77D8B49809}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AB59144-8090-4AF3-9322-E357B2CAF11F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AB59144-8090-4AF3-9322-E357B2CAF11F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AB59144-8090-4AF3-9322-E357B2CAF11F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AB59144-8090-4AF3-9322-E357B2CAF11F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +100,7 @@ Global
 		{C3ADE514-95AD-4FDD-8577-45F7EADB4A23} = {05524B1B-9965-4E36-9626-A2823B8588AA}
 		{FCFD60ED-3389-42A1-9B1A-4F2D30DCDA8B} = {05524B1B-9965-4E36-9626-A2823B8588AA}
 		{F929434C-07FB-4B55-A8EE-5C77D8B49809} = {59D7FFBC-3929-48AD-8C9C-242280D01CBD}
+		{3AB59144-8090-4AF3-9322-E357B2CAF11F} = {05524B1B-9965-4E36-9626-A2823B8588AA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B47A777A-C793-453F-8F4F-7703551DFC4C}


### PR DESCRIPTION
Insights on ARM Throttling & API consumption via a `promitor_ratelimit_arm_subscription` metric in Prometheus scraping endpoint.

### Example Output
```yaml
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="c8819874-9e56-4e3f-b1a8-1c0325138f27",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",app_id="ceb249a3-44ce-4c90-8863-6776336f5b7e"} 11998 1557417726598
```

Relates to #199