### PR TITLE
Provide capability to specify custom labels per metric

### DIFF
--- a/docs/configuration/metrics/index.md
+++ b/docs/configuration/metrics/index.md
@@ -26,6 +26,7 @@ Every metric that is being declared needs to define the following fields:
 - `name` - Name of the metric that will be exposed in the scrape endpoint for Prometheus
 - `description` - Description for the metric that will be exposed in the scrape endpoint for Prometheus
 - `resourceType` - Defines what type of resource needs to be queried.
+- `labels` - Defines a set of custom labels to included for a given metric.
 - `azureMetricConfiguration.metricName` - The name of the metric in Azure Monitor to query
 - `azureMetricConfiguration.aggregation.type` - The aggregation that needs to be used when querying Azure Monitor
 - `azureMetricConfiguration.aggregation.interval` - Overrides the default aggregation interval defined in `metricDefaults.aggregation.interval` with a new interval
@@ -69,6 +70,9 @@ metrics:
     namespace: promitor-messaging-dev
     queueName: orders
     resourceGroupName: promitor-dev
+    labels:
+      app: promitor
+      stage: dev
     azureMetricConfiguration:
       metricName: ActiveMessages
       aggregation:

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/MetricDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace Promitor.Core.Scraping.Configuration.Model.Metrics
+﻿using System.Collections.Generic;
+
+namespace Promitor.Core.Scraping.Configuration.Model.Metrics
 {
     public abstract class MetricDefinition
     {
@@ -27,6 +29,11 @@
         ///     Type of resource that is configured
         /// </summary>
         public abstract ResourceType ResourceType { get; }
+
+        /// <summary>
+        ///     Collection of custom labels to add to every metric
+        /// </summary>
+        public Dictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the scraping model.

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
@@ -43,8 +43,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.Core
             DeserializeScraping(metricNode, metricDefinition);
             DeserializeCustomLabels(metricNode, metricDefinition);
 
-
-
             return metricDefinition;
         }
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Core/MetricDeserializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -39,26 +40,63 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.Core
                 AzureMetricConfiguration = azureMetricConfiguration
             };
 
-            if (metricNode.Children.ContainsKey(@"scraping"))
-            {
-                var scrapingNode = (YamlMappingNode)metricNode.Children[new YamlScalarNode(@"scraping")];
-                try
-                {
-                    var scrapingIntervalNode = scrapingNode?.Children[new YamlScalarNode(@"schedule")];
+            DeserializeScraping(metricNode, metricDefinition);
+            DeserializeCustomLabels(metricNode, metricDefinition);
 
-                    if (scrapingIntervalNode != null)
-                    {
-                        metricDefinition.Scraping.Schedule = scrapingIntervalNode.ToString();
-                    }
-                }
-                catch (KeyNotFoundException)
-                {
-                    // happens when the YAML doesn't have the properties in it which is fine because the object
-                    // will get a default interval of 'null'
-                }
-            }
+
 
             return metricDefinition;
+        }
+
+        private static void DeserializeScraping<TMetricDefinition>(YamlMappingNode metricNode, TMetricDefinition metricDefinition) where TMetricDefinition : MetricDefinition, new()
+        {
+            if (metricNode.Children.ContainsKey(@"scraping") == false)
+            {
+                return;
+            }
+
+            var scrapingNode = (YamlMappingNode)metricNode.Children[new YamlScalarNode(@"scraping")];
+            try
+            {
+                var scrapingIntervalNode = scrapingNode?.Children[new YamlScalarNode(@"schedule")];
+
+                if (scrapingIntervalNode != null)
+                {
+                    metricDefinition.Scraping.Schedule = scrapingIntervalNode.ToString();
+                }
+            }
+            catch (KeyNotFoundException)
+            {
+                // happens when the YAML doesn't have the properties in it which is fine because the object
+                // will get a default interval of 'null'
+            }
+        }
+
+        private static void DeserializeCustomLabels<TMetricDefinition>(YamlMappingNode metricNode, TMetricDefinition metricDefinition) where TMetricDefinition : MetricDefinition, new()
+        {
+            if (metricNode.Children.ContainsKey(@"labels") == false)
+            {
+                return;
+            }
+
+            var labelNode = (YamlMappingNode)metricNode.Children[new YamlScalarNode(@"labels")];
+            foreach (KeyValuePair<YamlNode, YamlNode> customLabel in labelNode.Children)
+            {
+                var labelName = customLabel.Key.ToString();
+                var labelValue = customLabel.Value.ToString();
+
+                if (metricDefinition.Labels.ContainsKey(labelName))
+                {
+                    if (metricDefinition.Labels[labelName] == labelValue)
+                    {
+                        continue;
+                    }
+
+                    throw new Exception($"Label '{labelName}' is already defined with value '{metricDefinition.Labels[labelName]}' instead of '{labelValue}'");
+                }
+
+                metricDefinition.Labels.Add(labelName, labelValue);
+            }
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GuardNet;
-using Microsoft.Azure.Management.Monitor.Fluent;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
@@ -78,17 +78,15 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.ResourceType, faker => ResourceType.StorageQueue)
                 .RuleFor(metricDefinition => metricDefinition.AccountName, faker => faker.Name.LastName())
                 .RuleFor(metricDefinition => metricDefinition.QueueName, faker => faker.Name.FirstName())
