### PR TITLE
Exit gracefully if a validation error occurs

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -10,3 +10,4 @@ version:
 - {{% tag removed %}} Support for Swagger UI 2.0 ([deprecation notice](https://changelog.promitor.io/#swagger-ui-2-0))
 - {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. [#1105](https://github.com/tomkerkhove/promitor/issues/1105).
 - {{% tag added %}} Add validation to ensure the scraping schedule is a valid Cron expression. [#1103](https://github.com/tomkerkhove/promitor/issues/1103).
+- Handle validation failures on startup more gracefully. [#1113](https://github.com/tomkerkhove/promitor/issues/1113).

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -56,6 +56,11 @@
             Validation failed, so Promitor can't start.
             </summary>
         </member>
+        <member name="F:Promitor.Agents.Scraper.ExitStatus.ConfigurationFolderNotSpecified">
+            <summary>
+            The configuration folder environment variable has not been set.
+            </summary>
+        </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.IApplicationBuilderExtensions.UseMetricSinks(Microsoft.AspNetCore.Builder.IApplicationBuilder,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>
                 Adds the required metric sinks
@@ -99,6 +104,15 @@
         </member>
         <member name="M:Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes.SqlManagedInstanceMetricValidator.Validate(Promitor.Core.Scraping.Configuration.Model.Metrics.MetricDefinition)">
             <inheritdoc />
+        </member>
+        <member name="M:Promitor.Agents.Scraper.Validation.RuntimeValidator.Validate">
+            <summary>
+            Checks whether Promitor's configuration is valid so that the application
+            can start running successfully.
+            </summary>
+            <returns>
+            true if the configuration is valid, false otherwise.
+            </returns>
         </member>
         <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.DefineDependencies(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -35,6 +35,27 @@
             </summary>
             <remarks>Provides an indication about the health of the scraper</remarks>
         </member>
+        <member name="T:Promitor.Agents.Scraper.ExitStatus">
+            <summary>
+            The different statuses that the agent scraper can exit with.
+            </summary>
+        </member>
+        <member name="F:Promitor.Agents.Scraper.ExitStatus.Success">
+            <summary>
+            The application has run successfully.
+            </summary>
+        </member>
+        <member name="F:Promitor.Agents.Scraper.ExitStatus.UnhandledException">
+            <summary>
+            An unhandled exception was thrown during host startup. This probably
+            indicates a bug in Promitor that should be reported.
+            </summary>
+        </member>
+        <member name="F:Promitor.Agents.Scraper.ExitStatus.ValidationFailed">
+            <summary>
+            Validation failed, so Promitor can't start.
+            </summary>
+        </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.IApplicationBuilderExtensions.UseMetricSinks(Microsoft.AspNetCore.Builder.IApplicationBuilder,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>
                 Adds the required metric sinks

--- a/src/Promitor.Agents.Scraper/ExitStatus.cs
+++ b/src/Promitor.Agents.Scraper/ExitStatus.cs
@@ -1,0 +1,24 @@
+namespace Promitor.Agents.Scraper
+{
+    /// <summary>
+    /// The different statuses that the agent scraper can exit with.
+    /// </summary>
+    public enum ExitStatus
+    {
+        /// <summary>
+        /// The application has run successfully.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// An unhandled exception was thrown during host startup. This probably
+        /// indicates a bug in Promitor that should be reported.
+        /// </summary>
+        UnhandledException = 1,
+
+        /// <summary>
+        /// Validation failed, so Promitor can't start.
+        /// </summary>
+        ValidationFailed = 2
+    }
+}

--- a/src/Promitor.Agents.Scraper/ExitStatus.cs
+++ b/src/Promitor.Agents.Scraper/ExitStatus.cs
@@ -19,6 +19,11 @@ namespace Promitor.Agents.Scraper
         /// <summary>
         /// Validation failed, so Promitor can't start.
         /// </summary>
-        ValidationFailed = 2
+        ValidationFailed = 2,
+
+        /// <summary>
+        /// The configuration folder environment variable has not been set.
+        /// </summary>
+        ConfigurationFolderNotSpecified = 3
     }
 }

--- a/src/Promitor.Agents.Scraper/Program.cs
+++ b/src/Promitor.Agents.Scraper/Program.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Promitor.Agents.Core;
 using Promitor.Agents.Core.Configuration.Server;
+using Promitor.Agents.Scraper.Validation;
 using Promitor.Core;
 using Serilog;
 
@@ -20,16 +22,26 @@ namespace Promitor.Agents.Scraper
                 // Let's hook in a logger for start-up purposes.
                 ConfigureStartupLogging();
 
-                CreateHostBuilder(args)
-                    .Build()
-                    .Run();
+                var host = CreateHostBuilder(args)
+                    .Build();
+                
+                using (var scope = host.Services.CreateScope())
+                {
+                    var validator = scope.ServiceProvider.GetRequiredService<RuntimeValidator>();
+                    if (!validator.Run())
+                    {
+                        return (int)ExitStatus.ValidationFailed;
+                    }
+                }
 
-                return 0;
+                host.Run();
+
+                return (int)ExitStatus.Success;
             }
             catch (Exception exception)
             {
                 Log.Fatal(exception, "Host terminated unexpectedly");
-                return 1;
+                return (int)ExitStatus.UnhandledException;
             }
             finally
             {

--- a/src/Promitor.Agents.Scraper/Program.cs
+++ b/src/Promitor.Agents.Scraper/Program.cs
@@ -3,7 +3,6 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Promitor.Agents.Core;
 using Promitor.Agents.Core.Configuration.Server;
 using Promitor.Agents.Scraper.Validation;

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -12,7 +12,6 @@ using Promitor.Agents.Scraper.Configuration;
 using Promitor.Agents.Scraper.Configuration.Sinks;
 using Promitor.Agents.Scraper.Extensions;
 using Promitor.Agents.Scraper.Health;
-using Promitor.Agents.Scraper.Validation;
 using Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping;
 using Promitor.Integrations.AzureMonitor.Logging;
 using Serilog;
@@ -55,8 +54,6 @@ namespace Promitor.Agents.Scraper
                 healthCheckBuilder.AddCheck<ResourceDiscoveryHealthCheck>("Promitor Resource Discovery", HealthStatus.Degraded);
             }
 
-            ValidateRuntimeConfiguration(services);
-
             services.UseMetricSinks(Configuration)
                 .ScheduleMetricScraping();
         }
@@ -78,13 +75,6 @@ namespace Promitor.Agents.Scraper
                 .ExposeOpenApiUi()
                 .UseEndpoints(endpoints => endpoints.MapControllers());
             UseSerilog(ComponentName, app.ApplicationServices);
-        }
-
-        private void ValidateRuntimeConfiguration(IServiceCollection services)
-        {
-            var serviceProvider = services.BuildServiceProvider();
-            var runtimeValidator = serviceProvider.GetService<RuntimeValidator>();
-            runtimeValidator.Run();
         }
 
         protected override LoggerConfiguration FilterTelemetry(LoggerConfiguration loggerConfiguration)

--- a/src/Promitor.Agents.Scraper/Validation/RuntimeValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/RuntimeValidator.cs
@@ -38,27 +38,20 @@ namespace Promitor.Agents.Scraper.Validation
             };
         }
 
-        public bool Run()
+        /// <summary>
+        /// Checks whether Promitor's configuration is valid so that the application
+        /// can start running successfully.
+        /// </summary>
+        /// <returns>
+        /// true if the configuration is valid, false otherwise.
+        /// </returns>
+        public bool Validate()
         {
             _validationLogger.LogInformation("Starting validation of Promitor setup");
 
             var validationResults = RunValidationSteps();
-            return ProcessValidationResults(validationResults);
-        }
 
-        private bool ProcessValidationResults(List<ValidationResult> validationResults)
-        {
-            var failedValidationResults = validationResults.Where(result => result.IsSuccessful == false).ToList();
-
-            var validationFailed = failedValidationResults.Any();
-            if (validationFailed)
-            {
-                _validationLogger.LogCritical("Promitor is not configured correctly. Please fix validation issues and re-run.");
-                return false;
-            }
-
-            _validationLogger.LogInformation("Promitor configuration is valid, we are good to go.");
-            return true;
+            return validationResults.All(result => result.IsSuccessful);
         }
 
         private List<ValidationResult> RunValidationSteps()

--- a/src/Promitor.Agents.Scraper/Validation/RuntimeValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/RuntimeValidator.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Promitor.Agents.Scraper.Configuration;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
-using Promitor.Agents.Scraper.Validation.Exceptions;
 using Promitor.Agents.Scraper.Validation.Interfaces;
 using Promitor.Agents.Scraper.Validation.Steps;
 using Promitor.Agents.Scraper.Validation.Steps.Sinks;
@@ -39,15 +38,15 @@ namespace Promitor.Agents.Scraper.Validation
             };
         }
 
