### PR TITLE
Enforce instrumentation key when Application Insights is enabled

### DIFF
--- a/src/Promitor.Core.Telemetry/ApplicationInsightsTelemetry.cs
+++ b/src/Promitor.Core.Telemetry/ApplicationInsightsTelemetry.cs
@@ -29,7 +29,7 @@ namespace Promitor.Core.Telemetry
         {
             var telemetryConfiguration = new TelemetryConfiguration();
 
-            if (configuration.CurrentValue.IsEnabled == true)
+            if (configuration.CurrentValue.IsEnabled)
             {
                 telemetryConfiguration.DisableTelemetry = false;
 

--- a/src/Promitor.Core.Telemetry/ApplicationInsightsTelemetry.cs
+++ b/src/Promitor.Core.Telemetry/ApplicationInsightsTelemetry.cs
@@ -27,14 +27,18 @@ namespace Promitor.Core.Telemetry
 
         private TelemetryClient ConfigureTelemetryClient(IOptionsMonitor<ApplicationInsightsConfiguration> configuration)
         {
-            var telemetryConfiguration = new TelemetryConfiguration
-            {
-                DisableTelemetry = !configuration.CurrentValue.IsEnabled
-            };
+            var telemetryConfiguration = new TelemetryConfiguration();
 
-            var instrumentationKey = configuration.CurrentValue.InstrumentationKey;
-            if (string.IsNullOrWhiteSpace(instrumentationKey) == false)
+            if (configuration.CurrentValue.IsEnabled == true)
             {
+                telemetryConfiguration.DisableTelemetry = false;
+
+                var instrumentationKey = configuration.CurrentValue.InstrumentationKey;
+                if (string.IsNullOrWhiteSpace(instrumentationKey))
+                {
+                    throw new Exception("Application Insights instrumentation key is required when it is enabled.");
+                }
+
                 telemetryConfiguration.InstrumentationKey = instrumentationKey;
             }
 


### PR DESCRIPTION
Enforce instrumentation key when Application Insights is enabled, otherwise there is no point in enabling it.

Relates to #431