### PR TITLE
Dimensions with / in name are now supported by replacing it with _ for Prometheus metric sink

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -13,20 +13,21 @@ version:
 - {{% tag added %}} Support for scraping Azure Logic Apps ([docs](https://promitor.io/configuration/v2.x/metrics/logic-apps)
  | [#314](https://github.com/tomkerkhove/promitor/issues/314))
 - {{% tag added %}} New validation rule to ensure at least one resource or resource collection is configured to scrape
-- {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. [#1105](https://github.com/tomkerkhove/promitor/issues/1105).
-- {{% tag added %}} Add validation to ensure the scraping schedule is a valid Cron expression. [#1103](https://github.com/tomkerkhove/promitor/issues/1103).
+- {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. ([#1105](https://github.com/tomkerkhove/promitor/issues/1105)).
+- {{% tag added %}} Add validation to ensure the scraping schedule is a valid Cron expression. ([#1103](https://github.com/tomkerkhove/promitor/issues/1103)).
 - {{% tag added %}} Provide support for pushing metrics to Atlassian Statuspage
  ([docs](https://promitor.io/configuration/v2.x/runtime#atlassian-statuspage) | [#1152](https://github.com/tomkerkhove/promitor/issues/1152))
-- {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. [#1105](https://github.com/tomkerkhove/promitor/issues/1105).
-- {{% tag added %}} New validation rule to ensure the scraping schedule is a valid Cron expression. [#1103](https://github.com/tomkerkhove/promitor/issues/1103).
+- {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. ([#1105](https://github.com/tomkerkhove/promitor/issues/1105)).
+- {{% tag added %}} New validation rule to ensure the scraping schedule is a valid Cron expression. ([#1103](https://github.com/tomkerkhove/promitor/issues/1103)).
 - {{% tag added %}} New validation rule to ensure declarative or dynamic discovery for metrics to scrape are configured
 - {{% tag added %}} New System API endpoint giving runtime information ([docs](https://promitor.io/operations/#system)
  | [#1208](https://github.com/tomkerkhove/promitor/issues/1208))
 - {{% tag changed %}} Provide capability to scrape all queues in Azure Service Bus, instead of having to declare the
- queue name. [#529](https://github.com/tomkerkhove/promitor/issues/529).
-- {{% tag changed %}} Handle validation failures on startup more gracefully. [#1113](https://github.com/tomkerkhove/promitor/issues/1113).
+ queue name. ([#529](https://github.com/tomkerkhove/promitor/issues/529)).
+- {{% tag changed %}} Handle validation failures on startup more gracefully. ([#1113](https://github.com/tomkerkhove/promitor/issues/1113)).
 - {{% tag changed %}} Improve time series handling to ensure finalized time series are reported
-- {{% tag fixed %}} Ensure Prometheus metric sink does write timestamps [#1217](https://github.com/tomkerkhove/promitor/issues/1217).
+- {{% tag fixed %}} Ensure Prometheus metric sink does write timestamps ([#1217](https://github.com/tomkerkhove/promitor/issues/1217)).
+- {{% tag fixed %}} Dimensions with `/` in name are now supported by replacing it with `_` for Prometheus metric sink ([#1248](https://github.com/tomkerkhove/promitor/issues/1248)).
 - {{% tag removed %}} Support for Prometheus legacy configuration ([deprecation notice](https://changelog.promitor.io/#prometheus-legacy-configuration)
  | [migration guide](https://promitor.io/walkthrough/migrate-from-1.x-to-2.x))
 - {{% tag removed %}} Support for Swagger UI 2.0 ([deprecation notice](https://changelog.promitor.io/#swagger-ui-2-0) |


### PR DESCRIPTION
Dimensions with / in name are now supported by replacing it with _ for Prometheus metric sink