### PR TITLE
feat: Provide Azure Front Door scraper 

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,4 +6,6 @@ version:
 
 - {{% tag added %}} Support for scraping Azure Automation account ([docs](https://promitor.io/configuration/v2.x/metrics/automation-account)
  | [#352](https://github.com/tomkerkhove/promitor/issues/352))
+- {{% tag added %}} Support for scraping Azure Front Door account ([docs](https://promitor.io/configuration/v2.x/metrics/front-door)
+ | [#343](https://github.com/tomkerkhove/promitor/issues/343))
 - {{% tag changed %}} Provide better usability in terms of startup and configuration insights ([#1474](https://github.com/tomkerkhove/promitor/issues/1474))

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -4,8 +4,18 @@ weight: 1
 version:
 ---
 
+**Scraper (Container)**
+
 - {{% tag added %}} Support for scraping Azure Automation account ([docs](https://promitor.io/configuration/v2.x/metrics/automation-account)
  | [#352](https://github.com/tomkerkhove/promitor/issues/352))
 - {{% tag added %}} Support for scraping Azure Front Door account ([docs](https://promitor.io/configuration/v2.x/metrics/front-door)
+ | [#343](https://github.com/tomkerkhove/promitor/issues/343))
+- {{% tag changed %}} Provide better usability in terms of startup and configuration insights ([#1474](https://github.com/tomkerkhove/promitor/issues/1474))
+
+**Resource Discovery (Container)**
+
+- {{% tag added %}} Support for discovering Azure Automation resources ([docs](https://promitor.io/configuration/v2.x/metrics/automation-account)
+ | [#352](https://github.com/tomkerkhove/promitor/issues/352))
+- {{% tag added %}} Support for discovering Azure Front Door resources ([docs](https://promitor.io/configuration/v2.x/metrics/front-door)
  | [#343](https://github.com/tomkerkhove/promitor/issues/343))
 - {{% tag changed %}} Provide better usability in terms of startup and configuration insights ([#1474](https://github.com/tomkerkhove/promitor/issues/1474))

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -24,6 +24,8 @@ resourceDiscoveryGroups:
   type: DeviceProvisioningService
 - name: event-hubs-landscape
   type: EventHubs
+- name: front-door-landscape
+  type: FrontDoor
 - name: iot-gateways
   type: IoTHub
 - name: key-vaults

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -200,3 +200,30 @@ metrics:
     resources:
     - resourceGroupName: promitor-sources
       accountName: promitor-sandbox
+  - name: promitor_demo_frontdoor_backend_health_per_backend
+    description: "Health percentage for a backed in Azure Front Door"
+    resourceType: FrontDoor
+    labels:
+      app: promitor
+    azureMetricConfiguration:
+      metricName: BackendHealthPercentage
+      dimension:
+        name: Backend
+      aggregation:
+        type: Average
+    resources:
+    - name: promitor-landscape
+      resourceGroupName: promitor-landscape
+  - name: promitor_demo_frontdoor_backend_health_per_backend_pool
+    description: "Health percentage for a backed in Azure Front Door"
+    resourceType: FrontDoor
+    labels:
+      app: promitor
+    azureMetricConfiguration:
+      metricName: BackendHealthPercentage
+      dimension:
+        name: BackendPool
+      aggregation:
+        type: Average
+    resourceDiscoveryGroups:
+    - name: front-door-landscape

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -10,6 +10,17 @@ metricDefaults:
     # Every minute
     schedule: "0 * * ? * *"
 metrics:
+  - name: promitor_demo_frontdoor_backend_health
+    description: "Average percentage of memory usage on an Azure App Plan"
+    resourceType: FrontDoor
+    labels:
+      app: promitor
+    azureMetricConfiguration:
+      metricName: BackendHealthPercentage
+      aggregation:
+        type: Average
+    resources:
+    - name: promitor-app-plan
   - name: promitor_demo_appplan_percentage_cpu
     description: "Average percentage of memory usage on an Azure App Plan"
     resourceType: AppPlan

--- a/docs/configuration/v2.x/metrics/front-door.md
+++ b/docs/configuration/v2.x/metrics/front-door.md
@@ -19,18 +19,17 @@ All supported metrics are documented in the official [Azure Monitor documentatio
 Example:
 
 ```yaml
-name: azure_express_route_percentage_arp_availability
-description: "Average percentage of arp availability on an Azure express route circuit"
+name: promitor_demo_frontdoor_backend_health
+description: "Health percentage for backends in Azure Front Door"
 resourceType: FrontDoor
 azureMetricConfiguration:
-  metricName: ArpAvailability
+  metricName: BackendHealthPercentage
   aggregation:
     type: Average
 resources:
-- expressRouteCircuitName: promitor-express-route-circuit-1
-- expressRouteCircuitName: promitor-express-route-circuit-2
+- name: promitor-landscape
 resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
-- name: express-route-circuit-landscape
+- name: front-door-landscape
 ```
 
 <!-- markdownlint-disable MD033 -->

--- a/docs/configuration/v2.x/metrics/front-door.md
+++ b/docs/configuration/v2.x/metrics/front-door.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Azure Front Door Declaration
+---
+
+## Azure Front Door
+
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.1-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
+
+You can declare to scrape an Azure Front Door via the `FrontDoor` resource
+type.
+
+The following fields need to be provided:
+
+- `name` - The name of the Azure Front Door
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkfrontdoors).
+
+Example:
+
+```yaml
+name: azure_express_route_percentage_arp_availability
+description: "Average percentage of arp availability on an Azure express route circuit"
+resourceType: FrontDoor
+azureMetricConfiguration:
+  metricName: ArpAvailability
+  aggregation:
+    type: Average
+resources:
+- expressRouteCircuitName: promitor-express-route-circuit-1
+- expressRouteCircuitName: promitor-express-route-circuit-2
+resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
+- name: express-route-circuit-landscape
+```
+
+<!-- markdownlint-disable MD033 -->
+[&larr; back to metrics declarations](/configuration/v2.x/metrics)<br />
+[&larr; back to introduction](/)
+<!-- markdownlint-enable -->

--- a/docs/configuration/v2.x/metrics/index.md
+++ b/docs/configuration/v2.x/metrics/index.md
@@ -135,6 +135,7 @@ We also provide a simplified way to scrape the following Azure resources:
 - [Azure Database for PostgreSQL](postgresql)
 - [Azure Event Hubs](event-hubs)
 - [Azure Express Route Circuit](express-route-circuit)
+- [Azure Front Door](front-door)
 - [Azure Function App](function-app)
 - [Azure IoT Hub](iot-hub)
 - [Azure IoT Hub Device Provisioning Service (DPS)](iot-hub-device-provisioning-service)

--- a/docs/configuration/v2.x/resource-discovery.md
+++ b/docs/configuration/v2.x/resource-discovery.md
@@ -98,6 +98,7 @@ Dynamic resource discovery is supported for the following scrapers:
 - [Azure Database for PostgreSQL](metrics/postgresql)
 - [Azure Event Hubs](metrics/event-hubs)
 - [Azure Express Route Circuit](metrics/express-route-circuit)
+- [Azure Front Door](metrics/front-door)
 - [Azure Function App](metrics/function-app)
 - [Azure IoT Hub](metrics/iot-hub)
 - [Azure IoT Hub Device Provisioning Service (DPS)](metrics/iot-hub-device-provisioning-service)

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -30,6 +30,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new EventHubsDiscoveryQuery();
                 case ResourceType.ExpressRouteCircuit:
                     return new ExpressRouteCircuitDiscoveryQuery();
+                case ResourceType.FrontDoor:
+                    return new FrontDoorDiscoveryQuery();
                 case ResourceType.FunctionApp:
                     return new FunctionAppDiscoveryQuery();
                 case ResourceType.IoTHub:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/FrontDoorDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/FrontDoorDiscoveryQuery.cs
@@ -1,0 +1,22 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class FrontDoorDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/frontdoors" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var frontDoorName = resultRowEntry[3]?.ToString();
+            var resource = new FrontDoorResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), frontDoorName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -35,6 +35,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new ExpressRouteCircuitMetricsValidator();
                 case ResourceType.FileStorage:
                     return new FileStorageMetricValidator();
+                case ResourceType.FrontDoor:
+                    return new FrontDoorMetricValidator();
                 case ResourceType.FunctionApp:
                     return new FunctionAppMetricValidator();
                 case ResourceType.Generic:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/FrontDoorMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/FrontDoorMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class FrontDoorMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<FrontDoorResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.Name))
+                {
+                    yield return "No front door name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -33,6 +33,7 @@
         ApplicationGateway = 28,
         NetworkGateway = 29,
         KubernetesService = 30,
-        AutomationAccount = 31
+        AutomationAccount = 31,
+        FrontDoor = 32
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/FrontDoorResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/FrontDoorResourceDefinition.cs
@@ -1,0 +1,25 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    /// <summary>
+    ///     Represents files in an Azure Front Door resource.
+    /// </summary>
+    public class FrontDoorResourceDefinition : AzureResourceDefinition
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="FrontDoorResourceDefinition" /> class.
+        /// </summary>
+        /// <param name="subscriptionId">Specify a subscription to scrape that defers from the default subscription.</param>
+        /// <param name="resourceGroupName">The name of the resource group the server is in.</param>
+        /// <param name="name">The name of the Azure Front Door resource.</param>
+        public FrontDoorResourceDefinition(string subscriptionId, string resourceGroupName, string name)
+            : base(ResourceType.FrontDoor, subscriptionId, resourceGroupName, name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        ///     The name of the Azure Front Door resource.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -57,6 +57,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.FileStorage:
                     var fileStorageLogger = _loggerFactory.CreateLogger<FileStorageDeserializer>();
                     return new FileStorageDeserializer(fileStorageLogger);
+                case ResourceType.FrontDoor:
+                    var frontDoorDeserializer = _loggerFactory.CreateLogger<FrontDoorDeserializer>();
+                    return new FrontDoorDeserializer(frontDoorDeserializer);
                 case ResourceType.FunctionApp:
                     var functionAppLogger = _loggerFactory.CreateLogger<FunctionAppDeserializer>();
                     return new FunctionAppDeserializer(functionAppLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -35,6 +35,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<EventHubsResourceV1, EventHubResourceDefinition>();
             CreateMap<ExpressRouteCircuitResourceV1, ExpressRouteCircuitResourceDefinition>();
             CreateMap<FileStorageResourceV1, FileStorageResourceDefinition>();
+            CreateMap<FrontDoorResourceV1, FrontDoorResourceDefinition>();
             CreateMap<FunctionAppResourceV1, FunctionAppResourceDefinition>();
             CreateMap<GenericResourceV1, GenericAzureResourceDefinition>();
             CreateMap<IoTHubResourceV1, IoTHubResourceDefinition>();
@@ -73,6 +74,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<EventHubsResourceV1, EventHubResourceDefinition>()
                 .Include<ExpressRouteCircuitResourceV1, ExpressRouteCircuitResourceDefinition>()
                 .Include<FileStorageResourceV1, FileStorageResourceDefinition>()
+                .Include<FrontDoorResourceV1, FrontDoorResourceDefinition>()
                 .Include<FunctionAppResourceV1, FunctionAppResourceDefinition>()
                 .Include<GenericResourceV1, GenericAzureResourceDefinition>()
                 .Include<IoTHubResourceV1, IoTHubResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/FrontDoorResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/FrontDoorResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Front Door resource.
+    /// </summary>
+    public class FrontDoorResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Front Door resource to get metrics for.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FrontDoorDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/FrontDoorDeserializer.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    /// <summary>
+    /// Used to deserialize a <see cref="FrontDoorDeserializer" /> resource.
+    /// </summary>
+    public class FrontDoorDeserializer : ResourceDeserializer<FrontDoorResourceV1>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrontDoorDeserializer" /> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        public FrontDoorDeserializer(ILogger logger) : base(logger)
+        {
+            Map(resource => resource.Name)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -56,6 +56,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new ExpressRouteCircuitScraper(scraperConfiguration);
                 case ResourceType.FileStorage:
                     return new FileStorageScraper(scraperConfiguration);
+                case ResourceType.FrontDoor:
+                    return new FrontDoorScraper(scraperConfiguration);
                 case ResourceType.FunctionApp:
                     return new FunctionAppScraper(scraperConfiguration);
                 case ResourceType.Generic:

--- a/src/Promitor.Core.Scraping/ResourceTypes/FrontDoorScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/FrontDoorScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class FrontDoorScraper : AzureMonitorScraper<FrontDoorResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/frontdoors/{2}";
+
+        public FrontDoorScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, FrontDoorResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.Name);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -365,6 +365,23 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithFrontDoorMetric(string metricName = "promitor",
+            string metricDescription = "Description for a metric",
+            string name = "BackendHealthPercentage",
+            string azureMetricName = "Total",
+            string resourceDiscoveryGroupName = "",
+            bool omitResource = false)
+        {
+            var resource = new FrontDoorResourceV1
+            {
+                Name = name
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.FrontDoor, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, resource);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithBlobStorageMetric(string metricName = "promitor",
             string metricDescription = "Description for a metric",
             string accountName = "promitor-account",

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/FrontDoorDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/FrontDoorDeserializerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class FrontDoorDeserializerTests : ResourceDeserializerTest<FrontDoorDeserializer>
+    {
+        private readonly FrontDoorDeserializer _deserializer;
+
+        public FrontDoorDeserializerTests()
+        {
+            _deserializer = new FrontDoorDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_NameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<FrontDoorResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "name: promitor-front-door",
+                "promitor-front-door",
+                r => r.Name);
+        }
+
+        [Fact]
+        public void Deserialize_NameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<FrontDoorResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.Name);
+        }
+
+        [Fact]
+        public void Deserialize_NameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "name");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new FrontDoorDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/FrontDoorMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/FrontDoorMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,132 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class FrontDoorMetricsDeclarationValidationStepsTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutExpressRouteCircuitName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(name: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void FrontDoorMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithFrontDoorMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION
When implementing a new scraper; these tasks are completed:
- [x] Implement configuration
- [x] Implement validation
- [x] Implement scraping
- [x] Implement resource discovery
- [x] Test end-to-end
- [x] Document scraper
- [x] Add entry to changelog

**Metrics output:**
```
# HELP promitor_demo_frontdoor_backend_health_per_backend Health percentage for a backed in Azure Front Door
# TYPE promitor_demo_frontdoor_backend_health_per_backend gauge
promitor_demo_frontdoor_backend_health_per_backend{resource_group="promitor-landscape",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-landscape/providers/Microsoft.Network/frontdoors/promitor-landscape",instance_name="promitor-landscape",backend="promitor.io:443",app="promitor"} 100 1612809662196
# HELP promitor_demo_frontdoor_backend_health_per_backend_pool Health percentage for a backed in Azure Front Door
# TYPE promitor_demo_frontdoor_backend_health_per_backend_pool gauge
promitor_demo_frontdoor_backend_health_per_backend_pool{resource_group="promitor-landscape",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-landscape/providers/Microsoft.Network/frontdoors/promitor-landscape",instance_name="promitor-landscape",backendpool="promitor-landscape_Docs",app="promitor"} 100 1612809662999
```

**Discovery output:**
```json
[
  {
    "$type": "Promitor.Core.Contracts.ResourceTypes.FrontDoorResourceDefinition, Promitor.Core.Contracts",
    "Name": "promitor-landscape",
    "ResourceType": "FrontDoor",
    "SubscriptionId": "0f9d7fea-99e8-4768-8672-06a28514f77e",
    "ResourceGroupName": "promitor-landscape",
    "ResourceName": "promitor-landscape",
    "UniqueName": "promitor-landscape"
  }
]
```

Fixes #343 
