### PR TITLE
chore: Migrate to new Issue Forms YAML spec

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature_request.yml
@@ -3,23 +3,26 @@ about: Suggest an idea for this project
 labels: "feature-request"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Proposal
     description: "What would you like to have as a feature"
     placeholder: "A clear and concise description of what you want to happen."
-- type: multi_select
+- type: dropdown
   attributes:
     label: Component
     description: What Promitor agent are you having issues with?
-    required: true
-    choices:
+    multiple: true
+    options:
     - Resource Discovery
     - Scraper
+  validations:
+    required: true
 - type: input
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/1_feature_request_legacy.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature_request_legacy.yml
@@ -1,0 +1,25 @@
+name: Feature request 🧭
+about: Suggest an idea for this project
+labels: "feature-request"
+assignees: tomkerkhove
+issue_body: true
+inputs:
+- type: textarea
+  attributes:
+    label: Proposal
+    description: "What would you like to have as a feature"
+    placeholder: "A clear and concise description of what you want to happen."
+- type: multi_select
+  attributes:
+    label: Component
+    description: What Promitor agent are you having issues with?
+    required: true
+    choices:
+    - Resource Discovery
+    - Scraper
+- type: input
+  attributes:
+    label: Contact Details
+    description: How can we get in touch with you if we need more info?
+    required: false
+    placeholder: ex. email@example.com

--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -3,7 +3,7 @@ about: Create a report to help us improve
 labels: "bug"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Report
@@ -13,14 +13,16 @@ inputs:
   attributes:
     label: Expected Behavior
     description: What did you expect to happen?
-    required: true
     placeholder: What did you expect to happen?
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Actual Behavior
     description: Also tell us, what did you see is happen?
-    required: true
     placeholder: Tell us what you see that is happening
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Steps to Reproduce the Problem
@@ -30,19 +32,23 @@ inputs:
       2.
       3.
       ...
+  validations:
     required: true
-- type: multi_select
+- type: dropdown
   attributes:
     label: Component
     description: What Promitor agent are you having issues with?
-    required: true
-    choices:
+    multiple: true
+    options:
     - Resource Discovery
     - Scraper
+  validations:
+    required: true
 - type: input
   attributes:
     label: Version
     description: What version are you running?
+  validations:
     required: true
 - type: textarea
   attributes:
@@ -54,7 +60,8 @@ inputs:
       ```yaml
       # Add your scraping configuration here
       ```
-    required: false    
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Logs
@@ -63,22 +70,25 @@ inputs:
       ```shell
       example
       ```
+  validations:
     required: false
 - type: dropdown
   attributes:
     label: Platform
     description: Where is your cluster running?
-    required: false
-    choices:
+    options:
     - Alibaba Cloud
     - Amazon Web Services
     - Google Cloud
     - Microsoft Azure
     - Red Hat OpenShift
     - Other
+  validations:
+    required: false
 - type: input
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/2_bug_report_legacy.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_legacy.yml
@@ -1,0 +1,84 @@
+name: Report a bug 🐛
+about: Create a report to help us improve
+labels: "bug"
+assignees: tomkerkhove
+issue_body: true
+inputs:
+- type: textarea
+  attributes:
+    label: Report
+    description: "What bug have you encountered?"
+    placeholder: "A clear and concise description of what the bug is."
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: What did you expect to happen?
+    required: true
+    placeholder: What did you expect to happen?
+- type: textarea
+  attributes:
+    label: Actual Behavior
+    description: Also tell us, what did you see is happen?
+    required: true
+    placeholder: Tell us what you see that is happening
+- type: textarea
+  attributes:
+    label: Steps to Reproduce the Problem
+    description: "How can we reproduce this bug? Please walk us through it step by step."
+    value: |
+      1.
+      2.
+      3.
+      ...
+    required: true
+- type: multi_select
+  attributes:
+    label: Component
+    description: What Promitor agent are you having issues with?
+    required: true
+    choices:
+    - Resource Discovery
+    - Scraper
+- type: input
+  attributes:
+    label: Version
+    description: What version are you running?
+    required: true
+- type: textarea
+  attributes:
+    label: Configuration
+    description: "Provide insights in the configuration that you are using, if you can share them"
+    value: |
+      Configuration:
+
+      ```yaml
+      # Add your scraping configuration here
+      ```
+    required: false    
+- type: textarea
+  attributes:
+    label: Logs
+    description: "Provide logs of our component, if you can share them"
+    value: |
+      ```shell
+      example
+      ```
+    required: false
+- type: dropdown
+  attributes:
+    label: Platform
+    description: Where is your cluster running?
+    required: false
+    choices:
+    - Alibaba Cloud
+    - Amazon Web Services
+    - Google Cloud
+    - Microsoft Azure
+    - Red Hat OpenShift
+    - Other
+- type: input
+  attributes:
+    label: Contact Details
+    description: How can we get in touch with you if we need more info?
+    required: false
+    placeholder: ex. email@example.com

