### PR TITLE
Provide labels with resource information

### DIFF
--- a/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.ContainerGroup, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ContainerRegistryScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ContainerRegistryScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.RegistryName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/CosmosDbScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/CosmosDbScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.DbName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/GenericScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/GenericScraper.cs
@@ -24,7 +24,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, metricDefinition.Filter);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.NetworkInterfaceName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/PostgreSqlScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/PostgreSqlScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.ServerName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/RedisCacheScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/RedisCacheScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.CacheName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,12 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri, filter);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            var labels = new Dictionary<string, string>
+            {
+                {"entity_name", metricDefinition.QueueName}
+            };
+
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.Namespace, resourceUri, foundMetricValue, labels);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/StorageQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/StorageQueueScraper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GuardNet;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
@@ -44,7 +45,12 @@ namespace Promitor.Core.Scraping.ResourceTypes
                     throw new InvalidMetricNameException(metricDefinition.AzureMetricConfiguration.MetricName, metricDefinition.ResourceType.ToString());
             }
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            var labels = new Dictionary<string, string>
+            {
+                {"queue_name", metricDefinition.QueueName}
+            };
+
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.AccountName, resourceUri, foundMetricValue, labels);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
@@ -25,7 +25,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
 
-            return new ScrapeResult(resourceUri, foundMetricValue);
+            return new ScrapeResult(subscriptionId, resourceGroupName, metricDefinition.VirtualMachineName, resourceUri, foundMetricValue);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ScrapeResult.cs
+++ b/src/Promitor.Core.Scraping/ScrapeResult.cs
@@ -1,4 +1,5 @@
-﻿using GuardNet;
+﻿using System.Collections.Generic;
+using GuardNet;
 
 namespace Promitor.Core.Scraping
 {
@@ -7,15 +8,77 @@ namespace Promitor.Core.Scraping
         /// <summary>
         ///     Constructor
         /// </summary>
+        /// <param name="subscriptionId">Subscription that contains the resource that was scraped</param>
+        /// <param name="resourceGroupName">Resource group name that contains the resource that was scraped</param>
         /// <param name="resourceUri">Uri of the resource that was scraped</param>
         /// <param name="metricValue">Value of the metric that was found</param>
-        public ScrapeResult(string resourceUri, double metricValue)
+        public ScrapeResult(string subscriptionId, string resourceGroupName, string resourceUri, double metricValue) : this(subscriptionId, resourceGroupName, string.Empty, resourceUri, metricValue, new Dictionary<string, string>())
         {
-            Guard.NotNullOrEmpty(resourceUri, nameof(resourceUri));
+        }
 
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="subscriptionId">Subscription that contains the resource that was scraped</param>
+        /// <param name="resourceGroupName">Resource group name that contains the resource that was scraped</param>
+        /// <param name="instanceName">Name of the resource that is being scraped</param>
+        /// <param name="resourceUri">Uri of the resource that was scraped</param>
+        /// <param name="metricValue">Value of the metric that was found</param>
+        /// <param name="customLabels">A collection of custom labels to add to the scraping result</param>
+        public ScrapeResult(string subscriptionId, string resourceGroupName, string instanceName, string resourceUri, double metricValue, Dictionary<string, string> customLabels)
+        {
+            Guard.NotNullOrEmpty(subscriptionId, nameof(subscriptionId));
+            Guard.NotNullOrEmpty(resourceGroupName, nameof(resourceGroupName));
+            Guard.NotNullOrEmpty(resourceUri, nameof(resourceUri));
+            Guard.NotNull(customLabels, nameof(customLabels));
+
+            SubscriptionId = subscriptionId;
+            ResourceGroupName = resourceGroupName;
             ResourceUri = resourceUri;
             MetricValue = metricValue;
+
+            Labels.Add("resource_group", resourceGroupName);
+            Labels.Add("subscription_id", subscriptionId);
+            Labels.Add("resource_uri", resourceUri);
+
+            if (string.IsNullOrWhiteSpace(instanceName) == false)
+            {
+                InstanceName = instanceName;
+                Labels.Add("instance_name", instanceName);
+            }
+
+            foreach (KeyValuePair<string, string> customLabel in customLabels)
+            {
+                Labels.TryAdd(customLabel.Key, customLabel.Value);
+            }
         }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="subscriptionId">Subscription that contains the resource that was scraped</param>
+        /// <param name="resourceGroupName">Resource group name that contains the resource that was scraped</param>
+        /// <param name="instanceName">Name of the resource that is being scraped</param>
+        /// <param name="resourceUri">Uri of the resource that was scraped</param>
+        /// <param name="metricValue">Value of the metric that was found</param>
+        public ScrapeResult(string subscriptionId, string resourceGroupName, string instanceName, string resourceUri, double metricValue) : this(subscriptionId, resourceGroupName, instanceName,resourceUri,metricValue, new Dictionary<string, string>())
+        {
+        }
+
+        /// <summary>
+        ///     Subscription that contains the resource that was scraped
+        /// </summary>
+        public string SubscriptionId { get; }
+
+        /// <summary>
+        ///     Resource group name that contains the resource that was scraped
+        /// </summary>
+        public string ResourceGroupName { get; }
+
+        /// <summary>
+        ///     Name of the resource that is being scraped
+        /// </summary>
+        public string InstanceName { get; }
 
         /// <summary>
         ///     Uri of the resource that was scraped
@@ -26,5 +89,7 @@ namespace Promitor.Core.Scraping
         ///     Value of the metric that was found
         /// </summary>
         public double MetricValue { get; }
+
+        public Dictionary<string, string> Labels { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GuardNet;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
@@ -84,8 +85,8 @@ namespace Promitor.Core.Scraping
 
                 var metricsTimestampFeatureFlag = FeatureFlag.IsActive(FeatureFlag.Names.MetricsTimestamp, defaultFlagState: true);
 
-                var gauge = Metrics.CreateGauge(metricDefinition.Name, metricDefinition.Description, includeTimestamp: metricsTimestampFeatureFlag, labelNames: "resource_uri");
-                gauge.WithLabels(scrapedMetricResult.ResourceUri).Set(scrapedMetricResult.MetricValue);
+                var gauge = Metrics.CreateGauge(metricDefinition.Name, metricDefinition.Description, includeTimestamp: metricsTimestampFeatureFlag, labelNames: scrapedMetricResult.Labels.Keys.ToArray());
+                gauge.WithLabels(scrapedMetricResult.Labels.Values.ToArray()).Set(scrapedMetricResult.MetricValue);
             }
             catch (ErrorResponseException errorResponseException)
             {


### PR DESCRIPTION
Provide labels with resource information such as:
- Subscription id
- Resource group name
- Instance name
- Detailed information such as queue name

Closes #598

### New output format
```
# HELP promitor_demo_azurestoragequeue_queue_size Approximate amount of messages in 'orders' queue (determined with StorageQueue provider)
# TYPE promitor_demo_azurestoragequeue_queue_size gauge
promitor_demo_azurestoragequeue_queue_size{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Storage/storageAccounts/promitor/queueServices",instance_name="promitor",queue_name="orders"} 0 1561569513810
# HELP promitor_demo_azurestoragequeue_queue_timespentinqueue Approximate amount of time that the oldest message has been in 'orders' queue (determined with StorageQueue provider)
# TYPE promitor_demo_azurestoragequeue_queue_timespentinqueue gauge
promitor_demo_azurestoragequeue_queue_timespentinqueue{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Storage/storageAccounts/promitor/queueServices",instance_name="promitor",queue_name="orders"} 0 1561569516241
# HELP promitor_demo_generic_namespace_size Size of all queues in our Azure Service Bus namespace (determined with Generic provider)
# TYPE promitor_demo_generic_namespace_size gauge
promitor_demo_generic_namespace_size{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging"} 2031 1561569517550
# HELP promitor_demo_generic_queue_size Amount of active messages of the 'orders' queue (determined with Generic provider)
# TYPE promitor_demo_generic_queue_size gauge
promitor_demo_generic_queue_size{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging"} 579 1561569518095
# HELP promitor_demo_servicebusqueue_queue_size Amount of active messages of the 'orders' queue (determined with ServiceBusQueue provider)
# TYPE promitor_demo_servicebusqueue_queue_size gauge
promitor_demo_servicebusqueue_queue_size{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging",instance_name="promitor-messaging",entity_name="orders"} 579 1561569518084
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="c8819874-9e56-4e3f-b1a8-1c0325138f27",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",app_id="ceb249a3-44ce-4c90-8863-6776336f5b7e"} 11980 1561569518024

```