### PR TITLE
Ensure that Image.MajorMinorVersion is set in official releases

### DIFF
--- a/build/azure-devops/agents-scraper-release-official.yml
+++ b/build/azure-devops/agents-scraper-release-official.yml
@@ -13,26 +13,43 @@ variables:
   # Image.Version is configured in the build definition as settable at queue time
   # Helm.Chart.Version is configured in the build definition as settable at queue time
 stages:
-- stage: Build
-  displayName: Build and Push Docker image
+- stage: Init
+  displayName: Prepare Release
   jobs:
-   - job: Build
+   - job: DetermineVersion
+     displayName: Determine Version
      pool:
        vmImage: ubuntu-16.04
      steps:
-     - task: DotNetCoreInstaller@0
-       displayName: 'Install .NET SDK'
-       inputs:
-        version: '$(DotNet.SDK.Version)'
      - powershell: |
         Write-Host "Determining '{major}.{minor}' for '$(Image.Version)'"
         $index = "$(Image.Version)".IndexOf(".", 2);
         $majorMinorVersion = "$(Image.Version)".Substring(0, $index);
         Write-Host "Found version '$majorMinorVersion'"
         Write-Output ("##vso[task.setvariable variable=Image.MajorMinorVersion;]$majorMinorVersion")
-        Write-Output ("##vso[task.setvariable variable=MajorMinorVersion;isOutput=true]$majorMinorVersion")
-       name: DetermineMajorMinor
        displayName: 'Determine ''{major}.{minor}'' version'
+     - template: ./../templates/persist-variable.yml
+       parameters:
+          variableName: 'Image.MajorMinorVersion'
+     - publish: $(Pipeline.Workspace)/variables
+       artifact: variables
+- stage: Build
+  dependsOn: Init
+  displayName: Build and Push Docker image
+  jobs:
+   - job: Build
+     pool:
+       vmImage: ubuntu-16.04
+     steps:
+     - download: current
+       artifact: variables
+     - template: ./../templates/read-variable.yml
+       parameters:
+          variableName: 'Image.MajorMinorVersion'
+     - task: DotNetCoreInstaller@0
+       displayName: 'Install .NET SDK'
+       inputs:
+        version: '$(DotNet.SDK.Version)'
      - task: DotNetCoreCLI@2
        displayName: 'Run Unit Tests'
        inputs:
@@ -76,9 +93,12 @@ stages:
      displayName: Create Release
      pool:
        vmImage: ubuntu-16.04
-     variables:
-       BuildJob.DefinedMajorMinorVersion: $[ dependencies.Build.outputs['DetermineMajorMinor.MajorMinorVersion'] ]
      steps:
+     - download: current
+       artifact: variables
+     - template: ./../templates/read-variable.yml
+       parameters:
+          variableName: 'Image.MajorMinorVersion'
      - task: GitHubRelease@0
        displayName: 'Create GitHub Release'
        inputs:
@@ -108,7 +128,7 @@ stages:
           New Docker image tags are available:
           - `latest`
           - `$(Image.Version)`
