### PR TITLE
Metric labels for dimensions should always be lower-cased

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,3 +6,4 @@ version:
 ---
 
 - {{% tag added %}} Azure Virtual Machine Scale Set Scraper ([docs](https://promitor.io/configuration/v1.x/metrics/virtual-machine-scale-set) | [#310](https://github.com/tomkerkhove/promitor/issues/310))
+- {{% tag changed %}} Metric labels for dimensions are now always lower-cased

--- a/src/Promitor.Core.Scraping/Prometheus/PrometheusMetricWriter.cs
+++ b/src/Promitor.Core.Scraping/Prometheus/PrometheusMetricWriter.cs
@@ -52,7 +52,7 @@ namespace Promitor.Core.Scraping.Prometheus
 
             if (measuredMetric.IsDimensional)
             {
-                labels.Add(measuredMetric.DimensionName, measuredMetric.DimensionValue);
+                labels.Add(measuredMetric.DimensionName.ToLower(), measuredMetric.DimensionValue);
             }
 
             if (metricDefinition?.Labels?.Any() == true)


### PR DESCRIPTION
Metric labels for dimensions should always be lower-cased for consistency reasons.