### PR TITLE
Replace deprecated apiVersion extensions/v1beta1 with apps/v1

### DIFF
--- a/charts/promitor-agent-scraper/templates/deployment.yaml
+++ b/charts/promitor-agent-scraper/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "promitor-agent-scraper.fullname" . }}
@@ -27,9 +27,9 @@ spec:
         type: {{ .Values.service.selectorType }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- if .Values.secrets.createSecret }}
+        {{- if .Values.secrets.createSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-      {{- end }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Fixes #669

## Proposed Changes

  - As requested in #669 this replaces the deprecated apiVersion extensions/v1beta1 with apps/v1
  - The other apiVersions of the helm chart should be fine (https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16)
  - This breaks the helm chart for clusters with a version <1.9 but this should be fine