-          - `$(BuildJob.DefinedMajorMinorVersion)`
+          - `$(Image.MajorMinorVersion)`
 
           Docker image is available on [Docker Hub](https://hub.docker.com/r/tomkerkhove/promitor-agent-scraper/).<br />
           For more information about our tagging strategy, feel free to read our [documentation](https://promitor.io/deployment/#image-tagging-strategy).

--- a/build/azure-devops/agents-scraper-release-official.yml
+++ b/build/azure-devops/agents-scraper-release-official.yml
@@ -29,7 +29,8 @@ stages:
         $index = "$(Image.Version)".IndexOf(".", 2);
         $majorMinorVersion = "$(Image.Version)".Substring(0, $index);
         Write-Host "Found version '$majorMinorVersion'"
-        Write-Output ("##vso[task.setvariable variable=Image.MajorMinorVersion;]$majorMinorVersion")
+        Write-Output ("##vso[task.setvariable variable=Image.MajorMinorVersion;isOutput=true]$majorMinorVersion")
+       name: DetermineMajorMinor
        displayName: 'Determine ''{major}.{minor}'' version'
      - task: DotNetCoreCLI@2
        displayName: 'Run Unit Tests'
@@ -74,6 +75,8 @@ stages:
      displayName: Create Release
      pool:
        vmImage: ubuntu-16.04
+     variables:
+       BuildJob.DefinedMajorMinorVersion: $[ dependencies.Build.outputs['DetermineMajorMinor.Image.MajorMinorVersion'] ]
      steps:
      - task: GitHubRelease@0
        displayName: 'Create GitHub Release'
@@ -104,7 +107,7 @@ stages:
           New Docker image tags are available:
           - `latest`
           - `$(Image.Version)`
-          - `$(Image.MajorMinorVersion)`
+          - `$(BuildJob.DefinedMajorMinorVersion)`
 
           Docker image is available on [Docker Hub](https://hub.docker.com/r/tomkerkhove/promitor-agent-scraper/).<br />
           For more information about our tagging strategy, feel free to read our [documentation](https://promitor.io/deployment/#image-tagging-strategy).

--- a/build/azure-devops/agents-scraper-release-official.yml
+++ b/build/azure-devops/agents-scraper-release-official.yml
@@ -29,7 +29,8 @@ stages:
         $index = "$(Image.Version)".IndexOf(".", 2);
         $majorMinorVersion = "$(Image.Version)".Substring(0, $index);
         Write-Host "Found version '$majorMinorVersion'"
-        Write-Output ("##vso[task.setvariable variable=Image.MajorMinorVersion;isOutput=true]$majorMinorVersion")
+        Write-Output ("##vso[task.setvariable variable=Image.MajorMinorVersion;]$majorMinorVersion")
+        Write-Output ("##vso[task.setvariable variable=MajorMinorVersion;isOutput=true]$majorMinorVersion")
        name: DetermineMajorMinor
        displayName: 'Determine ''{major}.{minor}'' version'
      - task: DotNetCoreCLI@2
@@ -76,7 +77,7 @@ stages:
      pool:
        vmImage: ubuntu-16.04
      variables:
-       BuildJob.DefinedMajorMinorVersion: $[ dependencies.Build.outputs['DetermineMajorMinor.Image.MajorMinorVersion'] ]
+       BuildJob.DefinedMajorMinorVersion: $[ dependencies.Build.outputs['DetermineMajorMinor.MajorMinorVersion'] ]
      steps:
      - task: GitHubRelease@0
        displayName: 'Create GitHub Release'

--- a/build/azure-devops/templates/persist-variable.yml
+++ b/build/azure-devops/templates/persist-variable.yml
@@ -1,0 +1,18 @@
+parameters:
+  variableName: ''
+
+steps:
+- bash: |
+    echo "Variable 'variableName' found with value '$VARIABLE_NAME'"
+    if [ -z "$VARIABLE_NAME" ]; then
+      echo "##vso[task.logissue type=error;]Missing template parameter \"variableName\""
+      echo "##vso[task.complete result=Failed;]"
+    fi
+  env:
+    VARIABLE_NAME: ${{ parameters.variableName }}
+  displayName: Check for required parameters in YAML template
+- powershell: |
+   mkdir -p $(Pipeline.Workspace)/variables
+   echo "$(${{ parameters.variableName }})" > $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable
+   echo "Variable written to '$(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable'"
+  displayName: 'Persist ''${{ parameters.variableName }}'' variable'

--- a/build/azure-devops/templates/read-variable.yml
+++ b/build/azure-devops/templates/read-variable.yml
@@ -1,0 +1,20 @@
+parameters:
+  variableName: ''
+
+steps:
+- bash: |
+    echo "Variable 'variableName' found with value '$VARIABLE_NAME'"
+    if [ -z "$VARIABLE_NAME" ]; then
+      echo "##vso[task.logissue type=error;]Missing template parameter \"variableName\""
+      echo "##vso[task.complete result=Failed;]"
+    fi
+  env:
+    VARIABLE_NAME: ${{ parameters.variableName }}
+  displayName: Check for required parameters in YAML template
+- bash: |
+   echo "Reading file '$(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable'"
+   cat $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable
+   READ_VAR=$(cat $(Pipeline.Workspace)/variables/${{ parameters.variableName }}.variable)
+   echo "Read value '$READ_VAR'"
+   echo "##vso[task.setvariable variable=${{ parameters.variableName }};]$READ_VAR"
+  displayName: 'Reading ''${{ parameters.variableName }}'' variable'


### PR DESCRIPTION
Based on https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable.

Fixes #709