### PR TITLE
Raising a better exception message from Azure Monitoring http response

### DIFF
--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -91,17 +91,17 @@ namespace Promitor.Core.Scraping
             {
                 string reason = string.Empty;
 
-                if (!string.IsNullOrEmpty(erex.Message))
+                if (!string.IsNullOrEmpty(errorResponseException.Message))
                 {
-                    reason = erex.Message;
+                    reason = errorResponseException.Message;
                 }
 
-                if (erex.Response != null && !string.IsNullOrEmpty(erex.Response.Content))
+                if (errorResponseException.Response != null && !string.IsNullOrEmpty(errorResponseException.Response.Content))
                 {
                     try
                     {
                         var definition = new { error = new { code = "", message = "" } };
-                        var jsonError = JsonConvert.DeserializeAnonymousType(erex.Response.Content, definition);
+                        var jsonError = JsonConvert.DeserializeAnonymousType(errorResponseException.Response.Content, definition);
 
                         if (jsonError != null && jsonError.error != null)
                         {

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -118,6 +118,8 @@ namespace Promitor.Core.Scraping
                     catch (Exception)
                     {
                         // do nothing. maybe a bad deserialization of json content. Just fallback on outer exception message.
+                        _exceptionTracker.Track(errorResponseException);
+
                     }
                 }
 

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -87,7 +87,7 @@ namespace Promitor.Core.Scraping
                 var gauge = Metrics.CreateGauge(metricDefinition.Name, metricDefinition.Description, includeTimestamp: metricsTimestampFeatureFlag, labelNames: "resource_uri");
                 gauge.WithLabels(scrapedMetricResult.ResourceUri).Set(scrapedMetricResult.MetricValue);
             }
-            catch (ErrorResponseException erex)
+            catch (ErrorResponseException errorResponseException)
             {
                 string reason = string.Empty;
 

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -119,7 +119,6 @@ namespace Promitor.Core.Scraping
                     {
                         // do nothing. maybe a bad deserialization of json content. Just fallback on outer exception message.
                         _exceptionTracker.Track(errorResponseException);
-
                     }
                 }
 


### PR DESCRIPTION
Update `ScrapeAsync` method to raise better exception when Azure monitoring is returning a JSON Payload in its Response.

The json payload looks like this:
``` json
{
  "error": {
     "code": "xxxx",
     "message" : "zzzz"
  }
}
```
From the `Microsoft.Azure.Management.Monitor.Fluent` SDK, we have a wrapped exception `ErrorResponseException` used here to get the detailed message




