### PR TITLE
Update tests to use new mapping syntax

### DIFF
--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
@@ -261,18 +261,22 @@ namespace Promitor.Tests.Unit.Serialization.DeserializerTests
         {
             public RegistrationConfigDeserializer(IDeserializer childDeserializer) : base(NullLogger.Instance)
             {
-                MapRequired(t => t.Name);
-                MapRequired(t => t.Age);
-                MapRequired(t => t.Day);
-                MapOptional(t => t.NullableDay);
-                MapRequired(t => t.Classes);
-                MapOptional(t => t.Town);
-                MapOptional(t => t.Interval);
-                MapOptional(t => t.DefaultedInterval, defaultInterval);
-                MapOptional(t => t.NullableInterval);
-                MapOptional(t => t.InvertedProperty, false, InvertBooleanString);
-                MapRequired(t => t.Child, childDeserializer);
-                MapOptional(t => t.OptionalChild, childDeserializer);
+                Map(t => t.Name).IsRequired();
+                Map(t => t.Age).IsRequired();
+                Map(t => t.Day).IsRequired();
+                Map(t => t.NullableDay);
+                Map(t => t.Classes).IsRequired();
+                Map(t => t.Town);
+                Map(t => t.Interval);
+                Map(t => t.DefaultedInterval).WithDefault(defaultInterval);
+                Map(t => t.NullableInterval);
+                Map(t => t.InvertedProperty)
+                    .MapUsing(InvertBooleanString);
+                Map(t => t.Child)
+                    .IsRequired()
+                    .MapUsingDeserializer(childDeserializer);
+                Map(t => t.OptionalChild)
+                    .MapUsingDeserializer(childDeserializer);
             }
 
             private static object InvertBooleanString(string value, KeyValuePair<YamlNode, YamlNode> nodePair, IErrorReporter errorReporter)

--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -165,10 +165,10 @@ country: Scotland");
         {
             public TestDeserializer() : base(NullLogger.Instance)
             {
-                MapRequired(t => t.Name);
-                MapOptional(t => t.Age);
-                MapOptional(t => t.Day);
-                MapOptional(t => t.Interval);
+                Map(t => t.Name).IsRequired();
+                Map(t => t.Age);
+                Map(t => t.Day);
+                Map(t => t.Interval);
                 IgnoreField("customField");
             }
         }


### PR DESCRIPTION
I've updated the tests for Deserializer to use the new `Map()` method.

Part of #1091.