### PR TITLE
Provide support for scraping Azure Application Gateway

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -13,6 +13,7 @@ version:
 - {{% tag added %}} Support for scraping Azure Logic Apps ([docs](https://promitor.io/configuration/v2.x/metrics/logic-apps)
  | [#314](https://github.com/tomkerkhove/promitor/issues/314)).
 - {{% tag added %}} Support for scraping Azure Express Route circuits ([docs](https://promitor.io/configuration/v2.x/metrics/express-route-circuit) | [#1251](https://github.com/tomkerkhove/promitor/issues/1251)).
+- {{% tag added %}} Support for scraping Azure Application Gateway ([docs](https://promitor.io/configuration/v2.x/metrics/application-gateway) | [#1251](https://github.com/tomkerkhove/promitor/issues/313)).
 - {{% tag added %}} New validation rule to ensure at least one resource or resource collection is configured to scrape
 - {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. ([#1105](https://github.com/tomkerkhove/promitor/issues/1105)).
 - {{% tag added %}} Add validation to ensure the scraping schedule is a valid Cron expression. ([#1103](https://github.com/tomkerkhove/promitor/issues/1103)).

--- a/docs/configuration/v2.x/metrics/application-gateway.md
+++ b/docs/configuration/v2.x/metrics/application-gateway.md
@@ -7,7 +7,7 @@ title: Azure Application Gateway Declaration
 
 ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.0-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
 
-You can declare to scrape an Azure Application Gateway via the `ExpressRouteCircuit` resource
+You can declare to scrape an Azure Application Gateway via the `ApplicationGateway` resource
 type.
 
 The following fields need to be provided:

--- a/docs/configuration/v2.x/metrics/application-gateway.md
+++ b/docs/configuration/v2.x/metrics/application-gateway.md
@@ -20,7 +20,7 @@ Example:
 
 ```yaml
 name: azure_application_gateway_milli_total_time
-description: "Average cilliseconds of total time on an Azure application gateway"
+description: "Average milliseconds of total time on an Azure application gateway"
 resourceType: ApplicationGateway
 azureMetricConfiguration:
   metricName: ApplicationGatewayTotalTime

--- a/docs/configuration/v2.x/metrics/application-gateway.md
+++ b/docs/configuration/v2.x/metrics/application-gateway.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Azure Application Gateway Declaration
+---
+
+## Azure Application Gateway
+
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.0-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
+
+You can declare to scrape an Azure Application Gateway via the `ExpressRouteCircuit` resource
+type.
+
+The following fields need to be provided:
+
+- `applicationGatewayName` - The name of the Azure Application Gateway
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkapplicationgateways).
+
+Example:
+
+```yaml
+name: azure_application_gateway_milli_total_time
+description: "Average cilliseconds of total time on an Azure application gateway"
+resourceType: ApplicationGateway
+azureMetricConfiguration:
+  metricName: ApplicationGatewayTotalTime
+  aggregation:
+    type: Average
+resources:
+- applicationGatewayName: promitor-application-gateway-1
+- applicationGatewayName: promitor-application-gateway-2
+resourceDiscoveryGroups:
+- name: application-gateway-group
+```
+
+<!-- markdownlint-disable MD033 -->
+[&larr; back to metrics declarations](/configuration/v2.x/metrics)<br />
+[&larr; back to introduction](/)
+<!-- markdownlint-enable -->

--- a/docs/configuration/v2.x/metrics/index.md
+++ b/docs/configuration/v2.x/metrics/index.md
@@ -121,7 +121,7 @@ service supported by Azure Monitor.
 We also provide a simplified way to scrape the following Azure resources:
 
 - [Azure API Management](api-management)
-- [Application Gateway](application-gateway)
+- [Azure Application Gateway](application-gateway)
 - [Azure App Plan](app-plan)
 - [Azure Cache for Redis](redis-cache)
 - [Azure Container Instances](container-instances)

--- a/docs/configuration/v2.x/metrics/index.md
+++ b/docs/configuration/v2.x/metrics/index.md
@@ -121,6 +121,7 @@ service supported by Azure Monitor.
 We also provide a simplified way to scrape the following Azure resources:
 
 - [Azure API Management](api-management)
+- [Application Gateway](application-gateway)
 - [Azure App Plan](app-plan)
 - [Azure Cache for Redis](redis-cache)
 - [Azure Container Instances](container-instances)

--- a/docs/configuration/v2.x/resource-discovery.md
+++ b/docs/configuration/v2.x/resource-discovery.md
@@ -88,6 +88,7 @@ As of now, we only allow to define criteria that resources have to meet before t
 Dynamic resource discovery is supported for the following scrapers:
 
 - [Azure API Management](metrics/api-management)
+- [Azure Application Gateway](metrics/application-gateway)
 - [Azure App Plan](metrics/app-plan)
 - [Azure Cache for Redis](metrics/redis-cache)
 - [Azure Container Instances](metrics/container-instances)

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -12,6 +12,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
             {
                 case ResourceType.ApiManagement:
                     return new ApiManagementDiscoveryQuery();
+                case ResourceType.ApplicationGateway:
+                    return new ApplicationGatewayDiscoveryQuery();
                 case ResourceType.AppPlan:
                     return new AppPlanDiscoveryQuery();
                 case ResourceType.ContainerInstance:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ApplicationGatewayDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/ApplicationGatewayDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class ApplicationGatewayDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/applicationGateways" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var applicationGatewayName = resultRowEntry[3]?.ToString();
+            
+            var resource = new ApplicationGatewayResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), applicationGatewayName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -13,6 +13,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
             {
                 case ResourceType.ApiManagement:
                     return new ApiManagementMetricValidator();
+                case ResourceType.ApplicationGateway:
+                    return new ApplicationGatewayMetricValidator();
                 case ResourceType.AppPlan:
                     return new AppPlanMetricValidator();
                 case ResourceType.BlobStorage:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ApplicationGatewayMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ApplicationGatewayMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class ApplicationGatewayMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<ApplicationGatewayResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.ApplicationGatewayName))
+                {
+                    yield return "No Azure Application Gateway name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -29,6 +29,7 @@
         KeyVault = 24,
         LogicApp = 25,
         EventHubs = 26,
-        ExpressRouteCircuit = 27
+        ExpressRouteCircuit = 27,
+        ApplicationGateway = 28
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/ApplicationGatewayResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/ApplicationGatewayResourceDefinition.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class ApplicationGatewayResourceDefinition : AzureResourceDefinition
+    {
+        public ApplicationGatewayResourceDefinition(string subscriptionId, string resourceGroupName, string applicationGatewayName)
+            : base(ResourceType.ApplicationGateway, subscriptionId, resourceGroupName, applicationGatewayName)
+        {
+            ApplicationGatewayName = applicationGatewayName;
+        }
+
+        public string ApplicationGatewayName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -24,6 +24,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.ApiManagement:
                     var apiManagementLogger = _loggerFactory.CreateLogger<ApiManagementDeserializer>();
                     return new ApiManagementDeserializer(apiManagementLogger);
+                case ResourceType.ApplicationGateway:
+                    var applicationGatewayLogger = _loggerFactory.CreateLogger<ApplicationGatewayDeserializer>();
+                    return new ApplicationGatewayDeserializer(applicationGatewayLogger);
                 case ResourceType.AppPlan:
                     var appPlanLogger = _loggerFactory.CreateLogger<AppPlanDeserializer>();
                     return new AppPlanDeserializer(appPlanLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -24,6 +24,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<SecretV1, Secret>();
 
             CreateMap<ApiManagementResourceV1, ApiManagementResourceDefinition>();
+            CreateMap<ApplicationGatewayResourceV1, ApplicationGatewayResourceDefinition>();
             CreateMap<AppPlanResourceV1, AppPlanResourceDefinition>();
             CreateMap<BlobStorageResourceV1, BlobStorageResourceDefinition>();
             CreateMap<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>();
@@ -58,6 +59,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
 
             CreateMap<AzureResourceDefinitionV1, IAzureResourceDefinition>()
                 .Include<ApiManagementResourceV1, ApiManagementResourceDefinition>()
+                .Include<ApplicationGatewayResourceV1, ApplicationGatewayResourceDefinition>()
                 .Include<AppPlanResourceV1, AppPlanResourceDefinition>()
                 .Include<BlobStorageResourceV1, BlobStorageResourceDefinition>()
                 .Include<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/ApplicationGatewayResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/ApplicationGatewayResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Application Gateway.
+    /// </summary>
+    public class ApplicationGatewayResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Application Gateway to get metrics for.
+        /// </summary>
+        public string ApplicationGatewayName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApplicationGatewayDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/ApplicationGatewayDeserializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class ApplicationGatewayDeserializer : ResourceDeserializer<ApplicationGatewayResourceV1>
+    {
+        public ApplicationGatewayDeserializer(ILogger<ApplicationGatewayDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.ApplicationGatewayName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -34,6 +34,8 @@ namespace Promitor.Core.Scraping.Factories
             {
                 case ResourceType.ApiManagement:
                     return new ApiManagementScraper(scraperConfiguration);
+                case ResourceType.ApplicationGateway:
+                    return new ApplicationGatewayScraper(scraperConfiguration);
                 case ResourceType.AppPlan:
                     return new AppPlanScraper(scraperConfiguration);
                 case ResourceType.BlobStorage:

--- a/src/Promitor.Core.Scraping/ResourceTypes/ApplicationGatewayScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/ApplicationGatewayScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class ApplicationGatewayScraper : AzureMonitorScraper<ApplicationGatewayResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/applicationGateways/{2}";
+
+        public ApplicationGatewayScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, ApplicationGatewayResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.ApplicationGatewayName);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -166,7 +166,7 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
         public MetricsDeclarationBuilder WithExpressRouteCircuitMetric(string metricName = "promitor-express-route-circuit",
             string metricDescription = "Description for a metric",
             string expressRouteCircuitName = "promitor-express-route-circuit-name",
-            string azureMetricName = "Percent",
+            string azureMetricName = "ArpAvailability",
             string resourceDiscoveryGroupName = "",
             bool omitResource = false)
         {
@@ -210,6 +210,23 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             };
 
             CreateAndAddMetricDefinition(ResourceType.CosmosDb, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, resource);
+
+            return this;
+        }
+
+        public MetricsDeclarationBuilder WithApplicationGatewayMetric(string metricName = "promitor-application-gateway",
+            string metricDescription = "Description for a metric",
+            string applicationGatewayName = "promitor-application-gateway-name",
+            string azureMetricName = "ApplicationGatewayTotalTime",
+            string resourceDiscoveryGroupName = "",
+            bool omitResource = false)
+        {
+            var resource = new ApplicationGatewayResourceV1
+            {
+                ApplicationGatewayName = applicationGatewayName
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.ApplicationGateway, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, resource);
 
             return this;
         }

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/ApplicationGatewayDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/ApplicationGatewayDeserializerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class ApplicationGatewayDeserializerTests : ResourceDeserializerTest<ApplicationGatewayDeserializer>
+    {
+        private readonly ApplicationGatewayDeserializer _deserializer;
+
+        public ApplicationGatewayDeserializerTests()
+        {
+            _deserializer = new ApplicationGatewayDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_ApplicationGatewayNameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<ApplicationGatewayResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "applicationGatewayName: promitor-application-gateway",
+                "promitor-application-gateway",
+                r => r.ApplicationGatewayName);
+        }
+
+        [Fact]
+        public void Deserialize_ApplicationGatewayNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<ApplicationGatewayResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.ApplicationGatewayName);
+        }
+
+        [Fact]
+        public void Deserialize_ApplicationGatewayNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "applicationGatewayName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new ApplicationGatewayDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/ApplicationGatewayMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/ApplicationGatewayMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,132 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class ApplicationGatewayMetricsDeclarationValidationStepTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutApplicationGatewayName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(applicationGatewayName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void ApplicationGatewayMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithApplicationGatewayMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION
Provide support for scraping Azure Application Gateway

Fixes #313

Metrics output:
```
# HELP azure_application_gateway_milli_total_time Average milliseconds of total time on an Azure application gateway
# TYPE azure_application_gateway_milli_total_time gauge
azure_application_gateway_milli_total_time{resource_group="RG",subscription_id="SID",resource_uri="subscriptions/SID/resourceGroups/RG/providers/Microsoft.Network/applicationGateways/AG",instance_name="AG"} 8 1599050691198
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="TID",subscription_id="SID",app_id="APPID"} 11998 1599050690955
```

Discovery output:
`[{"$type":"Promitor.Core.Contracts.ResourceTypes.ApplicationGatewayResourceDefinition, Promitor.Core.Contracts","ApplicationGatewayName":"AG","ResourceType":"ApplicationGateway","SubscriptionId":"SID","ResourceGroupName":"RG","ResourceName":"AG","UniqueName":"AG"}]`