### PR TITLE
Provide resource_uri label for all metrics

### DIFF
--- a/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
@@ -18,14 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ContainerInstanceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ContainerInstanceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.ContainerGroup);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ContainerRegistryScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ContainerRegistryScraper.cs
@@ -18,14 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ContainerRegistryMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ContainerRegistryMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, subscriptionId, resourceGroupName, metricDefinition.RegistryName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/CosmosDbScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/CosmosDbScraper.cs
@@ -18,14 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, CosmosDbMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, CosmosDbMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, subscriptionId, resourceGroupName, metricDefinition.DbName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/GenericScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/GenericScraper.cs
@@ -18,13 +18,13 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, GenericAzureMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, GenericAzureMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, subscriptionId, resourceGroupName, metricDefinition.ResourceUri);
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, metricDefinition.Filter);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
@@ -18,14 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, NetworkInterfaceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, NetworkInterfaceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.NetworkInterfaceName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
@@ -18,7 +18,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ServiceBusQueueMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ServiceBusQueueMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, subscriptionId, resourceGroupName, metricDefinition.Namespace);
 
@@ -26,7 +26,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, filter);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
@@ -18,14 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override async Task<double> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, VirtualMachineMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, VirtualMachineMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
             var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.VirtualMachineName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return foundMetricValue;
+            return new ScrapeResult(resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ScrapeResult.cs
+++ b/src/Promitor.Core.Scraping/ScrapeResult.cs
@@ -1,0 +1,30 @@
+﻿using GuardNet;
+
+namespace Promitor.Core.Scraping
+{
+    public class ScrapeResult
+    {
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="resourceUri">Uri of the resource that was scraped</param>
+        /// <param name="metricValue">Value of the metric that was found</param>
+        public ScrapeResult(string resourceUri, double metricValue)
+        {
+            Guard.NotNullOrEmpty(resourceUri, nameof(resourceUri));
+
+            ResourceUri = resourceUri;
+            MetricValue = metricValue;
+        }
+
+        /// <summary>
+        ///     Uri of the resource that was scraped
+        /// </summary>
+        public string ResourceUri { get; }
+
+        /// <summary>
+        ///     Value of the metric that was found
+        /// </summary>
+        public double MetricValue { get; }
+    }
+}


### PR DESCRIPTION
Provide `resource_uri` label for all metrics

Relates to #513

### Scraping Output
```
# HELP demo_azurestoragequeue_queue_size Approximate amount of messages in 'orders' queue (determined with StorageQueue provider)
# TYPE demo_azurestoragequeue_queue_size gauge
demo_azurestoragequeue_queue_size{resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Storage/storageAccounts/promitor/queueServices"} 0 1558374841314
# HELP demo_azurestoragequeue_queue_timespentinqueue Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)
# TYPE demo_azurestoragequeue_queue_timespentinqueue gauge
demo_azurestoragequeue_queue_timespentinqueue{resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Storage/storageAccounts/promitor/queueServices"} 0 1558374902571
# HELP demo_generic_namespace_size Size of all queues in our Azure Service Bus namespace (determined with Generic provider)
# TYPE demo_generic_namespace_size gauge
demo_generic_namespace_size{resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging"} 8195 1558374842091
# HELP demo_generic_queue_size Amount of active messages of the 'myqueue' queue (determined with Generic provider)
# TYPE demo_generic_queue_size gauge
demo_generic_queue_size{resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging"} 2895 1558374903499
# HELP demo_servicebusqueue_queue_size Amount of active messages of the 'myqueue' queue (determined with ServiceBusQueue provider)
# TYPE demo_servicebusqueue_queue_size gauge
demo_servicebusqueue_queue_size{resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging"} 8685 1558374904021
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="c8819874-9e56-4e3f-b1a8-1c0325138f27",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",app_id="ceb249a3-44ce-4c90-8863-6776336f5b7e"} 11962 1558374903933

```