### PR TITLE
helm: add resources options in the deployment

### DIFF
--- a/charts/promitor-agent-scraper/README.md
+++ b/charts/promitor-agent-scraper/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Promitor chart and 
 | `metricDefaults.aggregation.interval`  | Default interval which defines over what period measurements of a metric should be aggregated | `00:05:00`            |
 | `metricDefaults.scraping.schedule`  | Cron expression that controls the fequency in which all the configured metrics will be scraped from Azure Monitor | `*/5 * * * *`            |
 | `metrics`  | List of metrics to scrape configured following the [metric declaration docs](https://promitor.io/configuration/metrics/) |        |
+| `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |
 | `secrets.appIdSecret`  | Name of the secret for Azure AD identity id | `azure-app-id`            |
 | `secrets.appKeySecret`  | Name of the secret for Azure AD identity secret | `azure-app-key`            |

--- a/charts/promitor-agent-scraper/templates/deployment.yaml
+++ b/charts/promitor-agent-scraper/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
           - name: PROMITOR_LOGGING_MINIMUMLEVEL
             value: {{ .Values.logging.minimalLogLevel }}
         {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           - name: config-volume-{{ template "promitor-agent-scraper.fullname" . }}
             mountPath: /config/

--- a/charts/promitor-agent-scraper/values.yaml
+++ b/charts/promitor-agent-scraper/values.yaml
@@ -62,3 +62,11 @@ service:
   targetPort: 88
   labelType: infrastructure
   selectorType: runtime
+
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
Currently, the helm chart does not have any resources parameter for the deployment. 

## Proposed Changes

  - add `resources` parameter in the helm chart
  - keep it to empty for the compatibility 
