### PR TITLE
Add an Azure SQL Database scraper

### DIFF
--- a/docs/configuration/v0.x/metrics/generic-azure-resource.md
+++ b/docs/configuration/v0.x/metrics/generic-azure-resource.md
@@ -33,6 +33,6 @@ azureMetricConfiguration:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v0.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v0.x/metrics/service-bus-queue.md
+++ b/docs/configuration/v0.x/metrics/service-bus-queue.md
@@ -36,6 +36,6 @@ azureMetricConfiguration:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v0.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/azure-sql-database.md
+++ b/docs/configuration/v1.x/metrics/azure-sql-database.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Azure SQL Database Declaration
+---
+
+## Azure SQL Database - ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v1.0.0-green.svg)
+
+You can scrape an Azure SQL Database via the `AzureSqlDatabase` resource type.
+
+The following fields need to be provided:
+
+- `serverName` - The name of the SQL Server instance.
+- `databaseName` - The name of the database.
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserversdatabases).
+
+Example:
+
+```yaml
+name: azure_sql_database_dtu_consumption_percent
+description: "The DTU consumption percentage used by an Azure SQL Database."
+resourceType: AzureSqlDatabase
+azureMetricConfiguration:
+  metricName: dtu_consumption_percent
+  aggregation:
+    type: Average
+resources:
+- serverName: promitor-sql-server
+- databaseName: promitor-db
+```
+
+<!-- markdownlint-disable MD033 -->
+[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to introduction](/)
+<!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/azure-sql-database.md
+++ b/docs/configuration/v1.x/metrics/azure-sql-database.md
@@ -30,6 +30,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/azure-sql-database.md
+++ b/docs/configuration/v1.x/metrics/azure-sql-database.md
@@ -3,7 +3,7 @@ layout: default
 title: Azure SQL Database Declaration
 ---
 
-## Azure SQL Database - ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v1.0.0-green.svg)
+## Azure SQL Database - ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v1.1.0-green.svg)
 
 You can scrape an Azure SQL Database via the `AzureSqlDatabase` resource type.
 
@@ -13,6 +13,11 @@ The following fields need to be provided:
 - `databaseName` - The name of the database.
 
 All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserversdatabases).
+
+The following scraper-specific metric labels will be added:
+
+- `server` - The name of the SQL Server instance.
+- `database` - The name of the database.
 
 Example:
 

--- a/docs/configuration/v1.x/metrics/container-instances.md
+++ b/docs/configuration/v1.x/metrics/container-instances.md
@@ -30,6 +30,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/container-registry.md
+++ b/docs/configuration/v1.x/metrics/container-registry.md
@@ -32,6 +32,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/cosmos-db.md
+++ b/docs/configuration/v1.x/metrics/cosmos-db.md
@@ -29,6 +29,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/generic-azure-resource.md
+++ b/docs/configuration/v1.x/metrics/generic-azure-resource.md
@@ -36,6 +36,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/index.md
+++ b/docs/configuration/v1.x/metrics/index.md
@@ -108,6 +108,7 @@ We also provide a simplified way to scrape the following Azure resources:
 - [Azure Database for PostgreSQL](postgresql)
 - [Azure Network Interface](network-interface)
 - [Azure Service Bus Queue](service-bus-queue)
+- [Azure SQL Database](azure-sql-database)
 - [Azure Storage Queue](storage-queue)
 - [Azure Virtual Machine](virtual-machine)
 

--- a/docs/configuration/v1.x/metrics/network-interface.md
+++ b/docs/configuration/v1.x/metrics/network-interface.md
@@ -30,6 +30,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/postgresql.md
+++ b/docs/configuration/v1.x/metrics/postgresql.md
@@ -33,6 +33,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/redis-cache.md
+++ b/docs/configuration/v1.x/metrics/redis-cache.md
@@ -36,6 +36,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/service-bus-queue.md
+++ b/docs/configuration/v1.x/metrics/service-bus-queue.md
@@ -15,7 +15,7 @@ The following fields need to be provided:
 
 All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftservicebusnamespaces).
 
