### PR TITLE
Switch to .NET Core Alpine as Docker base image

### DIFF
--- a/src/Promitor.Scraper.Host/Dockerfile
+++ b/src/Promitor.Scraper.Host/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2.300 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.300-alpine3.9 AS build
 WORKDIR /src
 COPY Promitor.Core/* Promitor.Core/
 COPY Promitor.Core.Scraping/* Promitor.Core.Scraping/
@@ -10,7 +10,7 @@ COPY Promitor.Scraper.Host/* Promitor.Scraper.Host/
 RUN dotnet --info
 RUN dotnet publish Promitor.Scraper.Host/Promitor.Scraper.Host.csproj --configuration release -o app
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.5 as runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.5-alpine3.9 as runtime
 WORKDIR /app
 COPY --from=build /src/Promitor.Scraper.Host/app .
 


### PR DESCRIPTION
Switch to .NET Core Alpine as Docker base image to get rid of all Docker image security vulnerabilities.

Closes #610
