### PR TITLE
Provide timestamps for logging

### DIFF
--- a/src/Promitor.Core.Telemetry/Loggers/Logger.cs
+++ b/src/Promitor.Core.Telemetry/Loggers/Logger.cs
@@ -12,6 +12,12 @@ namespace Promitor.Core.Telemetry.Loggers
         {
         }
 
+        public override void WriteMessage(LogLevel logLevel, string logName, int eventId, string message, Exception exception)
+        {
+            message = $"[{DateTimeOffset.UtcNow.ToString("u")}] {message}";
+            base.WriteMessage(logLevel, logName, eventId, message, exception);
+        }
+
         private static bool IsFilteringRequired(LogLevel usedLogLevel)
         {
             var rawMinimalLogLevel = Environment.GetEnvironmentVariable(EnvironmentVariables.Logging.MinimumLogLevel);


### PR DESCRIPTION
Fixes #571

### New logs with timestamp
```shell
██████╗ ██████╗  ██████╗ ███╗   ███╗██╗████████╗ ██████╗ ██████╗
██╔══██╗██╔══██╗██╔═══██╗████╗ ████║██║╚══██╔══╝██╔═══██╗██╔══██╗
██████╔╝██████╔╝██║   ██║██╔████╔██║██║   ██║   ██║   ██║██████╔╝
██╔═══╝ ██╔══██╗██║   ██║██║╚██╔╝██║██║   ██║   ██║   ██║██╔══██╗
██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║██║   ██║   ╚██████╔╝██║  ██║
╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
No scraping endpoint was specified, falling back to default '/metrics'...
No scraping configuration path was specified, falling back to default '/config/metrics-declaration.yaml'...
info: Validation[0]
      [2019-06-08 08:13:05Z] Starting validation of Promitor setup
info: Validation[0]
      [2019-06-08 08:13:05Z] Start Validation step 1/4: Metrics Declaration Path
warn: Validation[0]
      [2019-06-08 08:13:05Z] No scrape configuration path configured, falling back to default one on '/config/metrics-declaration.yaml'.
info: Validation[0]
      [2019-06-08 08:13:05Z] Scrape configuration found at '/config/metrics-declaration.yaml'
info: Validation[0]
      [2019-06-08 08:13:05Z] Validation step 1/4 succeeded
info: Validation[0]
      [2019-06-08 08:13:05Z] Start Validation step 2/4: Cron Schedule
warn: Validation[0]
      [2019-06-08 08:13:05Z] No scraping schedule was specified, falling back to default '*/5 * * * *' cron schedule...
```

### Olds logs without stamp
```shell
██████╗ ██████╗  ██████╗ ███╗   ███╗██╗████████╗ ██████╗ ██████╗
██╔══██╗██╔══██╗██╔═══██╗████╗ ████║██║╚══██╔══╝██╔═══██╗██╔══██╗
██████╔╝██████╔╝██║   ██║██╔████╔██║██║   ██║   ██║   ██║██████╔╝
██╔═══╝ ██╔══██╗██║   ██║██║╚██╔╝██║██║   ██║   ██║   ██║██╔══██╗
██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║██║   ██║   ╚██████╔╝██║  ██║
╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
No scraping configuration path was specified, falling back to default '/config/metrics-declaration.yaml'...
info: Validation[0]
      Starting validation of Promitor setup
info: Validation[0]
      Start Validation step 1/4: Metrics Declaration Path
warn: Validation[0]
      No scrape configuration path configured, falling back to default one on '/config/metrics-declaration.yaml'.
info: Validation[0]
      Scrape configuration found at '/config/metrics-declaration.yaml'
info: Validation[0]
      Validation step 1/4 succeeded
```