### PR TITLE
Fix resource group overriding

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDeserializer.cs
@@ -28,6 +28,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
 
             var name = metricNode.Children[new YamlScalarNode("name")];
             var description = metricNode.Children[new YamlScalarNode("description")];
+            
             var azureMetricConfigurationNode = (YamlMappingNode)metricNode.Children[new YamlScalarNode("azureMetricConfiguration")];
 
             var azureMetricConfigurationDeserializer = new AzureMetricConfigurationDeserializer(Logger);
@@ -37,13 +38,24 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             {
                 Name = name?.ToString(),
                 Description = description?.ToString(),
-                AzureMetricConfiguration = azureMetricConfiguration
+                AzureMetricConfiguration = azureMetricConfiguration,
+                ResourceGroupName = GetResourceGroupName(metricNode)
             };
 
             DeserializeScraping(metricNode, metricDefinition);
             DeserializeCustomLabels(metricNode, metricDefinition);
 
             return metricDefinition;
+        }
+
+        private static string GetResourceGroupName(YamlMappingNode metricNode)
+        {
+            if (metricNode.Children.TryGetValue("resourceGroupName", out var resourceGroupNode))
+            {
+                return resourceGroupNode.ToString();
+            }
+
+            return null;
         }
 
         private static void DeserializeScraping<TMetricDefinition>(YamlMappingNode metricNode, TMetricDefinition metricDefinition) where TMetricDefinition : MetricDefinition, new()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceMetricDeserializer.cs
@@ -1,10 +1,11 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class ContainerInstanceMetricDeserializer : GenericAzureMetricDeserializer
+    internal class ContainerInstanceMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Container Instances metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node to deserialize to Container Instances configuration</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryMetricDeserializer.cs
@@ -1,10 +1,11 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class ContainerRegistryMetricDeserializer : GenericAzureMetricDeserializer
+    internal class ContainerRegistryMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Container Registry metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node to deserialize to Container Registry configuration</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbMetricDeserializer.cs
@@ -1,10 +1,11 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class CosmosDbMetricDeserializer : GenericAzureMetricDeserializer
+    internal class CosmosDbMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Cosmos DB metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node to deserialize to Cosmos DB configuration</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericAzureMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericAzureMetricDeserializer.cs
@@ -18,10 +18,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
             {
                 metricDefinition.Filter = filterNode?.ToString();
             }
-            if (metricNode.Children.TryGetValue(new YamlScalarNode("resourceGroupName"), out var resourceGroupName))
-            {
-                metricDefinition.ResourceGroupName = resourceGroupName?.ToString();
-            }
 
             var resourceUri = metricNode.Children[new YamlScalarNode(value: "resourceUri")];
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceMetricDeserializer.cs
@@ -1,10 +1,11 @@
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class NetworkInterfaceMetricDeserializer : GenericAzureMetricDeserializer
+    internal class NetworkInterfaceMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Network Interface metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node containing 'networkInterfaceName' parameter pointing to an instance of a Network Interface</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlMetricDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
@@ -7,7 +8,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     /// <summary>
     /// Defines a deserializer for the PostgreSQL Server resource type
     /// </summary>
