### PR TITLE
Update all the resource type deserializers

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -99,50 +99,6 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             return builder;
         }
 
-        protected void MapRequired<TReturn>(Expression<Func<TObject, TReturn>> accessorExpression, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc = null)
-        {
-            var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();
-            builder.SetProperty(accessorExpression);
-            builder.IsRequired();
-            builder.MapUsing(customMapperFunc);
-
-            _fieldBuilders.Add(builder);
-        }
-
-        protected void MapRequired<TReturn>(
-            Expression<Func<TObject, TReturn>> accessorExpression, IDeserializer deserializer)
-            where TReturn: new()
-        {
-            var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();
-            builder.SetProperty(accessorExpression);
-            builder.IsRequired();
-            builder.MapUsingDeserializer(deserializer);
-
-            _fieldBuilders.Add(builder);
-        }
-        
-        protected void MapOptional<TReturn>(
-            Expression<Func<TObject, TReturn>> accessorExpression, TReturn defaultValue = default, Func<string, KeyValuePair<YamlNode, YamlNode>, IErrorReporter, object> customMapperFunc = null)
-        {
-            var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();
-            builder.SetProperty(accessorExpression);
-            builder.WithDefault(defaultValue);
-            builder.MapUsing(customMapperFunc);
-
-            _fieldBuilders.Add(builder);
-        }
-
-        protected void MapOptional<TReturn>(
-            Expression<Func<TObject, TReturn>> accessorExpression, IDeserializer deserializer)
-            where TReturn: new()
-        {
-            var builder = new FieldDeserializationInfoBuilder<TObject, TReturn>();
-            builder.SetProperty(accessorExpression);
-            builder.MapUsingDeserializer(deserializer);
-
-            _fieldBuilders.Add(builder);
-        }
-
         protected void IgnoreField(string fieldName)
         {
             _ignoredFields.Add(fieldName);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApiManagementDeserializer.cs
@@ -14,8 +14,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public ApiManagementDeserializer(ILogger logger) : base(logger)
         {
-            MapRequired(resource => resource.InstanceName);
-            MapOptional(resource => resource.LocationName);
+            Map(resource => resource.InstanceName)
+                .IsRequired();
+            Map(resource => resource.LocationName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AppPlanDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public AppPlanDeserializer(ILogger<AppPlanDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.AppPlanName);
+            Map(resource => resource.AppPlanName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/BlobStorageDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public BlobStorageDeserializer(ILogger<BlobStorageDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.AccountName);
+            Map(resource => resource.AccountName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerInstanceDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public ContainerInstanceDeserializer(ILogger<ContainerInstanceDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.ContainerGroup);
+            Map(resource => resource.ContainerGroup)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ContainerRegistryDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public ContainerRegistryDeserializer(ILogger<ContainerRegistryDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.RegistryName);
+            Map(resource => resource.RegistryName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/CosmosDbDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public CosmosDbDeserializer(ILogger<CosmosDbDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.DbName);
+            Map(resource => resource.DbName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/DeviceProvisioningServiceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/DeviceProvisioningServiceDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public DeviceProvisioningServiceDeserializer(ILogger<DeviceProvisioningServiceDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.DeviceProvisioningServiceName);
+            Map(resource => resource.DeviceProvisioningServiceName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FileStorageDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public FileStorageDeserializer(ILogger<FileStorageDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.AccountName);
+            Map(resource => resource.AccountName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FunctionAppDeserializer.cs
@@ -7,8 +7,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public FunctionAppDeserializer(ILogger<FunctionAppDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.FunctionAppName);
-            MapOptional(resource => resource.SlotName);
+            Map(resource => resource.FunctionAppName)
+                .IsRequired();
+            Map(resource => resource.SlotName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/GenericResourceDeserializer.cs
@@ -7,8 +7,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public GenericResourceDeserializer(ILogger<GenericResourceDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.ResourceUri);
-            MapOptional(resource => resource.Filter);
+            Map(resource => resource.ResourceUri)
+                .IsRequired();
+            Map(resource => resource.Filter);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/IoTHubDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/IoTHubDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public IoTHubDeserializer(ILogger<IoTHubDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.IoTHubName);
+            Map(resource => resource.IoTHubName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/KeyVaultDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/KeyVaultDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public KeyVaultDeserializer(ILogger<KeyVaultDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.VaultName);
+            Map(resource => resource.VaultName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NetworkInterfaceDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public NetworkInterfaceDeserializer(ILogger<NetworkInterfaceDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.NetworkInterfaceName);
+            Map(resource => resource.NetworkInterfaceName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PostgreSqlDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public PostgreSqlDeserializer(ILogger<PostgreSqlDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.ServerName);
+            Map(resource => resource.ServerName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/RedisCacheDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public RedisCacheDeserializer(ILogger<RedisCacheDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.CacheName);
+            Map(resource => resource.CacheName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ResourceDeserializer.cs
@@ -12,8 +12,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         protected ResourceDeserializer(ILogger logger) : base(logger)
         {
-            MapOptional(resource => resource.SubscriptionId);
-            MapOptional(resource => resource.ResourceGroupName);
+            Map(resource => resource.SubscriptionId);
+            Map(resource => resource.ResourceGroupName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
@@ -7,8 +7,10 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public ServiceBusQueueDeserializer(ILogger<ServiceBusQueueDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.QueueName);
-            MapRequired(resource => resource.Namespace);
+            Map(resource => resource.QueueName)
+                .IsRequired();
+            Map(resource => resource.Namespace)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlDatabaseDeserializer.cs
@@ -14,8 +14,10 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlDatabaseDeserializer(ILogger logger) : base(logger)
         {
-            MapRequired(resource => resource.ServerName);
-            MapRequired(resource => resource.DatabaseName);
+            Map(resource => resource.ServerName)
+                .IsRequired();
+            Map(resource => resource.DatabaseName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlManagedInstanceDeserializer.cs
@@ -14,7 +14,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlManagedInstanceDeserializer(ILogger logger) : base(logger)
         {
-            MapRequired(resource => resource.InstanceName);
+            Map(resource => resource.InstanceName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/SqlServerDeserializer.cs
@@ -14,7 +14,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
         /// <param name="logger">The logger.</param>
         public SqlServerDeserializer(ILogger logger) : base(logger)
         {
-            MapRequired(resource => resource.ServerName);
+            Map(resource => resource.ServerName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageAccountDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public StorageAccountDeserializer(ILogger<StorageAccountDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.AccountName);
+            Map(resource => resource.AccountName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/StorageQueueDeserializer.cs
@@ -8,9 +8,13 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public StorageQueueDeserializer(IDeserializer<SecretV1> secretDeserializer, ILogger<StorageQueueDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.AccountName);
-            MapRequired(resource => resource.QueueName);
-            MapRequired(resource => resource.SasToken, secretDeserializer);
+            Map(resource => resource.AccountName)
+                .IsRequired();
+            Map(resource => resource.QueueName)
+                .IsRequired();
+            Map(resource => resource.SasToken)
+                .IsRequired()
+                .MapUsingDeserializer(secretDeserializer);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public VirtualMachineDeserializer(ILogger<VirtualMachineDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.VirtualMachineName);
+            Map(resource => resource.VirtualMachineName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/VirtualMachineScaleSetDeserializer.cs
@@ -7,7 +7,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public VirtualMachineScaleSetDeserializer(ILogger<VirtualMachineScaleSetDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.ScaleSetName);
+            Map(resource => resource.ScaleSetName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/WebAppDeserializer.cs
@@ -7,8 +7,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public WebAppDeserializer(ILogger<WebAppDeserializer> logger) : base(logger)
         {
-            MapRequired(resource => resource.WebAppName);
-            MapOptional(resource => resource.SlotName);
+            Map(resource => resource.WebAppName)
+                .IsRequired();
+            Map(resource => resource.SlotName);
         }
     }
 }


### PR DESCRIPTION
- Updated all the resource type deserializers, switching them to the new mapping syntax.
- Removed the `MapOptional()` and `MapRequired()` methods since they aren't required anymore.

Part of #1091
