### PR TITLE
fix: OpenAPI docs are not rendered correctly when using a URL prefix

### DIFF
--- a/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="apiName">Name of API</param>
         /// <param name="openApiUiConfigurationAction">Action to configure Open API UI</param>
         /// <param name="openApiConfigurationAction">Action to configure Open API</param>
-        public static IApplicationBuilder ExposeOpenApiUi(this IApplicationBuilder app, string apiName = null, Action<SwaggerUIOptions> openApiUiConfigurationAction = null, Action<SwaggerOptions> openApiConfigurationAction = null)
+        public static IApplicationBuilder ExposeOpenApiUi(this IApplicationBuilder app, string apiName, Action<SwaggerUIOptions> openApiUiConfigurationAction = null, Action<SwaggerOptions> openApiConfigurationAction = null)
         {
             if (openApiConfigurationAction == null)
             {
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Builder
                 openApiUiConfigurationAction = swaggerUiOptions =>
                 {
                     swaggerUiOptions.ConfigureDefaultOptions(apiName);
-                    swaggerUiOptions.SwaggerEndpoint("/api/v1/docs.json", apiName);
+                    swaggerUiOptions.SwaggerEndpoint("../v1/docs.json", apiName);
                     swaggerUiOptions.RoutePrefix = "api/docs";
                 };
             }

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -20,6 +20,7 @@ namespace Promitor.Agents.Scraper
 {
     public class Startup : AgentStartup
     {
+        private const string ApiName = "Promitor - Scraper API";
         private const string ComponentName = "Promitor Scraper";
 
         public Startup(IConfiguration configuration)
@@ -66,7 +67,7 @@ namespace Promitor.Agents.Scraper
                 .UseVersionMiddleware()
                 .UseRouting()
                 .UseMetricSinks(Configuration)
-                .ExposeOpenApiUi()
+                .ExposeOpenApiUi(ApiName)
                 .UseEndpoints(endpoints => endpoints.MapControllers());
 
             UseSerilog(ComponentName, app.ApplicationServices);


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md -->

Fixes #1401
