### PR TITLE
Provide `X-Version` response header for API endpoints

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -26,6 +26,7 @@ version:
 - {{% tag added %}} New validation rule to ensure declarative or dynamic discovery for metrics to scrape are configured
 - {{% tag added %}} New System API endpoint giving runtime information ([docs](https://promitor.io/operations/#system)
  | [#1208](https://github.com/tomkerkhove/promitor/issues/1208))
+- {{% tag added %}} Provide `X-Version` response header for API endpoints ([#1209](https://github.com/tomkerkhove/promitor/issues/1209))
 - {{% tag changed %}} Show Promitor version during startup
 - {{% tag changed %}} Provide capability to scrape all queues in Azure Service Bus, instead of having to declare the
  queue name. ([#529](https://github.com/tomkerkhove/promitor/issues/529)).

--- a/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Promitor.Agents.Core.Middleware;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
@@ -8,6 +9,16 @@ namespace Microsoft.AspNetCore.Builder
     // ReSharper disable once InconsistentNaming
     public static class IApplicationBuilderExtensions
     {
+        /// <summary>
+        ///     Adds middleware to automatically add the version in our responses
+        /// </summary>
+        public static IApplicationBuilder UseVersionMiddleware(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<AgentVersionMiddleware>();
+
+            return app;
+        }
+
         /// <summary>
         ///     Add support for Open API with API explorer
         /// </summary>

--- a/src/Promitor.Agents.Core/HttpHeaders.cs
+++ b/src/Promitor.Agents.Core/HttpHeaders.cs
@@ -1,0 +1,7 @@
+﻿namespace Promitor.Agents.Core
+{
+    public class HttpHeaders
+    {
+        public const string AgentVersion = "X-Version";
+    }
+}

--- a/src/Promitor.Agents.Core/Middleware/AgentVersionMiddleware.cs
+++ b/src/Promitor.Agents.Core/Middleware/AgentVersionMiddleware.cs
@@ -1,0 +1,42 @@
+﻿
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Promitor.Core;
+
+namespace Promitor.Agents.Core.Middleware
+{
+    public class AgentVersionMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AgentVersionMiddleware" /> class which automatically adds the version of the agent to all HTTP responses
+        /// </summary>
+        /// <param name="next">The next <see cref="RequestDelegate" /> in the ASP.NET Core request pipeline.</param>
+        /// <exception cref="System.ArgumentNullException">When the <paramref name="next" /> is <c>null</c>.</exception>
+        public AgentVersionMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        /// <summary>
+        ///     Invoke the middleware to automatically add version to HTTP responses.
+        /// </summary>
+        /// <param name="httpContext">The context for the current HTTP request.</param>
+        public async Task Invoke(HttpContext httpContext)
+        {
+            var version = Version.Get();
+
+            httpContext.Response.OnStarting(state =>
+            {
+                var context = (HttpContext)state;
+                context.Response.Headers.TryAdd(HttpHeaders.AgentVersion, version);
+
+                return Task.CompletedTask;
+            }, httpContext);
+
+            await _next(httpContext);
+        }
+    }
+}

--- a/src/Promitor.Agents.ResourceDiscovery/Startup.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Startup.cs
@@ -49,6 +49,7 @@ namespace Promitor.Agents.ResourceDiscovery
             app.UseExceptionHandling();
             app.UseRequestTracking();
             app.UseHttpCorrelation();
+            app.UseVersionMiddleware();
             app.UseRouting();
 
             app.ExposeOpenApiUi(ApiName);

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -63,10 +63,12 @@ namespace Promitor.Agents.Scraper
             app.UseExceptionHandling()
                 .UseRequestTracking()
                 .UseHttpCorrelation()
+                .UseVersionMiddleware()
                 .UseRouting()
                 .UseMetricSinks(Configuration)
                 .ExposeOpenApiUi()
                 .UseEndpoints(endpoints => endpoints.MapControllers());
+
             UseSerilog(ComponentName, app.ApplicationServices);
         }
 

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/HealthTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/HealthTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Promitor.Agents.Core;
 using Promitor.Tests.Integration.Clients;
@@ -26,6 +27,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/HealthTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/HealthTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
+using Promitor.Agents.Core;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,6 +25,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceCollectionTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceCollectionTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Promitor.Agents.Core;
 using Promitor.Agents.ResourceDiscovery.Configuration;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
@@ -32,6 +33,20 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             var resourceDiscoveryGroups = JsonConvert.DeserializeObject<List<ResourceDiscoveryGroup>>(rawResponseBody);
             Assert.NotNull(resourceDiscoveryGroups);
             Assert.NotEmpty(resourceDiscoveryGroups);
+        }
+
+        [Fact]
+        public async Task ResourceDiscoveryGroup_SuccessfulCall_ReturnsVersionHeader()
+        {
+            // Arrange
+            var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
+
+            // Act
+            var response = await resourceDiscoveryClient.GetResourceDiscoveryGroupsAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceCollectionTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceCollectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -47,6 +48,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryIntegrationTest.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryIntegrationTest.cs
@@ -9,5 +9,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         public ResourceDiscoveryIntegrationTest(ITestOutputHelper testOutput) : base(testOutput)
         {
         }
+
+        public string ExpectedVersion => Configuration["Agents:ResourceDiscovery:Expectations:Version"];
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Bogus;
@@ -33,6 +34,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
 
         [Fact]
@@ -48,6 +50,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
 
         [Fact]

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
@@ -38,7 +38,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
-            const int expectedResourceCount = 25;
+            const int expectedResourceCount = 29;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act
@@ -118,7 +118,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "two-subscriptions-scenario";
-            const int expectedResourceCount = 25;
+            const int expectedResourceCount = 29;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act
@@ -198,7 +198,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "two-region-scenario";
-            const int expectedResourceCount = 24;
+            const int expectedResourceCount = 28;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Bogus;
 using Newtonsoft.Json;
+using Promitor.Agents.Core;
 using Promitor.Agents.ResourceDiscovery.Graph.Model;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
@@ -31,6 +32,22 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+        }
+
+        [Fact]
+        public async Task ResourceDiscovery_SuccessfulCall_ReturnsVersionHeader()
+        {
+            // Arrange
+            const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
+            var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
+
+            // Act
+            var response = await resourceDiscoveryClient.GetDiscoveredResourcesAsync(resourceDiscoveryGroupName);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
         }
 
         [Fact]

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/SystemTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/SystemTests.cs
@@ -21,7 +21,6 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         public async Task System_GetInfo_ReturnsOk()
         {
             // Arrange
-            var expectedVersion = Configuration["Agents:ResourceDiscovery:Expectations:Version"];
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act
@@ -33,9 +32,9 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             Assert.NotEmpty(rawPayload);
             var systemInfo = JsonConvert.DeserializeObject<SystemInfo>(rawPayload);
             Assert.NotNull(systemInfo);
-            Assert.Equal(expectedVersion, systemInfo.Version);
+            Assert.Equal(ExpectedVersion, systemInfo.Version);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
-            Assert.Equal(expectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/SystemTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/SystemTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Promitor.Agents.Core;
 using Promitor.Agents.Core.Contracts;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
@@ -32,6 +34,8 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             var systemInfo = JsonConvert.DeserializeObject<SystemInfo>(rawPayload);
             Assert.NotNull(systemInfo);
             Assert.Equal(expectedVersion, systemInfo.Version);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(expectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/Scraper/HealthTests.cs
+++ b/src/Promitor.Tests.Integration/Services/Scraper/HealthTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Promitor.Agents.Core;
 using Promitor.Tests.Integration.Clients;
@@ -26,6 +27,7 @@ namespace Promitor.Tests.Integration.Services.Scraper
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/Scraper/HealthTests.cs
+++ b/src/Promitor.Tests.Integration/Services/Scraper/HealthTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
+using Promitor.Agents.Core;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,6 +25,7 @@ namespace Promitor.Tests.Integration.Services.Scraper
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/Scraper/ScraperIntegrationTest.cs
+++ b/src/Promitor.Tests.Integration/Services/Scraper/ScraperIntegrationTest.cs
@@ -9,5 +9,7 @@ namespace Promitor.Tests.Integration.Services.Scraper
         public ScraperIntegrationTest(ITestOutputHelper testOutput) : base(testOutput)
         {
         }
+
+        public string ExpectedVersion => Configuration["Agents:Scraper:Expectations:Version"];
     }
 }

--- a/src/Promitor.Tests.Integration/Services/Scraper/SystemTests.cs
+++ b/src/Promitor.Tests.Integration/Services/Scraper/SystemTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Promitor.Agents.Core;
 using Promitor.Agents.Core.Contracts;
 using Promitor.Tests.Integration.Clients;
 using Xunit;
@@ -32,6 +34,8 @@ namespace Promitor.Tests.Integration.Services.Scraper
             var systemInfo = JsonConvert.DeserializeObject<SystemInfo>(rawPayload);
             Assert.NotNull(systemInfo);
             Assert.Equal(expectedVersion, systemInfo.Version);
+            Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
+            Assert.Equal(expectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }

--- a/src/Promitor.Tests.Integration/Services/Scraper/SystemTests.cs
+++ b/src/Promitor.Tests.Integration/Services/Scraper/SystemTests.cs
@@ -21,7 +21,6 @@ namespace Promitor.Tests.Integration.Services.Scraper
         public async Task System_GetInfo_ReturnsOk()
         {
             // Arrange
-            var expectedVersion = Configuration["Agents:Scraper:Expectations:Version"];
             var resourceDiscoveryClient = new ScraperClient(Configuration, Logger);
 
             // Act
@@ -33,9 +32,9 @@ namespace Promitor.Tests.Integration.Services.Scraper
             Assert.NotEmpty(rawPayload);
             var systemInfo = JsonConvert.DeserializeObject<SystemInfo>(rawPayload);
             Assert.NotNull(systemInfo);
-            Assert.Equal(expectedVersion, systemInfo.Version);
+            Assert.Equal(ExpectedVersion, systemInfo.Version);
             Assert.True(response.Headers.Contains(HttpHeaders.AgentVersion));
-            Assert.Equal(expectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
+            Assert.Equal(ExpectedVersion, response.Headers.GetValues(HttpHeaders.AgentVersion).First());
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Fixes #1209
