### PR TITLE
fix: Metrics without a timeseries are not reported

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -37,6 +37,9 @@ version:
 - {{% tag changed %}} Default name for `rbac.serviceAccount.name` is now `promitor-scraper` in Promitor Agent Helm chart
 - {{% tag fixed %}} Ensure Prometheus metric sink does write timestamps ([#1217](https://github.com/tomkerkhove/promitor/issues/1217)).
 - {{% tag fixed %}} Dimensions with `/` in name are now supported by replacing it with `_` for Prometheus metric sink ([#1248](https://github.com/tomkerkhove/promitor/issues/1248)).
+- {{% tag fixed %}} (Multi-Dimensional) Metrics that do not have a value/time series are not reported correctly in
+ Prometheus metric sink with `metricSinks.prometheusScrapingEndpoint.metricUnavailableValue` ([#1197](https://github.com/tomkerkhove/promitor/issues/1197)
+  | [FAQ](https://promitor.io/faq#why-does-my-multi-dimensional-metric-report-label-value-unknown-with-prometheus)).
 - {{% tag removed %}} Support for Prometheus legacy configuration ([deprecation notice](https://changelog.promitor.io/#prometheus-legacy-configuration)
  | [migration guide](https://promitor.io/walkthrough/migrate-from-1.x-to-2.x))
 - {{% tag removed %}} Support for Swagger UI 2.0 ([deprecation notice](https://changelog.promitor.io/#swagger-ui-2-0) |

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,6 +1,7 @@
 scrape_configs:
 - job_name: promitor
   scrape_interval: 5s
+  metrics_path: /scrape
   static_configs:
   - targets:
     - promitor.agents.scraper:88

--- a/docs/configuration/v2.x/runtime/scraper.md
+++ b/docs/configuration/v2.x/runtime/scraper.md
@@ -124,6 +124,16 @@ metricSinks:
     baseUriPath: /metrics # Optional. Default: /metrics
 ```
 
+#### What happens when metrics are unavailable for multi-dimensional metrics?
+
+Promitor allows you to use dimension in metrics so that it will report all values.
+
+For example, when scraping an Azure Event Hub namespace you can report the same metric for every entity inside the namespace.
+
+When Promitor reports the metric it will always add a label which clarifies the subresource. However; when it cannot find
+ a metric for that dimension it will keep on reporting the metric, but with value `unknown` given it cannot determine
+  the name of the dimension.
+
 ### StatsD
 
 ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v1.6-green.svg)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,6 +10,7 @@ Here are a list of questions you may have:
 - [Is scraping multiple subscriptions supported?](#is-scraping-multiple-subscriptions-supported)
 - [Are multi-dimensional metrics supported?](#are-multi-dimensional-metrics-supported)
 - [Why does Azure Blob & File Storage only report account-level information?](#why-does-azure-blob--file-storage-only-report-account-level-information)
+- [Why does my multi-dimensional metric report label value `unknown` with Prometheus?](#why-does-my-multi-dimensional-metric-report-label-value-unknown-with-prometheus)
 
 ## What Azure clouds are supported?
 
@@ -51,5 +52,12 @@ Azure Monitor currently only provides account-level metrics which we can serve.
 
 As part of [#450](https://github.com/tomkerkhove/promitor/issues/450) &
  [#446](https://github.com/tomkerkhove/promitor/issues/446) we plan to provide the capability to have more granular information.
+
+## Why does my multi-dimensional metric report label value `unknown` with Prometheus?
+
+When Promitor is unable to find a metric for a multi-dimensional metric, it will report `unknown` for the dimension
+ label given it was not able to determine what the dimension value is due to the lack of metrics.
+
+You can read more about it in our [Prometheus sink documentation](/configuration/v2.x/runtime/scraper/#what-happens-when-metrics-are-unavailable-for-multi-dimensional-metrics).
 
 [&larr; back](/)

--- a/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
+++ b/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
@@ -53,7 +53,9 @@ namespace Promitor.Core.Scraping
             catch (MetricInformationNotFoundException metricsNotFoundException)
             {
                 Logger.LogWarning("No metric information found for metric {MetricName} with dimension {MetricDimension}. Details: {Details}", metricsNotFoundException.Name, metricsNotFoundException.Dimension, metricsNotFoundException.Details);
-                measuredMetrics.Add(MeasuredMetric.CreateWithoutDimension(null));
+                
+                var measuredMetric = string.IsNullOrWhiteSpace(dimensionName) ? MeasuredMetric.CreateWithoutDimension(null) : MeasuredMetric.CreateForDimension(null, dimensionName, "unknown");
+                measuredMetrics.Add(measuredMetric);
             }
 
             // Provide more metric labels, if we need to

--- a/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
+++ b/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GuardNet;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
+using Microsoft.Extensions.Logging;
 using Promitor.Core.Contracts;
 using Promitor.Core.Metrics;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Integrations.AzureMonitor.Exceptions;
 using MetricDimension = Promitor.Core.Scraping.Configuration.Model.MetricDimension;
 
 namespace Promitor.Core.Scraping
@@ -42,14 +44,23 @@ namespace Promitor.Core.Scraping
             // Determine the metric dimension to use, if any
             var dimensionName = DetermineMetricDimension(resourceDefinition, scrapeDefinition.AzureMetricConfiguration?.Dimension);
 
-            // Query Azure Monitor for metrics
-            var foundMetricValue = await AzureMonitorClient.QueryMetricAsync(metricName, dimensionName, aggregationType, aggregationInterval, resourceUri, metricFilter);
+            List<MeasuredMetric> measuredMetrics = new List<MeasuredMetric>();
+            try
+            {
+                // Query Azure Monitor for metrics
+                measuredMetrics = await AzureMonitorClient.QueryMetricAsync(metricName, dimensionName, aggregationType, aggregationInterval, resourceUri, metricFilter);
+            }
+            catch (MetricInformationNotFoundException metricsNotFoundException)
+            {
+                Logger.LogWarning("No metric information found for metric {MetricName} with dimension {MetricDimension}. Details: {Details}", metricsNotFoundException.Name, metricsNotFoundException.Dimension, metricsNotFoundException.Details);
+                measuredMetrics.Add(MeasuredMetric.CreateWithoutDimension(null));
+            }
 
             // Provide more metric labels, if we need to
             var metricLabels = DetermineMetricLabels(resourceDefinition);
 
             // Enrich measured metrics, in case we need to
-            var finalMetricValues = EnrichMeasuredMetrics(resourceDefinition, dimensionName, foundMetricValue);
+            var finalMetricValues = EnrichMeasuredMetrics(resourceDefinition, dimensionName, measuredMetrics);
 
             // We're done!
             return new ScrapeResult(subscriptionId, scrapeDefinition.ResourceGroupName, resourceDefinition.ResourceName, resourceUri, finalMetricValues, metricLabels);

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -66,7 +66,21 @@ namespace Promitor.Core.Metrics
             Guard.For<ArgumentException>(() => timeseries.Metadatavalues.Any() == false);
 
             var dimensionValue = timeseries.Metadatavalues.Single(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);
-            return new MeasuredMetric(value, dimensionName, dimensionValue.Value);
+            return CreateForDimension(value, dimensionName, dimensionValue.Value);
+        }
+
+        /// <summary>
+        /// Create a measured metric for a given dimension
+        /// </summary>
+        /// <param name="value">Measured metric value</param>
+        /// <param name="dimensionName">Name of dimension that is being scraped</param>
+        /// <param name="dimensionValue">Value of the dimension that is being scraped</param>
+        public static MeasuredMetric CreateForDimension(double? value, string dimensionName, string dimensionValue)
+        {
+            Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
+            Guard.NotNullOrWhitespace(dimensionValue, nameof(dimensionValue));
+
+            return new MeasuredMetric(value, dimensionName, dimensionValue);
         }
     }
 }

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -82,7 +82,7 @@ namespace Promitor.Integrations.AzureMonitor
             var relevantMetric = await GetRelevantMetric(metricName, aggregationType, closestAggregationInterval, metricFilter, metricDimension, metricDefinition, startQueryingTime);
             if (relevantMetric.Timeseries.Count < 1)
             {
-                throw new MetricInformationNotFoundException(metricName, "No time series was found");
+                throw new MetricInformationNotFoundException(metricName,metricDimension, "No time series was found");
             }
 
             var measuredMetrics = new List<MeasuredMetric>();
@@ -159,8 +159,7 @@ namespace Promitor.Integrations.AzureMonitor
             return relevantMetric;
         }
 
-        private MetricValue GetMostRecentMetricValue(string metricName, TimeSeriesElement timeSeries,
-            DateTime recordDateTime)
+        private MetricValue GetMostRecentMetricValue(string metricName, TimeSeriesElement timeSeries, DateTime recordDateTime)
         {
             var relevantMetricValue = timeSeries.Data.Where(metricValue => metricValue.TimeStamp < recordDateTime)
                 .OrderByDescending(metricValue => metricValue.TimeStamp)

--- a/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricInformationNotFoundException.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Exceptions/MetricInformationNotFoundException.cs
@@ -8,21 +8,42 @@ namespace Promitor.Integrations.AzureMonitor.Exceptions
         /// <summary>
         ///     Constructor
         /// </summary>
-        /// <param name="metricName">Name of the metric</param>
+        /// <param name="name">Name of the metric</param>
         /// <param name="details">Details that provide more context about the scenario</param>
-        public MetricInformationNotFoundException(string metricName, string details) : base($"No metric information was found for '{metricName}'. Reason: '{details}'")
+        public MetricInformationNotFoundException(string name, string details) : base($"No metric information was found for '{name}'. Reason: '{details}'")
         {
-            Guard.NotNullOrWhitespace(metricName, nameof(metricName));
+            Guard.NotNullOrWhitespace(name, nameof(name));
             Guard.NotNullOrWhitespace(details, nameof(details));
 
-            MetricName = metricName;
+            Name = name;
+            Details = details;
+        }
+
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="name">Name of the metric</param>
+        /// <param name="dimension">Dimension of the metric</param>
+        /// <param name="details">Details that provide more context about the scenario</param>
+        public MetricInformationNotFoundException(string name, string details, string dimension) : base($"No metric information was found for '{name}' with dimension '{dimension}'. Reason: '{details}'")
+        {
+            Guard.NotNullOrWhitespace(name, nameof(name));
+            Guard.NotNullOrWhitespace(details, nameof(details));
+
+            Name = name;
+            Dimension = dimension;
             Details = details;
         }
 
         /// <summary>
         ///     Name of the metric
         /// </summary>
-        public string MetricName { get; }
+        public string Name { get; }
+
+        /// <summary>
+        ///     Dimension of the metric
+        /// </summary>
+        public string Dimension { get; }
 
         /// <summary>
         ///     Details that provide more context about the scenario


### PR DESCRIPTION
fix: Metrics without a timeseries are not reported with the `metricSinks.prometheusScrapingEndpoint.metricUnavailableValue`

Fixes #1197

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->
### Before:
```
# HELP azure_event_hubs_incoming_messages_discovery The number of incoming messages on an Azure Event Hub namespace
# TYPE azure_event_hubs_incoming_messages_discovery gauge
azure_event_hubs_incoming_messages_discovery{resource_group="promitor-sources",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.EventHub/namespaces/promitor-streaming",instance_name="promitor-streaming",entity_name="topic-1"} 1 1606049042395
```

For the other dimension that does not have a value triggered an exception:
> [12:44:02 FTL] Failed to scrape resource for metric 'azure_event_hubs_incoming_messages_discovery'
Promitor.Integrations.AzureMonitor.Exceptions.MetricInformationNotFoundException: No metric information was found for 'IncomingMessages'. Reason: 'No time series was found'
   at Promitor.Integrations.AzureMonitor.AzureMonitorClient.QueryMetricAsync(String metricName, String metricDimension, AggregationType aggregationType, TimeSpan aggregationInterval, String resourceId, String metricFilter) in C:\Code\GitHub\promitor\src\Promitor.Integrations.AzureMonitor\AzureMonitorClient.cs:line 88
   at Promitor.Core.Scraping.AzureMonitorScraper`1.ScrapeResourceAsync(String subscriptionId, ScrapeDefinition`1 scrapeDefinition, TResourceDefinition resourceDefinition, AggregationType aggregationType, TimeSpan aggregationInterval) in C:\Code\GitHub\promitor\src\Promitor.Core.Scraping\AzureMonitorScraper.cs:line 46
   at Promitor.Core.Scraping.Scraper`1.ScrapeAsync(ScrapeDefinition`1 scrapeDefinition) in C:\Code\GitHub\promitor\src\Promitor.Core.Scraping\Scraper.cs:line 69

### After:
```
# HELP azure_event_hubs_incoming_messages_discovery The number of incoming messages on an Azure Event Hub namespace
# TYPE azure_event_hubs_incoming_messages_discovery gauge
azure_event_hubs_incoming_messages_discovery{resource_group="dapr-actors",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/dapr-actors/providers/Microsoft.EventHub/namespaces/dapr-actors",instance_name="dapr-actors",entity_name="unknown"} -1 1606048322048
azure_event_hubs_incoming_messages_discovery{resource_group="promitor-sources",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.EventHub/namespaces/promitor-streaming",instance_name="promitor-streaming",entity_name="topic-1"} 1 1606048322133
```
