### PR TITLE
Fix incorrect notes instructions

### DIFF
--- a/charts/promitor-agent-scraper/templates/NOTES.txt
+++ b/charts/promitor-agent-scraper/templates/NOTES.txt
@@ -1,9 +1,9 @@
 1. Forward the application port by running these commands:
-  
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "promitor-agent-scraper.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-kubectl port-forward $POD_NAME 8080:{{ .Values.service.targetPort }}
 
-2. Check the scraping output at http://127.0.0.1:8080{{ .Values.prometheus.scrapeEndpointPath }}
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "promitor-agent-scraper.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.targetPort }}
+
+2. Check the scraping output at http://0.0.0.0:8080{{ .Values.prometheus.scrapeEndpointPath }}
 
 3. To set up Prometheus in your cluster & pull in metrics from Promitor's scraping output, run:
 


### PR DESCRIPTION
Fix incorrect notes instructions. Namespace was missing in the port-forward command, and use 0.0.0.0 IP for the curl command (127.0.0.1 doesn't work).