-                .RuleFor(metricDefinition => metricDefinition.SasToken, faker =>
+                .RuleFor(metricDefinition => metricDefinition.SasToken, faker => new Secret
                 {
-                    return new Secret
-                    {
-                        RawValue = sasTokenRawValue,
-                        EnvironmentVariable = sasTokenEnvironmentVariable
-                    };
+                    RawValue = sasTokenRawValue,
+                    EnvironmentVariable = sasTokenEnvironmentVariable
                 })
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
@@ -74,6 +74,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
@@ -70,6 +70,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithCosmosDbYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithCosmosDbYamlSerializationTests.cs
@@ -70,6 +70,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithNetworkInterfaceYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithNetworkInterfaceYamlSerializationTests.cs
@@ -69,6 +69,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithPostgreSqlYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithPostgreSqlYamlSerializationTests.cs
@@ -69,6 +69,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithRedisCacheYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithRedisCacheYamlSerializationTests.cs
@@ -69,6 +69,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
@@ -72,6 +72,11 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string>
+                {
+                    { faker.Name.FirstName(), faker.Random.Guid().ToString() },
+                    { faker.Name.FirstName(), faker.Random.Guid().ToString() }
+                })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
@@ -75,6 +75,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
                 .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
 
             return bogusGenerator.Generate();

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
@@ -18,13 +18,14 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             Assert.Equal(metricDefinition.ResourceType, deserializedMetricDefinition.ResourceType);
             Assert.NotNull(deserializedMetricDefinition.Labels);
             Assert.Equal(deserializedMetricDefinition.Labels, metricDefinition.Labels);
+
             foreach (var label in metricDefinition.Labels)
             {
                 var deserializedLabel = deserializedMetricDefinition.Labels[label.Key];
                 Assert.NotNull(deserializedLabel);
                 Assert.Equal(label.Value, deserializedLabel);
-
             }
+
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration);
             Assert.Equal(metricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration.Aggregation);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
@@ -16,6 +16,15 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             Assert.Equal(metricDefinition.Name, deserializedMetricDefinition.Name);
             Assert.Equal(metricDefinition.Description, deserializedMetricDefinition.Description);
             Assert.Equal(metricDefinition.ResourceType, deserializedMetricDefinition.ResourceType);
+            Assert.NotNull(deserializedMetricDefinition.Labels);
+            Assert.Equal(deserializedMetricDefinition.Labels, metricDefinition.Labels);
+            foreach (var label in metricDefinition.Labels)
+            {
+                var deserializedLabel = deserializedMetricDefinition.Labels[label.Key];
+                Assert.NotNull(deserializedLabel);
+                Assert.Equal(label.Value, deserializedLabel);
+
+            }
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration);
             Assert.Equal(metricDefinition.AzureMetricConfiguration.MetricName, deserializedMetricDefinition.AzureMetricConfiguration.MetricName);
             Assert.NotNull(deserializedMetricDefinition.AzureMetricConfiguration.Aggregation);

--- a/src/metric-config.yaml
+++ b/src/metric-config.yaml
@@ -14,6 +14,8 @@ metrics:
     resourceType: Generic
     resourceUri: Microsoft.ServiceBus/namespaces/promitor-messaging
     filter: EntityName eq 'orders'
+    labels:
+      app: promitor
     azureMetricConfiguration:
       metricName: ActiveMessages
       aggregation:


### PR DESCRIPTION
- [X] Deserialization of metrics
- [X] Validation / Improve deserialization to block duplicates
- [X] Merge internal & custom labels
- [X] Unit Testing
- [x] Documentation

Fixes #603

## Configuration
```yaml
azureMetadata:
  tenantId: <redacted>
  subscriptionId: <redacted>
  resourceGroupName: <redacted>
metricDefaults:
  aggregation:
    interval: 00:05:00
  scraping:
    # Every minute
    schedule: "0 * * ? * *"
metrics:
  - name: promitor_demo_generic_queue_size
    description: "Amount of active messages of the 'orders' queue (determined with Generic provider)"
    resourceType: Generic
    resourceUri: Microsoft.ServiceBus/namespaces/promitor-messaging
    filter: EntityName eq 'orders'
    labels:
      app: promitor
    azureMetricConfiguration:
      metricName: ActiveMessages
      aggregation:
        type: Average
```

## Output
```
# HELP promitor_demo_generic_queue_size Amount of active messages of the 'orders' queue (determined with Generic provider)
# TYPE promitor_demo_generic_queue_size gauge
promitor_demo_generic_queue_size{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging",app="promitor"} 579 1561633985175
```