### PR TITLE
Sanitize label names to comply with Prometheus requirements

### DIFF
--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -129,6 +129,7 @@ metrics:
     resourceDiscoveryGroups:
     - name: service-bus-landscape
   - name: promitor_demo_app_insights
+    description: "Average dependency duration per dependency type"
     resourceType: Generic
     azureMetricConfiguration:
       metricName: dependencies/duration

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -128,3 +128,14 @@ metrics:
         type: Total
     resourceDiscoveryGroups:
     - name: service-bus-landscape
+  - name: promitor_demo_app_insights
+    resourceType: Generic
+    azureMetricConfiguration:
+      metricName: dependencies/duration
+      dimension:
+        name: dependency/type
+      aggregation:
+        type: Average
+    resources:
+    - resourceUri: Microsoft.Insights/Components/docker-hub-metrics
+      resourceGroupName: docker-hub-metrics

--- a/src/Promitor.Integrations.Sinks.Prometheus/Extensions/StringExtensions.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Extensions/StringExtensions.cs
@@ -1,0 +1,21 @@
+﻿// ReSharper disable once CheckNamespace
+
+namespace System
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        ///     Ensures label key name is valid according to Prometheus requirements
+        /// </summary>
+        /// <param name="labelKey">Current label key value</param>
+        public static string SanitizeForPrometheusLabelKey(this string labelKey)
+        {
+            if (string.IsNullOrWhiteSpace(labelKey))
+            {
+                return labelKey;
+            }
+
+            return labelKey.Replace("/", "_").ToLower();
+        }
+    }
+}

--- a/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GuardNet;
@@ -85,18 +86,18 @@ namespace Promitor.Integrations.Sinks.Prometheus
 
         private Dictionary<string, string> DetermineLabels(PrometheusMetricDefinition metricDefinition, ScrapeResult scrapeResult, MeasuredMetric measuredMetric)
         {
-            var labels = new Dictionary<string, string>(scrapeResult.Labels.Select(label => new KeyValuePair<string, string>(label.Key.ToLower(), label.Value)));
+            var labels = new Dictionary<string, string>(scrapeResult.Labels.Select(label => new KeyValuePair<string, string>(label.Key.SanitizeForPrometheusLabelKey(), label.Value)));
 
             if (measuredMetric.IsDimensional)
             {
-                labels.Add(measuredMetric.DimensionName.ToLower(), measuredMetric.DimensionValue);
+                labels.Add(measuredMetric.DimensionName.SanitizeForPrometheusLabelKey(), measuredMetric.DimensionValue);
             }
 
             if (metricDefinition?.Labels?.Any() == true)
             {
                 foreach (var customLabel in metricDefinition.Labels)
                 {
-                    var customLabelKey = customLabel.Key.ToLower();
+                    var customLabelKey = customLabel.Key.SanitizeForPrometheusLabelKey();
                     if (labels.ContainsKey(customLabelKey))
                     {
                         _logger.LogWarning("Custom label {CustomLabelName} was already specified with value 'LabelValue' instead of 'CustomLabelValue'. Ignoring...", customLabel.Key, labels[customLabelKey], customLabel.Value);

--- a/src/Promitor.Tests.Unit/Prometheus/StringExtensionTests.cs
+++ b/src/Promitor.Tests.Unit/Prometheus/StringExtensionTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.ComponentModel;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Prometheus
+{
+    [Category("Unit")]
+    public class StringExtensionTests
+    {
+        [Fact]
+        public void SanitizeForPrometheusLabelKey_ValidKey_IdenticalOutput()
+        {
+            // Arrange
+            var labelKeyInput = "sample_label";
+
+            // Act
+            var sanitizedLabelKey = labelKeyInput.SanitizeForPrometheusLabelKey();
+
+            // Assert
+            Assert.Equal(labelKeyInput, sanitizedLabelKey);
+        }
+
+        [Fact]
+        public void SanitizeForPrometheusLabelKey_KeyIsUppercase_ConvertedToLowercase()
+        {
+            // Arrange
+            var labelKeyInput = "SAMPLE_LABEL";
+            var expectedLabelKey = "sample_label";
+
+            // Act
+            var sanitizedLabelKey = labelKeyInput.SanitizeForPrometheusLabelKey();
+
+            // Assert
+            Assert.Equal(expectedLabelKey, sanitizedLabelKey);
+        }
+
+        [Fact]
+        public void SanitizeForPrometheusLabelKey_KeyWithSlash_SlashIsReplaced()
+        {
+            // Arrange
+            var labelKeyInput = "sample/label";
+            var expectedLabelKey = "sample_label";
+
+            // Act
+            var sanitizedLabelKey = labelKeyInput.SanitizeForPrometheusLabelKey();
+
+            // Assert
+            Assert.Equal(expectedLabelKey, sanitizedLabelKey);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Config:
```yaml
metrics:
  - name: promitor_demo_app_insights
    resourceType: Generic
    azureMetricConfiguration:
      metricName: dependencies/duration
      dimension:
        name: dependency/type
      aggregation:
        type: Average
    resources:
    - resourceUri: Microsoft.Insights/Components/docker-hub-metrics
      resourceGroupName: docker-hub-metrics
```

Output:
```
# HELP promitor_demo_app_insights Average dependency duration per dependency type
# TYPE promitor_demo_app_insights gauge
promitor_demo_app_insights{resource_group="docker-hub-metrics",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/docker-hub-metrics/providers/Microsoft.Insights/Components/docker-hub-metrics",instance_name="Microsoft.Insights/Components/docker-hub-metrics",dependency_type="Http"} 500.5 1598877315829
```

Fixes #1248