### PR TITLE
chore: Remove rebase option from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "ignoreDeps":[],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}",
   "packageRules": [
     {
       "datasources": ["docker"],


### PR DESCRIPTION
Remove rebase option from Renovate to use auto-merge.
