### PR TITLE
feat: Allow `EntityPath` as a dimension for Service Bus metrics #808

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -16,6 +16,7 @@ version:
 - {{% tag added %}} Support for scraping Azure Application Gateway ([docs](https://promitor.io/configuration/v2.x/metrics/application-gateway) | [#1251](https://github.com/tomkerkhove/promitor/issues/313) | Contributed by [@bluepixbe](https://github.com/bluepixbe) 🎉).
 - {{% tag added %}} Support for scraping Azure Network Gateway ([docs](https://promitor.io/configuration/v2.x/metrics/network-gateway) | [#1264](https://github.com/tomkerkhove/promitor/issues/1264) | Contributed by [@bluepixbe](https://github.com/bluepixbe) 🎉).
 - {{% tag added %}} Support for scraping Azure Kubernetes Service ([docs](https://promitor.io/configuration/v2.x/metrics/kubernetes) | [#333](https://github.com/tomkerkhove/promitor/issues/333) | Contributed by [@jkataja](https://github.com/jkataja) 🎉).
+- {{% tag added %}} Support for using dimensions with Azure Service Bus ([#808](https://github.com/tomkerkhove/promitor/issues/808))
 - {{% tag added %}} New validation rule to ensure at least one resource or resource collection is configured to scrape
 - {{% tag added %}} Provide suggestions when unknown fields are found in the metrics config. ([#1105](https://github.com/tomkerkhove/promitor/issues/1105) | Contributed by [@adamconnelly](https://github.com/adamconnelly) 🎉).
 - {{% tag added %}} Add validation to ensure the scraping schedule is a valid Cron expression. ([#1103](https://github.com/tomkerkhove/promitor/issues/1103) | Contributed by [@adamconnelly](https://github.com/adamconnelly) 🎉).

--- a/docs/configuration/v2.x/metrics/event-hubs.md
+++ b/docs/configuration/v2.x/metrics/event-hubs.md
@@ -21,7 +21,7 @@ The following scraper-specific metric label will be added:
 
 - `entity_name` - Name of the topic
 
-> :warning: **As of today, `EntityPath` as a dimension is not supported.**
+> :warning: **As of today, it is not supported to combine `topicName` with `EntityPath` as a dimension.**
 
 Example:
 

--- a/docs/configuration/v2.x/metrics/service-bus-queue.md
+++ b/docs/configuration/v2.x/metrics/service-bus-queue.md
@@ -21,7 +21,7 @@ The following scraper-specific metric label will be added:
 
 - `entity_name` - Name of the queue
 
-> :warning: **As of today, `EntityPath` as a dimension is not supported.**
+> :warning: **As of today, it is not supported to combine `queueName` with `EntityPath` as a dimension.**
 
 Example:
 

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubsMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubsMetricValidator.cs
@@ -10,7 +10,7 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
 {
     internal class EventHubsMetricValidator : IMetricValidator
     {
-        private const string UnsupportedEntityDimension = "EntityName";
+        private const string EntityNameDimension = "EntityName";
 
         public IEnumerable<string> Validate(MetricDefinition metricDefinition)
         {
@@ -19,17 +19,18 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
             var errorMessages = new List<string>();
 
             var configuredDimension = metricDefinition.AzureMetricConfiguration?.Dimension?.Name;
-            if (string.IsNullOrWhiteSpace(configuredDimension) == false
-                && configuredDimension.Equals(UnsupportedEntityDimension, StringComparison.InvariantCultureIgnoreCase))
-            {
-                errorMessages.Add($"Dimension '{UnsupportedEntityDimension}' is not supported");
-            }
+            var isEntityNameDimensionConfigured = string.IsNullOrWhiteSpace(configuredDimension) == false && configuredDimension.Equals(EntityNameDimension, StringComparison.InvariantCultureIgnoreCase);
 
             foreach (var resourceDefinition in metricDefinition.Resources.Cast<EventHubResourceDefinition>())
             {
                 if (string.IsNullOrWhiteSpace(resourceDefinition.Namespace))
                 {
                     errorMessages.Add("No Azure Event Hubs Namespace is configured");
+                }
+
+                if (isEntityNameDimensionConfigured && string.IsNullOrWhiteSpace(resourceDefinition.TopicName) == false)
+                {
+                    errorMessages.Add($"Topic name is configured while '{EntityNameDimension}' dimension is configured as well. We only support one or the other.");
                 }
             }
 

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ServiceBusQueueMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/ServiceBusQueueMetricValidator.cs
@@ -10,7 +10,7 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
 {
     internal class ServiceBusQueueMetricValidator : IMetricValidator
     {
-        private const string UnsupportedEntityDimension = "EntityName";
+        private const string EntityNameDimension = "EntityName";
 
         public IEnumerable<string> Validate(MetricDefinition metricDefinition)
         {
@@ -19,17 +19,18 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
             var errorMessages = new List<string>();
 
             var configuredDimension = metricDefinition.AzureMetricConfiguration?.Dimension?.Name;
-            if (string.IsNullOrWhiteSpace(configuredDimension) == false
-                && configuredDimension.Equals(UnsupportedEntityDimension, StringComparison.InvariantCultureIgnoreCase))
-            {
-                errorMessages.Add($"Dimension '{UnsupportedEntityDimension}' is not supported for now");
-            }
+            var isEntityNameDimensionConfigured = string.IsNullOrWhiteSpace(configuredDimension) == false && configuredDimension.Equals(EntityNameDimension, StringComparison.InvariantCultureIgnoreCase);
 
             foreach (var resourceDefinition in metricDefinition.Resources.Cast<ServiceBusQueueResourceDefinition>())
             {
                 if (string.IsNullOrWhiteSpace(resourceDefinition.Namespace))
                 {
                     errorMessages.Add("No Service Bus Namespace is configured");
+                }
+
+                if (isEntityNameDimensionConfigured && string.IsNullOrWhiteSpace(resourceDefinition.QueueName) == false)
+                {
+                    errorMessages.Add($"Queue name is configured while '{EntityNameDimension}' dimension is configured as well. We only support one or the other.");
                 }
             }
 

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/EventHubsMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/EventHubsMetricsDeclarationValidationStepTests.cs
@@ -28,7 +28,24 @@ namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
         }
 
         [Fact]
-        public void EventHubsMetricsDeclaration_UseEntityNameAsDimension_Blocked()
+        public void EventHubsMetricsDeclaration_UseEntityNameDimensionWithoutTopicName_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithEventHubsMetric(metricDimension: "EntityName", topicName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var metricsDeclarationValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = metricsDeclarationValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void EventHubsMetricsDeclaration_UseEntityNameDimensionWithTopicName_Fails()
         {
             // Arrange
             var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/ServiceBusQueueMetricsDeclarationValidationStepTests.cs
@@ -28,7 +28,7 @@ namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
         }
 
         [Fact]
-        public void ServiceBusQueuesMetricsDeclaration_UseEntityNameAsDimension_Blocked()
+        public void ServiceBusQueuesMetricsDeclaration_UseEntityNameDimensionAndQueueName_Fails()
         {
             // Arrange
             var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
@@ -50,6 +50,23 @@ namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
             // Arrange
             var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
                 .WithServiceBusMetric(metricDimension: "OperationResult")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void ServiceBusQueuesMetricsDeclaration_UseEntityNameDimension_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithServiceBusMetric(metricDimension: "EntityName", queueName: string.Empty)
                 .Build(Mapper);
             var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
 


### PR DESCRIPTION
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Fixes #808