### PR TITLE
Provide capability to scrape all queues in Azure Service Bus

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,8 @@ version:
 - {{% tag added %}} Support for resource discovery ([docs](https://promitor.io/configuration/v2.x/resource-discovery) |
  [configuration](https://promitor.io/configuration/v2.x/resource-discovery) |
  [deployment](https://promitor.io/deployment/resource-discovery/deployment))
+- {{% tag added %}} Support for scraping Azure Event Hubs ([docs](https://promitor.io/configuration/v2.x/metrics/event-hubs)
+ | [#372](https://github.com/tomkerkhove/promitor/issues/69))
 - {{% tag added %}} Support for scraping Azure Logic Apps ([docs](https://promitor.io/configuration/v2.x/metrics/logic-apps)
  | [#372](https://github.com/tomkerkhove/promitor/issues/314))
 - {{% tag added %}} New validation rule to ensure at least one resource or resource collection is configured to scrape
@@ -18,6 +20,8 @@ version:
 - {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. [#1105](https://github.com/tomkerkhove/promitor/issues/1105).
 - {{% tag added %}} New validation rule to ensure the scraping schedule is a valid Cron expression. [#1103](https://github.com/tomkerkhove/promitor/issues/1103).
 - {{% tag added %}} New validation rule to ensure declarative or dynamic discovery for metrics to scrape are configured
+- {{% tag changed %}} Provide capability to scrape all queues in Azure Service Bus, instead of having to declare the
+ queue name. [#529](https://github.com/tomkerkhove/promitor/issues/529).
 - {{% tag changed %}} Handle validation failures on startup more gracefully. [#1113](https://github.com/tomkerkhove/promitor/issues/1113).
 - {{% tag changed %}} Improve time series handling to ensure finalized time series are reported
 - {{% tag removed %}} Support for Prometheus legacy configuration ([deprecation notice](https://changelog.promitor.io/#prometheus-legacy-configuration)

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -8,10 +8,6 @@ azureLandscape:
 resourceDiscoveryGroups:
 - name: service-bus-landscape
   type: ServiceBusQueue
-  criteria:
-    include:
-      subscriptions:
-      - 0329dd2a-59dc-4493-aa54-cb01cb027dc2
 - name: api-gateways
   type: ApiManagement
 - name: app-plan-landscape

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -119,3 +119,12 @@ metrics:
         type: Total
     resourceDiscoveryGroups:
     - name: event-hubs-landscape
+  - name: promitor_demo_servicebus_messagecount_discovered
+    description: "Average percentage of memory usage on an Azure App Plan"
+    resourceType: ServiceBusQueue
+    azureMetricConfiguration:
+      metricName: ActiveMessages
+      aggregation:
+        type: Total
+    resourceDiscoveryGroups:
+    - name: service-bus-landscape

--- a/docs/configuration/v2.x/metrics/event-hubs.md
+++ b/docs/configuration/v2.x/metrics/event-hubs.md
@@ -21,7 +21,7 @@ The following scraper-specific metric label will be added:
 
 - `entity_name` - Name of the topic
 
-> :warning: **As of today, `EntityPath` is not supported.**
+> :warning: **As of today, `EntityPath` as a dimension is not supported.**
 
 Example:
 

--- a/docs/configuration/v2.x/metrics/service-bus-queue.md
+++ b/docs/configuration/v2.x/metrics/service-bus-queue.md
@@ -5,7 +5,7 @@ title: Azure Service Bus Queue Declaration
 
 ## Azure Service Bus Queue
 
-![Availability Badge](https://img.shields.io/badge/Available%20Starting-v0.1-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-No-red.svg)
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v0.1-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
 
 You can declare to scrape an Azure Service Bus Queue via the `ServiceBusQueue`
 resource type.
@@ -13,7 +13,7 @@ resource type.
 The following fields need to be provided:
 
 - `namespace` - The name of the Service Bus namespace
-- `queueName` - The name of the queue
+- `queueName` - The name of the queue (optional)
 
 All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftservicebusnamespaces).
 
@@ -21,9 +21,7 @@ The following scraper-specific metric label will be added:
 
 - `entity_name` - Name of the queue
 
-Notes:
-
-- We currently do not support `EntityPath` as a dimension due to internal limitations.
+> :warning: **As of today, `EntityPath` as a dimension is not supported.**
 
 Example:
 

--- a/docs/configuration/v2.x/resource-discovery.md
+++ b/docs/configuration/v2.x/resource-discovery.md
@@ -101,7 +101,7 @@ Dynamic resource discovery is supported for the following scrapers:
 - [Azure Key Vault](metrics/key-vault)
 - [Azure Logic Apps](metrics/logic-apps)
 - [Azure Network Interface](metrics/network-interface)
-- [Azure Network Interface](metrics/service-bus-queue)
+- [Azure Service Bus Queue](metrics/service-bus-queue)
 - [Azure SQL Database](metrics/sql-database)
 - [Azure SQL Managed Instance](metrics/sql-managed-instance)
 - [Azure Storage (Account)](metrics/storage-account)

--- a/docs/configuration/v2.x/resource-discovery.md
+++ b/docs/configuration/v2.x/resource-discovery.md
@@ -101,6 +101,7 @@ Dynamic resource discovery is supported for the following scrapers:
 - [Azure Key Vault](metrics/key-vault)
 - [Azure Logic Apps](metrics/logic-apps)
 - [Azure Network Interface](metrics/network-interface)
+- [Azure Network Interface](metrics/service-bus-queue)
 - [Azure SQL Database](metrics/sql-database)
 - [Azure SQL Managed Instance](metrics/sql-managed-instance)
 - [Azure Storage (Account)](metrics/storage-account)

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -38,6 +38,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new RedisCacheDiscoveryQuery();
                 case ResourceType.PostgreSql:
                     return new PostgreSqlDiscoveryQuery();
+                case ResourceType.ServiceBusQueue:
+                    return new ServiceBusQueueDiscoveryQuery();
                 case ResourceType.SqlDatabase:
                     return new SqlDatabaseDiscoveryQuery();
                 case ResourceType.SqlManagedInstance:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ServiceBusQueueDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ServiceBusQueueDiscoveryQuery.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using GuardNet;
+﻿using GuardNet;
 using Newtonsoft.Json.Linq;
 using Promitor.Core.Contracts;
 using Promitor.Core.Contracts.ResourceTypes;

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ServiceBusQueueDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ServiceBusQueueDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class ServiceBusQueueDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.servicebus/namespaces" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var resource = new ServiceBusQueueResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), resultRowEntry[3]?.ToString(), string.Empty);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ServiceBusQueueMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ServiceBusQueueMetricValidator.cs
@@ -31,11 +31,6 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
                 {
                     errorMessages.Add("No Service Bus Namespace is configured");
                 }
-
-                if (string.IsNullOrWhiteSpace(resourceDefinition.QueueName))
-                {
-                    errorMessages.Add("No queue name is configured");
-                }
             }
 
             return errorMessages;

--- a/src/Promitor.Core.Contracts/ResourceTypes/ServiceBusQueueResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/ServiceBusQueueResourceDefinition.cs
@@ -2,10 +2,10 @@
 {
     public class ServiceBusQueueResourceDefinition : AzureResourceDefinition
     {
-        public ServiceBusQueueResourceDefinition(string subscriptionId, string resourceGroupName, string serviceBusNamespace, string queueName)
-            : base(ResourceType.ServiceBusQueue, subscriptionId, resourceGroupName, serviceBusNamespace, $"{serviceBusNamespace}-{queueName}")
+        public ServiceBusQueueResourceDefinition(string subscriptionId, string resourceGroupName, string @namespace, string queueName)
+            : base(ResourceType.ServiceBusQueue, subscriptionId, resourceGroupName, @namespace, $"{@namespace}-{queueName}")
         {
-            Namespace = serviceBusNamespace;
+            Namespace = @namespace;
             QueueName = queueName;
         }
 

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -40,8 +40,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<NetworkInterfaceResourceV1, NetworkInterfaceResourceDefinition>();
             CreateMap<PostgreSqlResourceV1, PostgreSqlResourceDefinition>();
             CreateMap<RedisCacheResourceV1, RedisCacheResourceDefinition>();
-            CreateMap<ServiceBusQueueResourceV1, ServiceBusQueueResourceDefinition>()
-                .ForCtorParam("serviceBusNamespace", o => o.MapFrom(s => s.Namespace));
+            CreateMap<ServiceBusQueueResourceV1, ServiceBusQueueResourceDefinition>();
             CreateMap<SqlDatabaseResourceV1, SqlDatabaseResourceDefinition>();
             CreateMap<SqlManagedInstanceResourceV1, SqlManagedInstanceResourceDefinition>();
             CreateMap<SqlServerResourceV1, SqlServerResourceDefinition>();

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ServiceBusQueueDeserializer.cs
@@ -7,10 +7,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public ServiceBusQueueDeserializer(ILogger<ServiceBusQueueDeserializer> logger) : base(logger)
         {
-            Map(resource => resource.QueueName)
-                .IsRequired();
             Map(resource => resource.Namespace)
                 .IsRequired();
+            Map(resource => resource.QueueName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/AzureMessagingScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/AzureMessagingScraper.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Contracts;
+using Promitor.Core.Metrics;
+using Promitor.Core.Scraping.Configuration.Model;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    public abstract class AzureMessagingScraper<TResourceDefinition> : AzureMonitorScraper<TResourceDefinition> where TResourceDefinition : class, IAzureResourceDefinition
+    {
+        private const string EntityNameLabel = "entity_name";
+
+        protected AzureMessagingScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override List<MeasuredMetric> EnrichMeasuredMetrics(TResourceDefinition resourceDefinition, string dimensionName, List<MeasuredMetric> metricValues)
+        {
+            // Change Azure Monitor Dimension name to more representable value
+            foreach (var measuredMetric in metricValues.Where(metricValue => string.IsNullOrWhiteSpace(metricValue.DimensionName) == false))
+            {
+                measuredMetric.DimensionName = EntityNameLabel;
+            }
+
+            return metricValues;
+        }
+
+        protected override Dictionary<string, string> DetermineMetricLabels(TResourceDefinition resourceDefinition)
+        {
+            var metricLabels = base.DetermineMetricLabels(resourceDefinition);
+
+            if (IsEntityDeclared(resourceDefinition))
+            {
+                var entityName = GetEntityName(resourceDefinition);
+                metricLabels.Add(EntityNameLabel, entityName);
+            }
+
+            return metricLabels;
+        }
+
+        protected override string DetermineMetricDimension(TResourceDefinition resourceDefinition, MetricDimension dimension)
+        {
+            if (IsEntityDeclared(resourceDefinition))
+            {
+                return base.DetermineMetricDimension(resourceDefinition, dimension);
+            }
+
+            Logger.LogWarning("Using 'EntityName' dimension since no topic was configured.");
+
+            return "EntityName";
+        }
+
+        protected override string DetermineMetricFilter(TResourceDefinition resourceDefinition)
+        {
+            var entityName = "*";
+
+            if (IsEntityDeclared(resourceDefinition))
+            {
+                entityName = GetEntityName(resourceDefinition);
+            }
+
+            return $"EntityName eq '{entityName}'";
+        }
+
+        /// <summary>
+        ///     Determines if an entity is declared or only the namespace
+        /// </summary>
+        /// <param name="resourceDefinition">Definition concerning the Azure resource</param>
+        protected abstract bool IsEntityDeclared(TResourceDefinition resourceDefinition);
+
+        /// <summary>
+        ///     Determines the name of the entity in the namespace namespace
+        /// </summary>
+        /// <param name="resourceDefinition">Definition concerning the Azure resource</param>
+        protected abstract string GetEntityName(TResourceDefinition resourceDefinition);
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/EventHubsScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/EventHubsScraper.cs
@@ -1,17 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Extensions.Logging;
-using Promitor.Core.Contracts;
+﻿using Promitor.Core.Contracts;
 using Promitor.Core.Contracts.ResourceTypes;
-using Promitor.Core.Metrics;
-using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 
 namespace Promitor.Core.Scraping.ResourceTypes
 {
-    public class EventHubsScraper : AzureMonitorScraper<EventHubResourceDefinition>
+    public class EventHubsScraper : AzureMessagingScraper<EventHubResourceDefinition>
     {
-        private const string EntityNameLabel = "entity_name";
         private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.EventHub/namespaces/{2}";
 
         public EventHubsScraper(ScraperConfiguration scraperConfiguration)
@@ -24,56 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
             return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.Namespace);
         }
 
-        protected override List<MeasuredMetric> EnrichMeasuredMetrics(EventHubResourceDefinition resourceDefinition, string dimensionName, List<MeasuredMetric> metricValues)
-        {
-            // Change Azure Monitor Dimension name to more representable value
-            foreach (var measuredMetric in metricValues.Where(metricValue=> string.IsNullOrWhiteSpace(metricValue.DimensionName) == false))
-            {
-                measuredMetric.DimensionName = EntityNameLabel;
-            }
-
-            return metricValues;
-        }
-
-        protected override Dictionary<string, string> DetermineMetricLabels(EventHubResourceDefinition resourceDefinition)
-        {
-            var metricLabels = base.DetermineMetricLabels(resourceDefinition); 
-            
-            if (IsTopicDeclared(resourceDefinition))
-            {
-                metricLabels.Add(EntityNameLabel, resourceDefinition.TopicName);
-            }
-            
-            return metricLabels;
-        }
-
-        protected override string DetermineMetricDimension(EventHubResourceDefinition resourceDefinition, MetricDimension dimension)
-        {
-            if (IsTopicDeclared(resourceDefinition))
-            {
-                return base.DetermineMetricDimension(resourceDefinition, dimension);
-            }
-
-            Logger.LogWarning("Using 'EntityName' dimension since no topic was configured.");
-
-            return "EntityName";
-        }
-        
-        protected override string DetermineMetricFilter(EventHubResourceDefinition resourceDefinition)
-        {
-            var entityName = "*";
-
-            if(IsTopicDeclared(resourceDefinition))
-            {
-                entityName = resourceDefinition.TopicName;
-            }
-
-            return $"EntityName eq '{entityName}'";
-        }
-
-        private static bool IsTopicDeclared(EventHubResourceDefinition resourceDefinition)
+        protected override bool IsEntityDeclared(EventHubResourceDefinition resourceDefinition)
         {
             return string.IsNullOrWhiteSpace(resourceDefinition.TopicName) == false;
+        }
+
+        protected override string GetEntityName(EventHubResourceDefinition resourceDefinition)
+        {
+            return resourceDefinition.TopicName;
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
@@ -1,17 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Extensions.Logging;
-using Promitor.Core.Contracts;
+﻿using Promitor.Core.Contracts;
 using Promitor.Core.Contracts.ResourceTypes;
-using Promitor.Core.Metrics;
-using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 
 namespace Promitor.Core.Scraping.ResourceTypes
 {
-    public class ServiceBusQueueScraper : AzureMonitorScraper<ServiceBusQueueResourceDefinition>
+    public class ServiceBusQueueScraper : AzureMessagingScraper<ServiceBusQueueResourceDefinition>
     {
-        private const string EntityNameLabel = "entity_name";
         private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ServiceBus/namespaces/{2}";
 
         public ServiceBusQueueScraper(ScraperConfiguration scraperConfiguration)
@@ -24,56 +18,14 @@ namespace Promitor.Core.Scraping.ResourceTypes
             return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.Namespace);
         }
 
-        protected override List<MeasuredMetric> EnrichMeasuredMetrics(ServiceBusQueueResourceDefinition resourceDefinition, string dimensionName, List<MeasuredMetric> metricValues)
-        {
-            // Change Azure Monitor Dimension name to more representable value
-            foreach (var measuredMetric in metricValues.Where(metricValue => string.IsNullOrWhiteSpace(metricValue.DimensionName) == false))
-            {
-                measuredMetric.DimensionName = EntityNameLabel;
-            }
-
-            return metricValues;
-        }
-
-        protected override Dictionary<string, string> DetermineMetricLabels(ServiceBusQueueResourceDefinition resourceDefinition)
-        {
-            var metricLabels = base.DetermineMetricLabels(resourceDefinition);
-
-            if (IsQueueDeclared(resourceDefinition))
-            {
-                metricLabels.Add(EntityNameLabel, resourceDefinition.QueueName);
-            }
-
-            return metricLabels;
-        }
-
-        protected override string DetermineMetricDimension(ServiceBusQueueResourceDefinition resourceDefinition, MetricDimension dimension)
-        {
-            if (IsQueueDeclared(resourceDefinition))
-            {
-                return base.DetermineMetricDimension(resourceDefinition, dimension);
-            }
-
-            Logger.LogWarning("Using 'EntityName' dimension since no topic was configured.");
-
-            return "EntityName";
-        }
-
-        protected override string DetermineMetricFilter(ServiceBusQueueResourceDefinition resourceDefinition)
-        {
-            var entityName = "*";
-
-            if (IsQueueDeclared(resourceDefinition))
-            {
-                entityName = resourceDefinition.QueueName;
-            }
-
-            return $"EntityName eq '{entityName}'";
-        }
-
-        private static bool IsQueueDeclared(ServiceBusQueueResourceDefinition resourceDefinition)
+        protected override bool IsEntityDeclared(ServiceBusQueueResourceDefinition resourceDefinition)
         {
             return string.IsNullOrWhiteSpace(resourceDefinition.QueueName) == false;
+        }
+
+        protected override string GetEntityName(ServiceBusQueueResourceDefinition resourceDefinition)
+        {
+            return resourceDefinition.QueueName;
         }
     }
 }

--- a/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ServiceBusQueueScraper.cs
@@ -1,12 +1,17 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 using Promitor.Core.Contracts;
 using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Metrics;
+using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 
 namespace Promitor.Core.Scraping.ResourceTypes
 {
     public class ServiceBusQueueScraper : AzureMonitorScraper<ServiceBusQueueResourceDefinition>
     {
+        private const string EntityNameLabel = "entity_name";
         private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ServiceBus/namespaces/{2}";
 
         public ServiceBusQueueScraper(ScraperConfiguration scraperConfiguration)
@@ -19,18 +24,56 @@ namespace Promitor.Core.Scraping.ResourceTypes
             return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.Namespace);
         }
 
+        protected override List<MeasuredMetric> EnrichMeasuredMetrics(ServiceBusQueueResourceDefinition resourceDefinition, string dimensionName, List<MeasuredMetric> metricValues)
+        {
+            // Change Azure Monitor Dimension name to more representable value
+            foreach (var measuredMetric in metricValues.Where(metricValue => string.IsNullOrWhiteSpace(metricValue.DimensionName) == false))
+            {
+                measuredMetric.DimensionName = EntityNameLabel;
+            }
+
+            return metricValues;
+        }
+
         protected override Dictionary<string, string> DetermineMetricLabels(ServiceBusQueueResourceDefinition resourceDefinition)
         {
             var metricLabels = base.DetermineMetricLabels(resourceDefinition);
 
-            metricLabels.TryAdd("entity_name", resourceDefinition.QueueName);
+            if (IsQueueDeclared(resourceDefinition))
+            {
+                metricLabels.Add(EntityNameLabel, resourceDefinition.QueueName);
+            }
 
             return metricLabels;
         }
 
+        protected override string DetermineMetricDimension(ServiceBusQueueResourceDefinition resourceDefinition, MetricDimension dimension)
+        {
+            if (IsQueueDeclared(resourceDefinition))
+            {
+                return base.DetermineMetricDimension(resourceDefinition, dimension);
+            }
+
+            Logger.LogWarning("Using 'EntityName' dimension since no topic was configured.");
+
+            return "EntityName";
+        }
+
         protected override string DetermineMetricFilter(ServiceBusQueueResourceDefinition resourceDefinition)
         {
-            return $"EntityName eq '{resourceDefinition.QueueName}'";
+            var entityName = "*";
+
+            if (IsQueueDeclared(resourceDefinition))
+            {
+                entityName = resourceDefinition.QueueName;
+            }
+
+            return $"EntityName eq '{entityName}'";
+        }
+
+        private static bool IsQueueDeclared(ServiceBusQueueResourceDefinition resourceDefinition)
+        {
+            return string.IsNullOrWhiteSpace(resourceDefinition.QueueName) == false;
         }
     }
 }

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/ServiceBusQueueDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/ServiceBusQueueDeserializerTests.cs
@@ -37,13 +37,13 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
         }
 
         [Fact]
-        public void Deserialize_QueueNameNotSupplied_ReportsError()
+        public void Deserialize_QueueNameNotSupplied_ReportsNoError()
         {
             // Arrange
             var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
 
             // Act / Assert
-            YamlAssert.ReportsErrorForProperty(
+            YamlAssert.ReportsNoErrorForProperty(
                 _deserializer,
                 node,
                 "queueName");

--- a/src/Promitor.Tests.Unit/Validation/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
@@ -132,7 +132,7 @@ namespace Promitor.Tests.Unit.Validation.Metrics.ResourceTypes
         }
 
         [Fact]
-        public void ServiceBusQueuesMetricsDeclaration_DeclarationWithoutQueueName_Fails()
+        public void ServiceBusQueuesMetricsDeclaration_DeclarationWithoutQueueName_Succeeded()
         {
             // Arrange
             var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
@@ -145,7 +145,7 @@ namespace Promitor.Tests.Unit.Validation.Metrics.ResourceTypes
             var validationResult = scrapingScheduleValidationStep.Run();
 
             // Assert
-            Assert.False(validationResult.IsSuccessful, "Validation is successful");
+            Assert.True(validationResult.IsSuccessful, "Validation is successful");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Provide capability to scrape all queues in Azure Service Bus, instead of having to declare the queue name

Fixes #529
