### PR TITLE
Resource discovery is not configured, but still blocked by scraper validation

### DIFF
--- a/src/Promitor.Agents.Scraper/Validation/Steps/ResourceDiscoveryValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/ResourceDiscoveryValidationStep.cs
@@ -26,9 +26,9 @@ namespace Promitor.Agents.Scraper.Validation.Steps
 
         public ValidationResult Run()
         {
-            var doesDeclareResourceDiscoveryGroups = DetermineIfDiscoveryGroupsAreDefined();
-            if (_resourceDiscoveryConfiguration == null)
+            if (_resourceDiscoveryConfiguration?.Value == null || _resourceDiscoveryConfiguration.Value.IsConfigured == false)
             {
+                var doesDeclareResourceDiscoveryGroups = DetermineIfDiscoveryGroupsAreDefined();
                 if (doesDeclareResourceDiscoveryGroups)
                 {
                     return ValidationResult.Failure(ComponentName, new List<string> { NoDiscoveryConfiguredError });
@@ -38,11 +38,6 @@ namespace Promitor.Agents.Scraper.Validation.Steps
             }
 
             var errorMessages = new List<string>();
-            if (string.IsNullOrWhiteSpace(_resourceDiscoveryConfiguration.Value.Host))
-            {
-                errorMessages.Add( "No host name for resource discovery was configured");
-            }
-
             if (_resourceDiscoveryConfiguration.Value.Port <= 0)
             {
                 errorMessages.Add($"No valid port ({_resourceDiscoveryConfiguration.Value.Port}) for resource discovery was configured");

--- a/src/Promitor.Agents.Scraper/Validation/Steps/ResourceDiscoveryValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/ResourceDiscoveryValidationStep.cs
@@ -38,6 +38,11 @@ namespace Promitor.Agents.Scraper.Validation.Steps
             }
 
             var errorMessages = new List<string>();
+            if (string.IsNullOrWhiteSpace(_resourceDiscoveryConfiguration.Value.Host))
+            {
+                errorMessages.Add("No host name for resource discovery was configured");
+            }
+            
             if (_resourceDiscoveryConfiguration.Value.Port <= 0)
             {
                 errorMessages.Add($"No valid port ({_resourceDiscoveryConfiguration.Value.Port}) for resource discovery was configured");

--- a/src/Promitor.Tests.Unit/Validation/Misc/ResourceDiscoveryValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Misc/ResourceDiscoveryValidationStepTests.cs
@@ -39,7 +39,7 @@ namespace Promitor.Tests.Unit.Validation.Misc
         }
 
         [Fact]
-        public void Validate_ResourceDiscoveryIsNotConfigured_Success()
+        public void Validate_ResourceDiscoveryConfigurationIsNotConfigured_Success()
         {
             // Arrange
             var metricsDeclarationProvider = GetMetricDeclarationProvider();
@@ -55,7 +55,24 @@ namespace Promitor.Tests.Unit.Validation.Misc
         }
 
         [Fact]
-        public void Validate_ResourceDiscoveryIsNotConfiguredButMetricWithDiscoveryIsDefined_Fails()
+        public void Validate_ResourceDiscoveryHostIsNotConfigured_Success()
+        {
+            // Arrange
+            var metricsDeclarationProvider = GetMetricDeclarationProvider();
+            var resourceDiscoveryConfiguration = CreateRuntimeConfiguration();
+            resourceDiscoveryConfiguration.Value.Host = string.Empty;
+
+            // Act
+            // ReSharper disable once ExpressionIsAlwaysNull
+            var azureAuthenticationValidationStep = new ResourceDiscoveryValidationStep(resourceDiscoveryConfiguration, metricsDeclarationProvider, NullLogger<ResourceDiscoveryValidationStep>.Instance);
+            var validationResult = azureAuthenticationValidationStep.Run();
+
+            // Assert
+            Assert.True(validationResult.IsSuccessful);
+        }
+
+        [Fact]
+        public void Validate_ResourceDiscoveryConfigurationIsNotConfiguredButMetricWithDiscoveryIsDefined_Fails()
         {
             // Arrange
             var metricsDeclarationProvider = GetMetricDeclarationProvider(useDiscoveryGroup: true);
@@ -71,7 +88,24 @@ namespace Promitor.Tests.Unit.Validation.Misc
         }
 
         [Fact]
-        public void Validate_StatsDWithNegativePort_Fails()
+        public void Validate_NoResourceDiscoveryHostIsNotConfiguredButMetricWithDiscoveryIsDefined_Fails()
+        {
+            // Arrange
+            var metricsDeclarationProvider = GetMetricDeclarationProvider(useDiscoveryGroup: true);
+            var resourceDiscoveryConfiguration = CreateRuntimeConfiguration();
+            resourceDiscoveryConfiguration.Value.Host = string.Empty;
+
+            // Act
+            // ReSharper disable once ExpressionIsAlwaysNull
+            var azureAuthenticationValidationStep = new ResourceDiscoveryValidationStep(resourceDiscoveryConfiguration, metricsDeclarationProvider, NullLogger<ResourceDiscoveryValidationStep>.Instance);
+            var validationResult = azureAuthenticationValidationStep.Run();
+
+            // Assert
+            Assert.False(validationResult.IsSuccessful);
+        }
+
+        [Fact]
+        public void Validate_PortIsNegative_Fails()
         {
             // Arrange
             var metricsDeclarationProvider = GetMetricDeclarationProvider();
@@ -87,7 +121,7 @@ namespace Promitor.Tests.Unit.Validation.Misc
         }
 
         [Fact]
-        public void Validate_StatsDWithPortZero_Fails()
+        public void Validate_PortIsZero_Fails()
         {
             // Arrange
             var metricsDeclarationProvider = GetMetricDeclarationProvider();
@@ -106,7 +140,7 @@ namespace Promitor.Tests.Unit.Validation.Misc
         [InlineData("")]
         [InlineData(" ")]
         [InlineData(null)]
-        public void Validate_NoHostIsConfigured_Fails(string host)
+        public void Validate_NoHostIsConfigured_Succeeds(string host)
         {
             // Arrange
             var metricsDeclarationProvider = GetMetricDeclarationProvider();
@@ -118,7 +152,7 @@ namespace Promitor.Tests.Unit.Validation.Misc
             var validationResult = azureAuthenticationValidationStep.Run();
 
             // Assert
-            Assert.False(validationResult.IsSuccessful);
+            Assert.True(validationResult.IsSuccessful);
         }
 
         private IOptions<ResourceDiscoveryConfiguration> CreateRuntimeConfiguration()


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Resource discovery is not configured, but still blocked by scraper validation.

Fixes #1196
