### PR TITLE
Update discovery agent startup to match scraper

### DIFF
--- a/src/Promitor.Agents.Core/ExitStatus.cs
+++ b/src/Promitor.Agents.Core/ExitStatus.cs
@@ -1,4 +1,4 @@
-namespace Promitor.Agents.Scraper
+namespace Promitor.Agents.Core
 {
     /// <summary>
     /// The different statuses that the agent scraper can exit with.
@@ -24,6 +24,11 @@ namespace Promitor.Agents.Scraper
         /// <summary>
         /// The configuration folder environment variable has not been set.
         /// </summary>
-        ConfigurationFolderNotSpecified = 3
+        ConfigurationFolderNotSpecified = 3,
+
+        /// <summary>
+        /// A required configuration file was not found.
+        /// </summary>
+        ConfigurationFileNotFound = 4
     }
 }

--- a/src/Promitor.Agents.Core/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using Microsoft.Extensions.Configuration;
+
+namespace Promitor.Agents.Core.Extensions
+{
+    /// <summary>
+    /// Extensions for <see cref="IConfigurationBuilder" />.
+    /// </summary>
+    public static class ConfigurationBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a required yaml file to the builder.
+        /// </summary>
+        /// <param name="builder">The configuration builder.</param>
+        /// <param name="path">The full absolute path to the file.</param>
+        /// <param name="reloadOnChange">
+        /// Indicates whether the file will be reloaded if the contents change.
+        /// </param>
+        /// <exception cref="ConfigurationFileNotFoundException">
+        /// Thrown if the specified configuration file was not found.
+        /// </exception>
+        public static IConfigurationBuilder AddRequiredYamlFile(
+            this IConfigurationBuilder builder, string path, bool reloadOnChange)
+        {
+            if (!File.Exists(path))
+            {
+                throw new ConfigurationFileNotFoundException(path);
+            }
+
+            builder.AddYamlFile(path, optional: false, reloadOnChange: reloadOnChange);
+
+            return builder;
+        }
+    }
+}

--- a/src/Promitor.Agents.Core/Extensions/ConfigurationFileNotFoundException.cs
+++ b/src/Promitor.Agents.Core/Extensions/ConfigurationFileNotFoundException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Promitor.Agents.Core.Extensions
+{
+    /// <summary>
+    /// Thrown if a required configuration file was not found.
+    /// </summary>
+    public class ConfigurationFileNotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationFileNotFoundException" /> class.
+        /// </summary>
+        /// <param name="path">The full path to the file that was not found.</param>
+        public ConfigurationFileNotFoundException(string path)
+            : base($"A required configuration file was not found at '{path}'")
+        {
+            this.Path = path;
+        }
+
+        /// <summary>
+        /// Gets the full path to the file that was not found.
+        /// </summary>
+        public string Path { get; }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -35,32 +35,6 @@
             </summary>
             <remarks>Provides an indication about the health of the scraper</remarks>
         </member>
-        <member name="T:Promitor.Agents.Scraper.ExitStatus">
-            <summary>
-            The different statuses that the agent scraper can exit with.
-            </summary>
-        </member>
-        <member name="F:Promitor.Agents.Scraper.ExitStatus.Success">
-            <summary>
-            The application has run successfully.
-            </summary>
-        </member>
-        <member name="F:Promitor.Agents.Scraper.ExitStatus.UnhandledException">
-            <summary>
-            An unhandled exception was thrown during host startup. This probably
-            indicates a bug in Promitor that should be reported.
-            </summary>
-        </member>
-        <member name="F:Promitor.Agents.Scraper.ExitStatus.ValidationFailed">
-            <summary>
-            Validation failed, so Promitor can't start.
-            </summary>
-        </member>
-        <member name="F:Promitor.Agents.Scraper.ExitStatus.ConfigurationFolderNotSpecified">
-            <summary>
-            The configuration folder environment variable has not been set.
-            </summary>
-        </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.IApplicationBuilderExtensions.UseMetricSinks(Microsoft.AspNetCore.Builder.IApplicationBuilder,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>
                 Adds the required metric sinks

--- a/src/Promitor.Tests.Unit/Agents/Core/Extensions/ConfigurationBuilder/AddRequiredYamlFileTests.cs
+++ b/src/Promitor.Tests.Unit/Agents/Core/Extensions/ConfigurationBuilder/AddRequiredYamlFileTests.cs
@@ -1,0 +1,69 @@
+namespace Promitor.Tests.Unit.Agents.Core.Extensions.ConfigurationBuilder
+{
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Configuration;
+    using System.IO;
+
+    using Xunit;
+    using System;
+    using NetEscapades.Configuration.Yaml;
+    using Promitor.Agents.Core.Extensions;
+
+    public class AddRequiredYamlFileTests : IDisposable
+    {
+        private readonly List<string> _tempFiles = new List<string>();
+
+        [Fact]
+        public void AddRequiredYamlFile_FileExists_AddsFile()
+        {
+            // Arrange
+            var yamlFile = CreateYamlFile();
+            var builder = new ConfigurationBuilder();
+            builder.AddRequiredYamlFile(yamlFile.FullName, true);
+
+            // Act
+            var source = Assert.IsType<YamlConfigurationSource>(builder.Sources[0]);
+
+            // Assert
+            Assert.Equal(yamlFile.Name, source.Path);
+        }
+
+        [Fact]
+        public void AddRequiredYamlFile_FileDoesNotExist_ThrowsException()
+        {
+            // Arrange
+            const string configurationFilename = "/opt/promitor/runtime.yaml";
+            var builder = new ConfigurationBuilder();
+
+            // Act
+            var exception = Assert.Throws<ConfigurationFileNotFoundException>(
+                () => builder.AddRequiredYamlFile(configurationFilename, true));
+
+            // Assert
+            Assert.Equal(configurationFilename, exception.Path);
+        }
+
+        public void Dispose()
+        {
+            foreach (var file in _tempFiles)
+            {
+                File.Delete(file);
+            }
+
+            _tempFiles.Clear();
+        }
+
+        private FileInfo CreateYamlFile()
+        {
+            var yamlFile = Path.GetTempFileName();
+            using (var writer = new StreamWriter(yamlFile))
+            {
+                writer.WriteLine("name: promitor");
+            }
+
+            _tempFiles.Add(yamlFile);
+
+            return new FileInfo(yamlFile);
+        }
+  }
+}


### PR DESCRIPTION
- Moved `ExitStatus` into the agents core and updated the discovery agent to use it.
- Updated the unhandled exception message for the discovery agent to match the format of the scraper agent.
- Added some additional validation to both agents to check that their required config files exist. This is to avoid us ending up in the unhandled exception block and directing users to create an issue.

Fixes #1113