### PR TITLE
Fix broken runtime config name in Helm chart

### DIFF
--- a/charts/promitor-agent-scraper/templates/configmap.yaml
+++ b/charts/promitor-agent-scraper/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  yaml: |-
+  runtime.yaml: |-
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
       prometheus:


### PR DESCRIPTION
Fix broken runtime config name in Helm chart