### PR TITLE
Fix MD027 violation on sql-server.md

### DIFF
--- a/build/azure-devops/scraper-ci.yml
+++ b/build/azure-devops/scraper-ci.yml
@@ -13,6 +13,7 @@ pr:
     - build/azure-devops/scraper-ci.yml
     - charts/promitor-agent-scraper/*
     - deploy/automation/docker-hub/ci/* # Add Docker Hub bot here to trigger it for testing sake
+    - docs/*
 variables:
   DotNet.SDK.Version: '3.1.101'
   DotNet.Configuration: 'release'

--- a/docs/configuration/v1.x/metrics/sql-server.md
+++ b/docs/configuration/v1.x/metrics/sql-server.md
@@ -21,8 +21,8 @@ Supported metrics:
   - *Requires `dimension.name` to be set to `DatabaseResourceId`*
 
 > The official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlservers)
- lists more metrics but these are not surfaced externally. However, you can still give them a try but we don't
- support them for now.
+> lists more metrics but these are not surfaced externally. However, you can still give them a try but we don't
+> support them for now.
 
 Example:
 


### PR DESCRIPTION
markdownlint was complaining because there was a blockquote defined without an angle bracket on each line. This triggered <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md027---multiple-spaces-after-blockquote-symbol>.

I think what's happened is that the docs folder wasn't configured to trigger an Azure Pipelines build, so the check was never run on the PR. I've updated the pipelines file to trigger a build on changes to the docs folder now.

@tomkerkhove do you think it makes sense to have a separate pipeline for the docs folder so it doesn't need to run a full build of the code if you're just making a documentation change? I went with the easy option of just adding the docs folder for now, but I figured it was worth asking.