### PR TITLE
Provide possible suggestions for unknown fields

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,3 +8,4 @@ version:
 - {{% tag added %}} New validation rule to ensure at least one resource or resource collection is configured to scrape
 - {{% tag removed %}} Support for Swagger 2.0 ([deprecation notice](https://changelog.promitor.io/#swagger-2-0))
 - {{% tag removed %}} Support for Swagger UI 2.0 ([deprecation notice](https://changelog.promitor.io/#swagger-ui-2-0))
+- {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. [#1105](https://github.com/tomkerkhove/promitor/issues/1105).

--- a/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
@@ -40,7 +40,7 @@ namespace Promitor.Core.Scraping.Configuration.Providers
 
             var config = _configurationSerializer.Deserialize(rawMetricsDeclaration, errorReporter);
 
-            if (applyDefaults)
+            if (!errorReporter.HasErrors && applyDefaults)
             {
                 foreach (var metric in config.Metrics)
                 {

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -45,7 +45,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
                 }
                 else
                 {
-                    errorReporter.ReportWarning(child.Key, $"Unknown field '{child.Key}'.");
+                    errorReporter.ReportWarning(
+                        child.Key, GetUnknownFieldWarningMessage(deserializationContext, child.Key.ToString()));
                 }
             }
 
@@ -157,6 +158,29 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
             }
 
             return null;
+        }
+        
+        /// <summary>
+        /// Gets the warning message to use when an invalid field name is found
+        /// in the configuration.
+        /// </summary>
+        /// <param name="deserializationContext">The deserialization context.</param>
+        /// <param name="fieldName">The unknown field.</param>
+        private static string GetUnknownFieldWarningMessage(DeserializationContext<TObject> deserializationContext, string fieldName)
+        {
+            var message = $"Unknown field '{fieldName}'.";
+            var suggestions = deserializationContext
+                .GetSuggestions(fieldName)
+                .Select(suggestion => $"'{suggestion}'")
+                .ToList();
+
+            if (suggestions.Any())
+            {
+                var formattedSuggestions = string.Join(", ", suggestions);
+                message += $" Did you mean {formattedSuggestions}?";
+            }
+
+            return message;
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/Deserializer.cs
@@ -45,8 +45,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization
                 }
                 else
                 {
-                    errorReporter.ReportWarning(
-                        child.Key, GetUnknownFieldWarningMessage(deserializationContext, child.Key.ToString()));
+                    var warningMessage = GetUnknownFieldWarningMessage(deserializationContext, child.Key.ToString());
+                    errorReporter.ReportWarning(child.Key, warningMessage);
                 }
             }
 

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="Fastenshtein" Version="1.0.0.5" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.34.0" />

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
+    <PackageReference Include="Fastenshtein" Version="1.0.0.5" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />

--- a/src/Promitor.Tests.Unit/Serialization/DeserializationContextTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializationContextTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization
+{
+    public class DeserializationContextTests
+    {
+        [Fact]
+        public void GetSuggestions_NoFieldsConfigured_Empty()
+        {
+            // Arrange
+            var context = new DeserializationContext<Person>(
+                new HashSet<string>(), new List<FieldDeserializationInfo>());
+
+            // Act
+            var suggestions = context.GetSuggestions("job");
+
+            // Assert
+            Assert.Empty(suggestions);
+        }
+
+        [Fact]
+        public void GetSuggestions_CloseEnoughSuggestion_ReturnsSuggestion()
+        {
+            // Arrange
+            var fields = new List<FieldDeserializationInfo>
+            {
+                CreateField(typeof(Person).GetProperty(nameof(Person.Name))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Age))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Country))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.County)))
+            };
+            var context = new DeserializationContext<Person>(new HashSet<string>(), fields);
+
+            // Act
+            var suggestions = context.GetSuggestions("nmae");
+
+            // Assert
+            Assert.Collection(suggestions, suggestion => Assert.Equal("name", suggestion));
+        }
+
+        [Fact]
+        public void GetSuggestions_CloseEnoughSuggestion_ReturnsAllSuggestions()
+        {
+            // Arrange
+            var fields = new List<FieldDeserializationInfo>
+            {
+                CreateField(typeof(Person).GetProperty(nameof(Person.Name))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Age))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Country))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.County)))
+            };
+            var context = new DeserializationContext<Person>(new HashSet<string>(), fields);
+
+            // Act
+            var suggestions = context.GetSuggestions("count");
+
+            // Assert
+            Assert.Collection(suggestions,
+                suggestion => Assert.Equal("country", suggestion),
+                suggestion => Assert.Equal("county", suggestion));
+        }
+
+        [Fact]
+        public void GetSuggestions_IgnoredFields_IncludesIgnoredFieldsInSuggestions()
+        {
+            // Arrange
+            var fields = new List<FieldDeserializationInfo>
+            {
+                CreateField(typeof(Person).GetProperty(nameof(Person.Name))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Age))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.Country))),
+                CreateField(typeof(Person).GetProperty(nameof(Person.County)))
+            };
+            var ignoredFields = new HashSet<string> { "named" };
+            var context = new DeserializationContext<Person>(ignoredFields, fields);
+
+            // Act
+            var suggestions = context.GetSuggestions("nam");
+
+            // Assert
+            Assert.Collection(suggestions,
+                suggestion => Assert.Equal("name", suggestion),
+                suggestion => Assert.Equal("named", suggestion));
+        }
+
+        private FieldDeserializationInfo CreateField(PropertyInfo propertyInfo)
+        {
+            return new FieldDeserializationInfo(propertyInfo, false, null, null, null);
+        }
+
+        public class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public string Country { get; set; }
+            public string County { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I've updated the deserialization to provide a list of suggestions for unknown field names. This uses the Fastenshtein library to calculate the edit distance between the field name entered by a user and the possible fields.

I've chosen to return fields if they have an edit distance less than 3. This is fairly arbitrary and just based on some simple testing. I wanted to provide suggestions, but not provide ones that were completely different to the name entered.

Also:

- Updated the V1Deserializer to use the `Map()` syntax for mapping rather than doing everything manually. The main reason for this was so that the fields are added as suggestions, although it also removes some unnecessary code.
- Altered MetricsDeclarationProvider to not set the defaults if validating the metrics fails. The reason I've done this is that if the metric defaults couldn't be deserialized, we end up with a NullReferenceException.

Fixes #1105

If we have the following config:

```yaml
version: v1
azureMetadata:
  tenantId: <tenant-id>
  subscriptionId: <subscription-id>
  resourceGroupName: promitor
metricDeflauts:
  aggregation:
    interval: 00:05:00
  scraping:
    # Every minute
    schedule: "0 * * ? * *"
metrics:
  - nam: azure_lb_data_path_availability
    desription: "The CPU of our containers in a container group."
    resourcetype: Generic
    Scraping:
      schedule: '0 * * ? * *'
    azureMetricConfiguration:
      metricName: VipAvailability
      aggregation:
        type: Average
    resource:
    - resourceUri: "Microsoft.Network/loadBalancers/promitor-lb"
```

It produces the following error messages:

```text
[17:47:06 ERR] The following problems were found with the metric configuration:
Warning 6:1: Unknown field 'metricDeflauts'. Did you mean 'metricDefaults'?
Warning 13:5: Unknown field 'nam'. Did you mean 'name'?
Error 13:5: 'name' is a required field but was not found.
Error 13:5: 'description' is a required field but was not found.
Error 13:5: 'resourceType' is a required field but was not found.
Warning 14:5: Unknown field 'desription'. Did you mean 'description'?
Warning 15:5: Unknown field 'resourcetype'. Did you mean 'resourceType'?
Warning 16:5: Unknown field 'Scraping'. Did you mean 'scraping'?
Warning 22:5: Unknown field 'resource'. Did you mean 'resources'?
[17:47:06 WRN] Validation step 3/6 failed. Error(s): Errors were found while deserializing the metric configuration.
```