-The following scraper-specific metric label(s) will be added:
+The following scraper-specific metric label will be added:
 
 - `entity_name` - Name of the queue
 

--- a/docs/configuration/v1.x/metrics/service-bus-queue.md
+++ b/docs/configuration/v1.x/metrics/service-bus-queue.md
@@ -37,6 +37,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/storage-queue.md
+++ b/docs/configuration/v1.x/metrics/storage-queue.md
@@ -22,7 +22,7 @@ Supported metrics:
   in the queue to be processed.
 - `MessageCount`
 
-The following scraper-specific metric label(s) will be added:
+The following scraper-specific metric label will be added:
 
 - `queue_name` - Name of the queue
 

--- a/docs/configuration/v1.x/metrics/storage-queue.md
+++ b/docs/configuration/v1.x/metrics/storage-queue.md
@@ -48,6 +48,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/configuration/v1.x/metrics/virtual-machine.md
+++ b/docs/configuration/v1.x/metrics/virtual-machine.md
@@ -30,6 +30,6 @@ resources:
 ```
 
 <!-- markdownlint-disable MD033 -->
-[&larr; back to metrics declarations](/configuration/metrics)<br />
+[&larr; back to metrics declarations](/configuration/v1.x/metrics)<br />
 [&larr; back to introduction](/)
 <!-- markdownlint-enable -->

--- a/docs/metrics/labels.md
+++ b/docs/metrics/labels.md
@@ -31,6 +31,7 @@ Currently we support this for:
 
 - Azure Service Bus
 - Azure Storage Queue
+- Azure SQL Database
 
 For more information, we recommend reading the [scraper-specific documentation](./../configuration/v1.x/metrics/#supported-azure-services).
 

--- a/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/AzureSqlDatabaseResourceDefinition.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/Metrics/ResourceTypes/AzureSqlDatabaseResourceDefinition.cs
@@ -1,0 +1,31 @@
+namespace Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes
+{
+    /// <summary>
+    /// Represents an Azure SQL Database resource.
+    /// </summary>
+    public class AzureSqlDatabaseResourceDefinition : AzureResourceDefinition
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureSqlDatabaseResourceDefinition" /> class.
+        /// </summary>
+        /// <param name="resourceGroupName">The name of the resource group the server is in.</param>
+        /// <param name="serverName">The name of the Azure SQL Server instance.</param>
+        /// <param name="databaseName">The name of the Azure SQL database name.</param>
+        public AzureSqlDatabaseResourceDefinition(string resourceGroupName, string serverName, string databaseName)
+            : base(ResourceType.AzureSqlDatabase, resourceGroupName)
+        {
+            ServerName = serverName;
+            DatabaseName = databaseName;
+        }
+
+        /// <summary>
+        /// The name of the SQL server instance.
+        /// </summary>
+        public string ServerName { get; }
+
+        /// <summary>
+        /// The name of the database.
+        /// </summary>
+        public string DatabaseName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Model/ResourceType.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/ResourceType.cs
@@ -13,5 +13,6 @@
         CosmosDb = 8,
         RedisCache = 9,
         PostgreSql = 10,
+        AzureSqlDatabase = 11
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -41,6 +41,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                     return new RedisCacheDeserializer(_logger);
                 case ResourceType.PostgreSql:
                     return new PostgreSqlDeserializer(_logger);
+                case ResourceType.AzureSqlDatabase:
+                    return new AzureSqlDatabaseDeserializer(_logger);
                 default:
                     throw new ArgumentOutOfRangeException($"Resource Type {resourceType} not supported.");
             }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -31,6 +31,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .ForCtorParam("ns", o => o.MapFrom(s => s.Namespace));
             CreateMap<StorageQueueResourceV1, StorageQueueResourceDefinition>();
             CreateMap<VirtualMachineResourceV1, VirtualMachineResourceDefinition>();
+            CreateMap<AzureSqlDatabaseResourceV1, AzureSqlDatabaseResourceDefinition>();
 
             CreateMap<MetricDefinitionV1, PrometheusMetricDefinition>();
 
@@ -47,7 +48,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<RedisCacheResourceV1, RedisCacheResourceDefinition>()
                 .Include<ServiceBusQueueResourceV1, ServiceBusQueueResourceDefinition>()
                 .Include<StorageQueueResourceV1, StorageQueueResourceDefinition>()
-                .Include<VirtualMachineResourceV1, VirtualMachineResourceDefinition>();
+                .Include<VirtualMachineResourceV1, VirtualMachineResourceDefinition>()
+                .Include<AzureSqlDatabaseResourceV1, AzureSqlDatabaseResourceDefinition>();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureSqlDatabaseResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureSqlDatabaseResourceV1.cs
@@ -1,0 +1,18 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Represents an Azure SQL Database to scrape.
+    /// </summary>
+    public class AzureSqlDatabaseResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the SQL Server instance.
+        /// </summary>
+        public string ServerName { get; set; }
+
+        /// <summary>
+        /// The name of the SQL database.
+        /// </summary>
+        public string DatabaseName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AzureSqlDatabaseDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AzureSqlDatabaseDeserializer.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    /// <summary>
+    /// Used to deserialize a <see cref="AzureSqlDatabaseResourceV1" /> resource.
+    /// </summary>
+    public class AzureSqlDatabaseDeserializer : ResourceDeserializer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureSqlDatabaseDeserializer" /> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        public AzureSqlDatabaseDeserializer(ILogger logger) : base(logger)
+        {
+        }
+
+        protected override AzureResourceDefinitionV1 DeserializeResource(YamlMappingNode node)
+        {
+            var serverName = node.GetString("serverName");
+            var databaseName = node.GetString("databaseName");
+
+            return new AzureSqlDatabaseResourceV1
+            {
+                ServerName = serverName,
+                DatabaseName = databaseName
+            };
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -65,6 +65,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new RedisCacheScraper(scraperConfiguration);
                 case ResourceType.PostgreSql:
                     return new PostgreSqlScraper(scraperConfiguration);
+                case ResourceType.AzureSqlDatabase:
+                    return new AzureSqlDatabaseScraper(scraperConfiguration);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/Promitor.Core.Scraping/ResourceTypes/AzureSqlDatabaseScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/AzureSqlDatabaseScraper.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.Monitor.Fluent.Models;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    /// <summary>
+    /// Scrapes an Azure SQL Database.
+    /// </summary>
+    public class AzureSqlDatabaseScraper : Scraper<AzureSqlDatabaseResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Sql/servers/{2}/databases/{3}";
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AzureSqlDatabaseScraper" /> class.
+        /// </summary>
+        /// <param name="scraperConfiguration">The scraper configuration</param>
+        public AzureSqlDatabaseScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override async Task<ScrapeResult> ScrapeResourceAsync(string subscriptionId, ScrapeDefinition<AzureResourceDefinition> scrapeDefinition, AzureSqlDatabaseResourceDefinition resource, AggregationType aggregationType, TimeSpan aggregationInterval)
+        {
+            var resourceUri = string.Format(
+                ResourceUriTemplate,
+                AzureMetadata.SubscriptionId,
+                scrapeDefinition.ResourceGroupName,
+                resource.ServerName,
+                resource.DatabaseName);
+
+            var metricName = scrapeDefinition.AzureMetricConfiguration.MetricName;
+            var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, aggregationType, aggregationInterval, resourceUri);
+
+            var labels = new Dictionary<string, string>
+            {
+                {"server", resource.ServerName},
+                {"database", resource.DatabaseName}
+            };
+
+            return new ScrapeResult(subscriptionId, scrapeDefinition.ResourceGroupName, null, resourceUri, foundMetricValue, labels);
+        }
+    }
+}

--- a/src/Promitor.Scraper.Host/Docs/Open-Api.xml
+++ b/src/Promitor.Scraper.Host/Docs/Open-Api.xml
@@ -85,5 +85,13 @@
             <param name="metricDefinition">Metric definition to validate</param>
             <returns>List of validation errors</returns>
         </member>
+        <member name="T:Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes.AzureSqlDatabaseMetricValidator">
+            <summary>
+            Validates <see cref="T:Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes.AzureSqlDatabaseResourceDefinition" /> objects.
+            </summary>
+        </member>
+        <member name="M:Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes.AzureSqlDatabaseMetricValidator.Validate(Promitor.Core.Scraping.Configuration.Model.Metrics.MetricDefinition)">
+            <inheritdoc />
+        </member>
     </members>
 </doc>

--- a/src/Promitor.Scraper.Host/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Scraper.Host/Validation/Factories/MetricValidatorFactory.cs
@@ -31,6 +31,8 @@ namespace Promitor.Scraper.Host.Validation.Factories
                     return new RedisCacheMetricValidator();
                 case ResourceType.PostgreSql:
                     return new PostgreSqlMetricValidator();
+                case ResourceType.AzureSqlDatabase:
+                    return new AzureSqlDatabaseMetricValidator();
             }
 
             throw new ArgumentOutOfRangeException(nameof(resourceType), $"No validation rules are defined for metric type '{resourceType}'");

--- a/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/AzureSqlDatabaseMetricValidator.cs
+++ b/src/Promitor.Scraper.Host/Validation/MetricDefinitions/ResourceTypes/AzureSqlDatabaseMetricValidator.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.Configuration.Model.Metrics.ResourceTypes;
+using Promitor.Scraper.Host.Validation.MetricDefinitions.Interfaces;
+
+namespace Promitor.Scraper.Host.Validation.MetricDefinitions.ResourceTypes
+{
+    /// <summary>
+    /// Validates <see cref="AzureSqlDatabaseResourceDefinition" /> objects.
+    /// </summary>
+    public class AzureSqlDatabaseMetricValidator : IMetricValidator
+    {
+        /// <inheritdoc />
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var definition in metricDefinition.Resources.Cast<AzureSqlDatabaseResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(definition.ServerName))
+                {
+                    yield return "No server name is configured";
+                }
+
+                if (string.IsNullOrWhiteSpace(definition.DatabaseName))
+                {
+                    yield return "No database name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -309,5 +309,33 @@ namespace Promitor.Scraper.Tests.Unit.Builders.Metrics.v1
 
             return this;
         }
+
+        public MetricsDeclarationBuilder WithAzureSqlDatabaseMetric(
+            string metricName = "promitor-sql-db",
+            string azureMetricName = "cpu_percent",
+            string serverName = "promitor-sql-server",
+            string databaseName = "promitor-db",
+            string metricDescription = "Metric description")
+        {
+            var azureMetricConfiguration = CreateAzureMetricConfiguration(azureMetricName);
+            var resource = new AzureSqlDatabaseResourceV1
+            {
+                ServerName = serverName,
+                DatabaseName = databaseName
+            };
+
+            var metric = new MetricDefinitionV1
+            {
+                Name = metricName,
+                Description = metricDescription,
+                AzureMetricConfiguration = azureMetricConfiguration,
+                Resources = new List<AzureResourceDefinitionV1> {resource},
+                ResourceType = ResourceType.AzureSqlDatabase
+            };
+
+            _metrics.Add(metric);
+
+            return this;
+        }
     }
 }

--- a/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/AzureSqlDatabaseDeserializerTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Serialization/v1/Providers/AzureSqlDatabaseDeserializerTests.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Scraper.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class AzureSqlDatabaseDeserializerTests : ResourceDeserializerTest
+    {
+        private readonly AzureSqlDatabaseDeserializer _deserializer;
+
+        public AzureSqlDatabaseDeserializerTests()
+        {
+            _deserializer = new AzureSqlDatabaseDeserializer(NullLogger.Instance);
+        }
+
+        [Fact]
+        public void Deserialize_ServerNameSupplied_SetsServerName()
+        {
+            YamlAssert.PropertySet<AzureSqlDatabaseResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "serverName: promitor-sql-server",
+                "promitor-sql-server",
+                c => c.ServerName);
+        }
+
+        [Fact]
+        public void Deserialize_ServerNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<AzureSqlDatabaseResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                c => c.ServerName);
+        }
+
+        [Fact]
+        public void Deserialize_DatabaseNameSupplied_SetsDatabaseName()
+        {
+            YamlAssert.PropertySet<AzureSqlDatabaseResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "databaseName: promitor-db",
+                "promitor-db",
+                c => c.DatabaseName);
+        }
+
+        [Fact]
+        public void Deserialize_DatabaseNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<AzureSqlDatabaseResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                c => c.DatabaseName);
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new AzureSqlDatabaseDeserializer(NullLogger.Instance);
+        }
+    }
+}

--- a/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/AzureSqlDatabaseMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Scraper.Tests.Unit/Validation/Metrics/ResourceTypes/AzureSqlDatabaseMetricsDeclarationValidationStepTests.cs
@@ -1,0 +1,90 @@
+﻿using Promitor.Scraper.Host.Validation.Steps;
+using Promitor.Scraper.Tests.Unit.Stubs;
+using System.ComponentModel;
+using AutoMapper;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping;
+using Promitor.Scraper.Tests.Unit.Builders.Metrics.v1;
+using Xunit;
+
+namespace Promitor.Scraper.Tests.Unit.Validation.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class AzureSqlDatabaseMetricsDeclarationValidationStepTests
+    {
+        private readonly IMapper _mapper;
+
+        public AzureSqlDatabaseMetricsDeclarationValidationStepTests()
+        {
+            var config = new MapperConfiguration(c => c.AddProfile<V1MappingProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void AzureSqlDatabaseMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureSqlDatabaseMetric(azureMetricName: string.Empty)
+                .Build(_mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, _mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            Assert.False(validationResult.IsSuccessful, "Validation is not successful");
+        }
+
+        [Fact]
+        public void AzureSqlDatabaseMetricsDeclaration_DeclarationWithoutAzureMetricDescription_Succeeds()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureSqlDatabaseMetric(metricDescription: string.Empty)
+                .Build(_mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, _mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            Assert.True(validationResult.IsSuccessful, "Validation is successful");
+        }
+
+        [Fact]
+        public void AzureSqlDatabaseMetricsDeclaration_DeclarationWithoutServerName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureSqlDatabaseMetric(serverName: string.Empty)
+                .Build(_mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, _mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            Assert.False(validationResult.IsSuccessful, "Validation is not successful");
+        }
+
+        [Fact]
+        public void AzureSqlDatabaseMetricsDeclaration_DeclarationWithoutDatabaseName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureSqlDatabaseMetric(databaseName: string.Empty)
+                .Build(_mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, _mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            Assert.False(validationResult.IsSuccessful, "Validation is not successful");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #317

## Proposed Changes

  - Implements a scraper for Azure SQL Database.

Here's an example of the metric output:

```text
# HELP azure_sql_database_dtu_consumption_percent The DTU percentage.
# TYPE azure_sql_database_dtu_consumption_percent gauge
azure_sql_database_dtu_consumption_percent{resource_group="promitor-group",subscription_id="<subscription-id>",resource_uri="subscriptions/<subscription-id>/resourceGroups/promitor-group/providers/Microsoft.Sql/servers/promitor-server/databases/database-1",server="promitor-server",database="database-1"} 70.4375
azure_sql_database_dtu_consumption_percent{resource_group="promitor-group",subscription_id="<subscription-id>",resource_uri="subscriptions/<subscription-id>/resourceGroups/promitor-group/providers/Microsoft.Sql/servers/promitor-server/databases/database-2",server="promitor-server",database="database-2"} 0

```
