### PR TITLE
chore: Use disablePrControls preset to remove rebase option from PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
   "ignoreDeps":[],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}",
   "packageRules": [
     {
       "datasources": ["docker"],
@@ -17,7 +16,8 @@
   ],
   "extends": [
     "config:base",
-    "default:pinDigestsDisabled"
+    "default:pinDigestsDisabled",
+    "default:disablePrControls"
   ],
   "nuget": {
     "enabled": true


### PR DESCRIPTION
I made a new preset for the Renovate bot called `disablePrControls` that you can use instead of manually overriding the `prBodyTemplate`.

The behavior is exactly the same.
But now you're using less lines of configuration code. 😄 

Link to Renovate documentation for `disablePrControls` preset:
https://docs.renovatebot.com/presets-default/#disableprcontrols

Release notes:
https://github.com/renovatebot/renovate/releases/tag/24.28.0