-        public void Run()
+        public bool Run()
         {
             _validationLogger.LogInformation("Starting validation of Promitor setup");
 
             var validationResults = RunValidationSteps();
-            ProcessValidationResults(validationResults);
+            return ProcessValidationResults(validationResults);
         }
 
-        private void ProcessValidationResults(List<ValidationResult> validationResults)
+        private bool ProcessValidationResults(List<ValidationResult> validationResults)
         {
             var failedValidationResults = validationResults.Where(result => result.IsSuccessful == false).ToList();
 
@@ -55,10 +54,11 @@ namespace Promitor.Agents.Scraper.Validation
             if (validationFailed)
             {
                 _validationLogger.LogCritical("Promitor is not configured correctly. Please fix validation issues and re-run.");
-                throw new ValidationFailedException(failedValidationResults);
+                return false;
             }
 
             _validationLogger.LogInformation("Promitor configuration is valid, we are good to go.");
+            return true;
         }
 
         private List<ValidationResult> RunValidationSteps()


### PR DESCRIPTION
I've tweaked the way that the startup process for Promitor works so that it runs the validation in the `Main()` method. This gives us the opportunity to exit gracefully if validation fails instead of throwing an exception.

I've also added a new enum to track the possible exit statuses, and made sure that unhandled exceptions continue to use an exit code of `1`.

