### PR TITLE
Expose Promitor via LoadBalancer service in Kubernetes 

### DIFF
--- a/charts/promitor-agent-scraper/templates/service.yaml
+++ b/charts/promitor-agent-scraper/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     type: {{ .Values.service.labelType }}
 spec:
 {{- if .Values.service.exposeExternally }}
-  type: ExternalIP
+  type: LoadBalancer
 {{- else }}
   type: ClusterIP
 {{- end }}


### PR DESCRIPTION
Expose Promitor via LoadBalancer service in Kubernetes, depending on Helm configuration

Fixes #572