-    internal class PostgreSqlMetricDeserializer : GenericAzureMetricDeserializer
+    internal class PostgreSqlMetricDeserializer : MetricDeserializer
     {
         /// <summary>
         /// Deserializes the specified PostgreSQL Server metric node from the YAML configuration file.

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheMetricDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
@@ -7,7 +8,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     /// <summary>
     /// Defines a deserializer for the Redis Cache resource type
     /// </summary>
-    internal class RedisCacheMetricDeserializer : GenericAzureMetricDeserializer
+    internal class RedisCacheMetricDeserializer : MetricDeserializer
     {
         /// <summary>
         /// Deserializes the specified Redis Cache metric node from the YAML configuration file.

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueMetricDeserializer.cs
@@ -1,10 +1,11 @@
 ﻿using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class ServiceBusQueueMetricDeserializer : GenericAzureMetricDeserializer
+    internal class ServiceBusQueueMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Service Bus Queue metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node to deserialize to Service Bus queue</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueMetricDeserializer.cs
@@ -6,7 +6,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class StorageQueueMetricDeserializer : GenericAzureMetricDeserializer
+    internal class StorageQueueMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Storage Queue metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node to deserialize to Storage queue configuration</param>

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineMetricDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineMetricDeserializer.cs
@@ -1,10 +1,11 @@
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
 {
-    internal class VirtualMachineMetricDeserializer : GenericAzureMetricDeserializer
+    internal class VirtualMachineMetricDeserializer : MetricDeserializer
     {
         /// <summary>Deserializes the specified Virtual Machine metric node from the YAML configuration file.</summary>
         /// <param name="metricNode">The metric node containing 'virtualMachineName' parameter pointing to an instance of a Virtual Machine</param>

--- a/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricDeserializerFactory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Core;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
 
 namespace Promitor.Core.Scraping.Factories
 {
     internal static class MetricDeserializerFactory
     {
-        internal static GenericAzureMetricDeserializer GetDeserializerFor(Configuration.Model.ResourceType resource)
+        internal static MetricDeserializer GetDeserializerFor(Configuration.Model.ResourceType resource)
         {
             switch (resource)
             {

--- a/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ContainerInstanceScraper.cs
@@ -16,7 +16,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
 
         protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, ContainerInstanceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
-            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.ContainerGroup);
+            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, resourceGroupName, metricDefinition.ContainerGroup);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);

--- a/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/NetworkInterfaceScraper.cs
@@ -16,7 +16,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
 
         protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, NetworkInterfaceMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
-            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.NetworkInterfaceName);
+            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, resourceGroupName, metricDefinition.NetworkInterfaceName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);

--- a/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/VirtualMachineScraper.cs
@@ -16,7 +16,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
 
         protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, string resourceGroupName, VirtualMachineMetricDefinition metricDefinition, AggregationType aggregationType, TimeSpan aggregationInterval)
         {
-            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, AzureMetadata.ResourceGroupName, metricDefinition.VirtualMachineName);
+            var resourceUri = string.Format(ResourceUriTemplate, AzureMetadata.SubscriptionId, resourceGroupName, metricDefinition.VirtualMachineName);
 
             var metricName = metricDefinition.AzureMetricConfiguration.MetricName;
             var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithAzureStorageQueueYamlSerializationTests.cs
@@ -88,8 +88,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerInstanceYamlSerializationTests.cs
@@ -76,8 +76,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithContainerRegistryYamlSerializationTests.cs
@@ -72,8 +72,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithCosmosDbYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithCosmosDbYamlSerializationTests.cs
@@ -72,8 +72,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithNetworkInterfaceYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithNetworkInterfaceYamlSerializationTests.cs
@@ -71,8 +71,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithPostgreSqlYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithPostgreSqlYamlSerializationTests.cs
@@ -71,8 +71,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithRedisCacheYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithRedisCacheYamlSerializationTests.cs
@@ -71,8 +71,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithServiceBusQueueYamlSerializationTests.cs
@@ -78,8 +78,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 {
                     { faker.Name.FirstName(), faker.Random.Guid().ToString() },
                     { faker.Name.FirstName(), faker.Random.Guid().ToString() }
-                })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/MetricsDeclarationWithVirtualMachineYamlSerializationTests.cs
@@ -77,8 +77,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
                 .RuleFor(metricDefinition => metricDefinition.AzureMetricConfiguration, faker => bogusAzureMetricConfiguration)
                 .RuleFor(metricDefinition => metricDefinition.ResourceGroupName, faker => resourceGroupName)
                 .RuleFor(metricDefinition => metricDefinition.Scraping, faker => bogusScrapingInterval)
-                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } })
-                .Ignore(metricDefinition => metricDefinition.ResourceGroupName);
+                .RuleFor(metricDefinition => metricDefinition.Labels, faker => new Dictionary<string, string> { { faker.Name.FirstName(), faker.Random.Guid().ToString() } });
 
             return bogusGenerator.Generate();
         }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/MetricsDeclaration/YamlSerializationTests.cs
@@ -18,6 +18,7 @@ namespace Promitor.Scraper.Tests.Unit.Serialization.MetricsDeclaration
             Assert.Equal(metricDefinition.ResourceType, deserializedMetricDefinition.ResourceType);
             Assert.NotNull(deserializedMetricDefinition.Labels);
             Assert.Equal(deserializedMetricDefinition.Labels, metricDefinition.Labels);
+            Assert.Equal(deserializedMetricDefinition.ResourceGroupName, metricDefinition.ResourceGroupName);
 
             foreach (var label in metricDefinition.Labels)
             {


### PR DESCRIPTION
The ability to override the resource group per metric was broken for all resource types other than the Generic resource type.

This commit:

- Fixes the tests for all resource types to test for this by removing the `Ignore()` method calls for the `ResourceGroupName` property and added an extra assert to check for the resource group.
- Alters the deserializers to inherit directly from `MetricDeserializer` rather than `GenericAzureMetricDeserializer`. They weren't actually using any of the functionality from the generic type.
- Fixes a few Scraper implementations to actually use the overridden group name.

Fixes #655