--- a/.github/ISSUE_TEMPLATE/3_security_issue.yml
+++ b/.github/ISSUE_TEMPLATE/3_security_issue.yml
@@ -3,7 +3,7 @@ about: Report security vulnerability impacting users
 labels: security
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Report
@@ -13,33 +13,40 @@ inputs:
   attributes:
     label: Vulnerability Information
     description: Are there official sources listing the vulnerability? For example, the National Vulnurability Database or similar.
+  validations:
     required: false
-- type: multi_select
+- type: dropdown
   attributes:
     label: Affected Component(s)
     description: What Promitor components are impacted?
-    required: true
-    choices:
+    multiple: true
+    options:
     - Resource Discovery
     - Scraper
+  validations:
+    required: true
 - type: input
   attributes:
     label: Affected Version(s)
     description: What version(s) are impacted?
+  validations:
     required: true
 - type: textarea
   attributes:
     label: Vulnerability Migitation
     description: "What are the options to mitigate the vulnerability?"
+  validations:
     required: false
 - type: textarea
   attributes:
     label: Vulnerability Fix
     description: "What are the options to patch the vulnerability?"
+  validations:
     required: false
 - type: input
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/3_security_issue_legacy.yml
+++ b/.github/ISSUE_TEMPLATE/3_security_issue_legacy.yml
@@ -1,0 +1,45 @@
+name: Security Report 🔐
+about: Report security vulnerability impacting users
+labels: security
+assignees: tomkerkhove
+issue_body: true
+inputs:
+- type: textarea
+  attributes:
+    label: Report
+    description: What is the vulnerability and how does it affect Promitor?
+    placeholder: A clear and concise description of how the security issue affects this project
+- type: input
+  attributes:
+    label: Vulnerability Information
+    description: Are there official sources listing the vulnerability? For example, the National Vulnurability Database or similar.
+    required: false
+- type: multi_select
+  attributes:
+    label: Affected Component(s)
+    description: What Promitor components are impacted?
+    required: true
+    choices:
+    - Resource Discovery
+    - Scraper
+- type: input
+  attributes:
+    label: Affected Version(s)
+    description: What version(s) are impacted?
+    required: true
+- type: textarea
+  attributes:
+    label: Vulnerability Migitation
+    description: "What are the options to mitigate the vulnerability?"
+    required: false
+- type: textarea
+  attributes:
+    label: Vulnerability Fix
+    description: "What are the options to patch the vulnerability?"
+    required: false
+- type: input
+  attributes:
+    label: Contact Details
+    description: How can we get in touch with you if we need more info?
+    required: false
+    placeholder: ex. email@example.com

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a question 💬
     url: https://github.com/tomkerkhove/promitor/discussions/new


### PR DESCRIPTION
Migrate to new Issue Forms YAML spec as per https://gh-community.github.io/issue-template-feedback/changes/ which is taking affect tomorrow.