### PR TITLE
Report validation error if resources not specified

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefinitionDeserializer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Linq;
+using Microsoft.Extensions.Logging;
 using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
 using YamlDotNet.RepresentationModel;
@@ -76,6 +77,12 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 {
                     errorReporter.ReportError(resourceTypeNode, $"Could not find a deserializer for resource type '{metricDefinition.ResourceType}'.");
                 }
+            }
+
+            if ((metricDefinition.Resources == null || !metricDefinition.Resources.Any()) &&
+                (metricDefinition.ResourceCollections == null || !metricDefinition.ResourceCollections.Any()))
+            {
+                errorReporter.ReportError(node, "Either 'resources' or 'resourceCollections' must be specified.");
             }
         }
     }


### PR DESCRIPTION
I've updated the MetricDefinitionDeserializer to report a validation error if neither `resources` nor `resourceCollections` is populated.

Fixes #806

A metric definition like the following:

```yaml
- name: azure_lb_data_path_availability
  description: "The CPU of our containers in a container group."
  resourceType: Generic
  azureMetricConfiguration:
    metricName: VipAvailability
    aggregation:
      type: Average
```

Will now produce the following validation error:

```text
[15:56:21 ERR] The following problems were found with the metric configuration:
Error 13:5: Either 'resources' or 'resourceCollections' must be specified.
```