### PR TITLE
Improve fluent mapping

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -89,6 +89,16 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             return Deserialize(node, errorReporter);
         }
 
+        protected FieldDeserializationInfoBuilder<TObject, TReturn> Map<TReturn>(Expression<Func<TObject, TReturn>> accessorExpression)
+        {
+            var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();
+            builder.SetProperty(accessorExpression);
+
+            _fieldBuilders.Add(builder);
+
+            return builder;
+        }
+
         protected void MapRequired<TReturn>(Expression<Func<TObject, TReturn>> accessorExpression, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc = null)
         {
             var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationInfoBuilder.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/FieldDeserializationInfoBuilder.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// Used to build a <see cref="FieldDeserializationInfo" /> object.
+    /// </summary>
+    public class FieldDeserializationInfoBuilder<TObject, TReturn> : IFieldDeserializationInfoBuilder
+    {
+        private PropertyInfo _propertyInfo;
+        private bool _isRequired;
+        private object _defaultValue;
+        private Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> _customMapperFunc;
+        private IDeserializer _deserializer;
+
+        /// <summary>
+        /// Sets the expression that defines the property to map.
+        /// </summary>
+        /// <param name="accessorExpression">The expression used to map the property.</param>
+        public void SetProperty(Expression<Func<TObject, TReturn>> accessorExpression)
+        {
+            var memberExpression = accessorExpression.Body as MemberExpression;
+
+            if (memberExpression?.Member is PropertyInfo info)
+            {
+                _propertyInfo = info;
+            }
+            else
+            {
+                throw new ArgumentException("The expression must be a property accessor", nameof(accessorExpression));
+            }
+        }
+
+        /// <summary>
+        /// Marks the field as required.
+        /// </summary>
+        /// <returns>The builder.</returns>
+        public FieldDeserializationInfoBuilder<TObject, TReturn> IsRequired()
+        {
+            _isRequired = true;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies a default value to use if the field isn't supplied.
+        /// </summary>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>The builder.</returns>
+        public FieldDeserializationInfoBuilder<TObject, TReturn> WithDefault(object defaultValue)
+        {
+            _defaultValue = defaultValue;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies a custom method to use to map the field.
+        /// </summary>
+        /// <param name="customMapperFunc">The custom method to use.</param>
+        /// <returns>The builder.</returns>
+        public FieldDeserializationInfoBuilder<TObject, TReturn> MapUsing(Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc)
+        {
+            _customMapperFunc = customMapperFunc;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies an <see cref="IDeserializer" /> to use to map the field.
+        /// </summary>
+        /// <param name="deserializer">The deserializer.</param>
+        /// <returns>The builder.</returns>
+        public FieldDeserializationInfoBuilder<TObject, TReturn> MapUsingDeserializer(IDeserializer deserializer)
+        {
+            _deserializer = deserializer;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the field.
+        /// </summary>
+        /// <returns>The field.</returns>
+        public FieldDeserializationInfo Build()
+        {
+            return new FieldDeserializationInfo(
+                _propertyInfo, _isRequired, _defaultValue, _customMapperFunc, _deserializer);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/IFieldDeserializationInfoBuilder.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/IFieldDeserializationInfoBuilder.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization
+{
+    /// <summary>
+    /// An object that can build <see cref="FieldDeserializationInfo" /> objects.
+    /// </summary>
+    public interface IFieldDeserializationInfoBuilder
+    {
+        /// <summary>
+        /// Builds the deserialization info object.
+        /// </summary>
+        FieldDeserializationInfo Build();
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetadataDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureMetadataDeserializer.cs
@@ -10,10 +10,15 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
     {
         public AzureMetadataDeserializer(ILogger<AzureMetadataDeserializer> logger) : base(logger)
         {
-            MapRequired(metadata => metadata.TenantId);
-            MapRequired(metadata => metadata.SubscriptionId);
-            MapRequired(metadata => metadata.ResourceGroupName);
-            MapOptional(metadata => metadata.Cloud, AzureEnvironment.AzureGlobalCloud, DetermineAzureCloud);
+            Map(metadata => metadata.TenantId)
+                .IsRequired();
+            Map(metadata => metadata.SubscriptionId)
+                .IsRequired();
+            Map(metadata => metadata.ResourceGroupName)
+                .IsRequired();
+            Map(metadata => metadata.Cloud)
+                .WithDefault(AzureEnvironment.AzureGlobalCloud)
+                .MapUsing(DetermineAzureCloud);
         }
 
         private object DetermineAzureCloud(string rawAzureCloud, KeyValuePair<YamlNode, YamlNode> nodePair, IErrorReporter errorReporter)

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
@@ -1,0 +1,47 @@
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class DefaultTests
+    {
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
+            new FieldDeserializationInfoBuilder<TestConfig, string>();
+
+        public DefaultTests()
+        {
+            _builder.SetProperty(c => c.Name);
+        }
+
+        [Fact]
+        public void WithDefault_SetsDefaultValueForField()
+        {
+            // Act
+            _builder.WithDefault("Promitor");
+
+            // Assert
+            var fieldInfo = _builder.Build();
+            Assert.Equal("Promitor", fieldInfo.DefaultValue);
+        }
+
+        [Fact]
+        public void Build_WithDefaultNotCalled_UsesDefaultValueForType()
+        {
+            // Act
+            var fieldInfo = _builder.Build();
+
+            // Assert
+            Assert.Equal(default(string), fieldInfo.DefaultValue);
+        }
+
+        [Fact]
+        public void WithDefault_ReturnsBuilder()
+        {
+            // Act
+            var result = _builder.WithDefault("abc123");
+
+            // Assert
+            Assert.Same(_builder, result);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
@@ -1,0 +1,44 @@
+using Moq;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class MapUsingDeserializerTests
+    {
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
+            new FieldDeserializationInfoBuilder<TestConfig, string>();
+
+        public MapUsingDeserializerTests()
+        {
+            _builder.SetProperty(c => c.Name);
+        }
+
+        [Fact]
+        public void MapUsingDeserializer_SetsDeserializer()
+        {
+            // Arrange
+            var deserializer = Mock.Of<IDeserializer>();
+
+            // Act
+            _builder.MapUsingDeserializer(deserializer);
+
+            // Assert
+            var fieldInfo = _builder.Build();
+            Assert.Same(deserializer, fieldInfo.Deserializer);
+        }
+
+        [Fact]
+        public void MapUsingDeserializer_ReturnsBuilder()
+        {
+            // Arrange
+            var deserializer = Mock.Of<IDeserializer>();
+
+            // Act
+            var result = _builder.MapUsingDeserializer(deserializer);
+
+            // Assert
+            Assert.Same(_builder, result);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class MapUsingTests
+    {
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
+            new FieldDeserializationInfoBuilder<TestConfig, string>();
+
+        public MapUsingTests()
+        {
+            _builder.SetProperty(c => c.Name);
+        }
+
+        [Fact]
+        public void MapUsing_UsesCustomMapper()
+        {
+            // Act
+            _builder.MapUsing((name, node, reporter) => "Hello " + name);
+
+            // Assert
+            var fieldInfo = _builder.Build();
+            var result = fieldInfo.CustomMapperFunc("Promitor", new KeyValuePair<YamlNode, YamlNode>(), null);
+            Assert.Equal("Hello Promitor", result);
+        }
+
+        [Fact]
+        public void MapUsing_ReturnsBuilder()
+        {
+            // Act
+            var result = _builder.MapUsing((name, node, reporter) => "Hello " + name);
+
+            // Assert
+            Assert.Same(_builder, result);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
@@ -1,0 +1,47 @@
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class RequiredTests
+    {
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
+            new FieldDeserializationInfoBuilder<TestConfig, string>();
+
+        public RequiredTests()
+        {
+            _builder.SetProperty(c => c.Name);
+        }
+
+        [Fact]
+        public void IsRequired_SetsFieldAsRequired()
+        {
+            // Act
+            _builder.IsRequired();
+
+            // Assert
+            var fieldInfo = _builder.Build();
+            Assert.True(fieldInfo.IsRequired);
+        }
+
+        [Fact]
+        public void Build_DefaultsIsRequiredToFalse()
+        {
+            // Act
+            var fieldInfo = _builder.Build();
+
+            // Assert
+            Assert.False(fieldInfo.IsRequired);
+        }
+
+        [Fact]
+        public void IsRequired_ReturnsBuilder()
+        {
+            // Act
+            var result = _builder.IsRequired();
+
+            // Assert
+            Assert.Same(_builder, result);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class SetPropertyTests
+    {
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
+            new FieldDeserializationInfoBuilder<TestConfig, string>();
+
+        [Fact]
+        public void SetProperty_SetsPropertyInfo_WhenBuilding()
+        {
+            // Arrange
+            _builder.SetProperty(c => c.Name);
+
+            // Act
+            var fieldInfo = _builder.Build();
+
+            // Assert
+            var nameProperty = typeof(TestConfig).GetProperty(nameof(TestConfig.Name));
+            Assert.Same(nameProperty, fieldInfo.PropertyInfo);
+        }
+
+        [Fact]
+        public void SetProperty_ThrowsException_IfExpressionNotForProperty()
+        {
+            // Act / Assert
+            Assert.Throws<ArgumentException>(() => _builder.SetProperty(c => c.GetName()));
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/TestConfig.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/TestConfig.cs
@@ -1,0 +1,11 @@
+namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
+{
+    public class TestConfig
+    {
+        public string Name { get; set; }
+        public string GetName()
+        {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
I've added a new way of configuring deserializers to try to simplify things a bit, and to make it easier for us to extend deserialization. So instead of writing the following:

```csharp
MapOptional(metadata => metadata.Cloud, AzureEnvironment.AzureGlobalCloud, DetermineAzureCloud);
```

We can write it:

```csharp
Map(metadata => metadata.Cloud)
    .WithDefault(AzureEnvironment.AzureGlobalCloud)
    .MapUsing(DetermineAzureCloud);
```

Originally when I'd added the `MapOptional()` / `MapRequired()` methods, I wanted to avoid going too far down the route of designing a fluent interface because this is just used internally by Promitor, but the approach of using overloads becomes pretty unwieldy very quickly. Making this change makes it easier to add extra functionality to the deserializers, for example custom validation. This would allow us to do something like this to make sure Cron expressions were in the correct format:

```csharp
Map(scraping => scraping.Schedule)
    .IsRequired()
    .ValidateUsing(schedule => CronExpression.Parse(schedule), "The schedule must be a valid Cron expression.");
```

At the moment I've just converted the `AzureMetadataDeserializer` to give an example of how it might look, but I'll go ahead and convert all the deserializers if it's all looking good.