### PR TITLE
Ignore changelog folder in markdown linting

### DIFF
--- a/build/azure-devops/scraper-ci.yml
+++ b/build/azure-devops/scraper-ci.yml
@@ -77,20 +77,20 @@ stages:
          solutionOrProjectPath: 'src/Promitor.sln'
          failBuildLevelSelector: 'Warning'
          commandLineInterfacePath: '$(Build.SourcesDirectory)/Lib/Resharper'
-# - stage: Docs
-#   displayName: Docs
-#   dependsOn: []
-#   jobs:
-#    - job: RunMarkdownLinter
-#      displayName: Run Markdown Linter
-#      condition: succeeded()
-#      pool:
-#        vmImage: ubuntu-16.04
-#      steps:
-#      - script: npm install
-#        displayName: 'Install npm Packages'
-#      - script: npm run --silent markdownlint
-#        displayName: 'Run markdownlint'
+- stage: Docs
+  displayName: Docs
+  dependsOn: []
+  jobs:
+   - job: RunMarkdownLinter
+     displayName: Run Markdown Linter
+     condition: succeeded()
+     pool:
+       vmImage: ubuntu-16.04
+     steps:
+     - script: npm install
+       displayName: 'Install npm Packages'
+     - script: npm run --silent markdownlint
+       displayName: 'Run markdownlint'
 - stage: Test
   displayName: Run Tests
   dependsOn: []

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "markdownlint": "markdownlint -c .markdownlint.json --ignore node_modules ."
+    "markdownlint": "markdownlint -c .markdownlint.json --ignore node_modules --ignore changelog ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Updated the markdownlint command to ignore the changelog folder.
- Re-added the check into the pipeline.

Fixes #775

@tomkerkhove for now I've just configured it to ignore the entire changelog folder because when I just ignored `changelog/themes` there were linting errors in some of the other files, and I wasn't sure if they were generated or not. If you pull down the branch you can easily try it out by changing the `--ignore changelog` to `--ignore changelog/themes` in the package.json file, and then just run `npm run markdownlint` to run the checks.