Fixes #1113

Here's what the output looks like with a validation error now:

```shell
[14:35:42 INF] Metrics declaration is using spec version v1
[14:35:42 INF] Starting validation of Promitor setup
[14:35:42 INF] Start Validation step 1/6: Metrics Declaration Path
[14:35:42 INF] Scrape configuration found at '/home/adam/github.com/adamconnelly/promitor/config/promitor/scraper/metrics.yaml'
[14:35:42 INF] Validation step 1/6 succeeded
[14:35:42 INF] Start Validation step 2/6: Azure Authentication
[14:35:42 INF] Validation step 2/6 succeeded
[14:35:42 INF] Start Validation step 3/6: Metrics Declaration
[14:35:42 INF] Metrics declaration is using spec version v1
[14:35:42 ERR] The following problems were found with the metric configuration:
Error 1:1: 'metrics' is a required field but was not found.
Warning 12:1: Unknown field 'metric'. Did you mean 'metrics'?
[14:35:42 WRN] Validation step 3/6 failed. Error(s): Errors were found while deserializing the metric configuration.
[14:35:42 INF] Start Validation step 4/6: Resource Discovery
[14:35:42 INF] Validation step 4/6 succeeded
[14:35:42 INF] Start Validation step 5/6: StatsD Metric Sink
[14:35:42 INF] Validation step 5/6 succeeded
[14:35:42 INF] Start Validation step 6/6: Prometheus Scraping Endpoint Metric Sink
[14:35:42 INF] Validation step 6/6 succeeded
[14:35:42 FTL] Promitor is not configured correctly. Please fix validation issues and re-run.
```