### PR TITLE
Provide capability to transform metric labels in Prometheus

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,7 +6,8 @@ version:
 
 #### Scraper
 
-None.
+- {{% tag added %}} Provide capability to transform metric labels in Prometheus ([docs](https://promitor.io/configuration/v2.x/runtime/scraper#prometheus-scraping-endpoint)
+ | [#1596](https://github.com/tomkerkhove/promitor/issues/1596))
 
 #### Resource Discovery
 

--- a/docs/configuration/v2.x/runtime/scraper.md
+++ b/docs/configuration/v2.x/runtime/scraper.md
@@ -30,6 +30,8 @@ metricSinks:
     metricUnavailableValue: NaN # Optional. Default: NaN
     enableMetricTimestamps: false # Optional. Default: true
     baseUriPath: /metrics # Optional. Default: /metrics
+    labels:
+      transformation: None # Optional. Default: None.
   statsd:
     host: graphite
     port: 8125 # Optional. Default: 8125
@@ -135,8 +137,10 @@ In order to expose a Prometheus Scraping endpoint, you'll need to configure the 
 - `prometheusScrapingEndpoint.enableMetricTimestamps` - Defines whether or not a timestamp should
   be included when the value was scraped on Azure Monitor. Supported values are
   `True` to opt-in & `False` to opt-out. (Default: `true`)
-- `prometheusScrapingEndpoint.scrapeEndpoint.baseUriPath` - Controls the path where the scraping
+- `prometheusScrapingEndpoint.baseUriPath` - Controls the path where the scraping
   endpoint for Prometheus is being exposed.  (Default: `/metrics`)
+- `prometheusScrapingEndpoint.labels.transformation` - Controls how label values are reported to Prometheus by using
+ transformation. Options are `None` & `Lowercase`.  (Default: `None`)
 
 ```yaml
 metricSinks:
@@ -144,6 +148,8 @@ metricSinks:
     metricUnavailableValue: NaN # Optional. Default: NaN
     enableMetricTimestamps: false # Optional. Default: true
     baseUriPath: /metrics # Optional. Default: /metrics
+    labels:
+      transformation: None # Optional. Default: None.
 ```
 
 #### What happens when metrics are unavailable for multi-dimensional metrics?

--- a/src/Promitor.Integrations.Sinks.Prometheus/Configuration/LabelConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Configuration/LabelConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Promitor.Integrations.Sinks.Prometheus.Configuration
+{
+    public class LabelConfiguration
+    {
+        public LabelTransformation Transformation { get; set; } = Defaults.Prometheus.LabelTransformation;
+    }
+}

--- a/src/Promitor.Integrations.Sinks.Prometheus/Configuration/LabelTransformation.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Configuration/LabelTransformation.cs
@@ -1,0 +1,8 @@
+﻿namespace Promitor.Integrations.Sinks.Prometheus.Configuration
+{
+    public enum LabelTransformation
+    {
+        None,
+        Lowercase
+    }
+}

--- a/src/Promitor.Integrations.Sinks.Prometheus/Configuration/PrometheusScrapingEndpointSinkConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Configuration/PrometheusScrapingEndpointSinkConfiguration.cs
@@ -5,5 +5,6 @@
         public string BaseUriPath { get; set; } = Defaults.Prometheus.ScrapeEndpointBaseUri;
         public double? MetricUnavailableValue { get; set; } = Defaults.Prometheus.MetricUnavailableValue;
         public bool EnableMetricTimestamps { get; set; } = Defaults.Prometheus.EnableMetricTimestamps;
+        public LabelConfiguration Labels { get; set; } = new LabelConfiguration();
     }
 }

--- a/src/Promitor.Integrations.Sinks.Prometheus/Defaults.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Defaults.cs
@@ -1,4 +1,6 @@
-﻿namespace Promitor.Integrations.Sinks.Prometheus
+﻿using Promitor.Integrations.Sinks.Prometheus.Configuration;
+
+namespace Promitor.Integrations.Sinks.Prometheus
 {
     public static class Defaults
     {
@@ -7,6 +9,7 @@
             public static bool EnableMetricTimestamps { get; set; } = false;
             public static double MetricUnavailableValue { get; } = double.NaN;
             public static string ScrapeEndpointBaseUri { get; } = "/metrics";
+            public static LabelTransformation LabelTransformation { get; } = LabelTransformation.None;
         }
     }
 }

--- a/src/Promitor.Integrations.Sinks.Prometheus/Labels/LabelTransformer.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Labels/LabelTransformer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Promitor.Integrations.Sinks.Prometheus.Configuration;
+
+namespace Promitor.Integrations.Sinks.Prometheus.Labels
+{
+    public static class LabelTransformer
+    {
+        public static Dictionary<string, string> TransformLabels(LabelTransformation transformation, Dictionary<string, string> labels)
+        {
+            switch (transformation)
+            {
+                case LabelTransformation.None:
+                    return labels;
+                case LabelTransformation.Lowercase:
+                    return TransformToLowercase(labels);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private static Dictionary<string, string> TransformToLowercase(Dictionary<string, string> labels)
+        {
+            Dictionary<string, string> transformedLabels = new Dictionary<string, string>();
+
+            foreach (KeyValuePair<string, string> label in labels)
+            {
+                transformedLabels.Add(label.Key, label.Value.ToLower());
+            }
+
+            return transformedLabels;
+        }
+    }
+}

--- a/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
@@ -12,6 +12,7 @@ using Promitor.Core.Metrics.Sinks;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Integrations.Sinks.Prometheus.Configuration;
+using Promitor.Integrations.Sinks.Prometheus.Labels;
 
 namespace Promitor.Integrations.Sinks.Prometheus
 {
@@ -106,6 +107,12 @@ namespace Promitor.Integrations.Sinks.Prometheus
 
                     labels.Add(customLabelKey, customLabel.Value);
                 }
+            }
+
+            // Transform labels, if need be
+            if(_prometheusConfiguration.CurrentValue.Labels!=null)
+            {
+                labels = LabelTransformer.TransformLabels(_prometheusConfiguration.CurrentValue.Labels.Transformation,labels);
             }
 
             return labels;

--- a/src/Promitor.Tests.Unit/Agents/Core/UserAgentTests.cs
+++ b/src/Promitor.Tests.Unit/Agents/Core/UserAgentTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Agents.Core
 {
-    public class UserAgentTest
+    public class UserAgentTest : UnitTest
     {
         [Theory]
         [InlineData(null)]

--- a/src/Promitor.Tests.Unit/Azure/AzureAuthenticationFactoryUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureAuthenticationFactoryUnitTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Azure
 {
     [Category("Unit")]
-    public class AzureAuthenticationFactoryUnitTests
+    public class AzureAuthenticationFactoryUnitTests : UnitTest
     {
         [Fact]
         public void GetConfiguredAzureAuthentication_SystemAssignedManagedIdentityIsValid_Succeeds()

--- a/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Azure
 {
     [Category("Unit")]
-    public class AzureCloudUnitTests
+    public class AzureCloudUnitTests : UnitTest
     {
         [Fact]
         public void GetAzureEnvironment_ForAzureGlobalCloud_ProvidesCorrectEnvironmentInfo()

--- a/src/Promitor.Tests.Unit/Clients/AtlassianStatuspageClientTests.cs
+++ b/src/Promitor.Tests.Unit/Clients/AtlassianStatuspageClientTests.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -15,17 +14,15 @@ using Xunit;
 namespace Promitor.Tests.Unit.Clients
 {
     [Category("Unit")]
-    public class AtlassianStatuspageClientTests
+    public class AtlassianStatuspageClientTests : UnitTest
     {
-        private readonly Faker _bogus = new Faker();
-
         [Fact]
         public async Task ReportMetricAsync_MetricIdAndValueAreProvided_Succeeds()
         {
             // Arrange
-            var pageId = _bogus.Name.FirstName();
-            var metricId = _bogus.Name.FirstName();
-            var metricValue = _bogus.Random.Double();
+            var pageId = BogusGenerator.Name.FirstName();
+            var metricId = BogusGenerator.Name.FirstName();
+            var metricValue = BogusGenerator.Random.Double();
             var fakeHttpMessageHandler = new HttpMessageHandlerStub();
             var sinkConfiguration = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration(pageId: pageId);
             var atlassianStatuspageClient = new AtlassianStatuspageClient(httpClient: new HttpClient(fakeHttpMessageHandler), sinkConfiguration, NullLogger<AtlassianStatuspageClient>.Instance);
@@ -47,7 +44,7 @@ namespace Promitor.Tests.Unit.Clients
         public async Task ReportMetricAsync_NoMetricIdIsProvided_ThrowsException()
         {
             // Arrange
-            var metricValue = _bogus.Random.Double();
+            var metricValue = BogusGenerator.Random.Double();
             var httpClientMock = new Mock<HttpClient>();
             var sinkConfiguration = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration();
             var atlassianStatuspageClient = new AtlassianStatuspageClient(httpClient: httpClientMock.Object, sinkConfiguration, NullLogger<AtlassianStatuspageClient>.Instance);

--- a/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Threading.Tasks;
-using Bogus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Promitor.Agents.Scraper.Configuration;
@@ -11,10 +10,8 @@ using Defaults = Promitor.Agents.Scraper.Configuration.Defaults;
 namespace Promitor.Tests.Unit.Configuration
 {
     [Category("Unit")]
-    public class RuntimeConfigurationUnitTes
+    public class RuntimeConfigurationUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -57,7 +54,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredApplicationInsightsInstrumentationKey_UsesConfigured()
         {
             // Arrange
-            var instrumentationKey = _faker.Random.Guid().ToString();
+            var instrumentationKey = BogusGenerator.Random.Guid().ToString();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithApplicationInsightsTelemetry(instrumentationKey)
                 .GenerateAsync();
@@ -129,7 +126,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredHttpPort_UsesConfigured()
         {
             // Arrange
-            var bogusHttpPort = _faker.Random.Int();
+            var bogusHttpPort = BogusGenerator.Random.Int();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration(bogusHttpPort)
                 .GenerateAsync();
 
@@ -166,7 +163,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredMetricUnavailableValueInPrometheusScrapeEndpointSink_UsesConfigured()
         {
             // Arrange
-            var metricUnavailableValue = _faker.Random.Double(min: 1);
+            var metricUnavailableValue = BogusGenerator.Random.Double(min: 1);
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithPrometheusMetricSink(metricUnavailableValue: metricUnavailableValue)
                 .GenerateAsync();
@@ -185,7 +182,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredPrometheusScrapeEndpointSinkConfigured_UsesConfigured()
         {
             // Arrange
-            var scrapeEndpointBaseUri = _faker.System.DirectoryPath();
+            var scrapeEndpointBaseUri = BogusGenerator.System.DirectoryPath();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithPrometheusMetricSink(scrapeEndpointBaseUri: scrapeEndpointBaseUri)
                 .GenerateAsync();
@@ -204,7 +201,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredHostInStatsDEndpoint_UsesConfigured()
         {
             // Arrange
-            var statsdHost = _faker.System.DirectoryPath();
+            var statsdHost = BogusGenerator.System.DirectoryPath();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithStatsDMetricSink(host: statsdHost)
                 .GenerateAsync();
@@ -223,7 +220,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredMetricPrefixInStatsDEndpoint_UsesConfigured()
         {
             // Arrange
-            var metricPrefix = _faker.Name.FirstName();
+            var metricPrefix = BogusGenerator.Name.FirstName();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithStatsDMetricSink(metricPrefix: metricPrefix)
                 .GenerateAsync();
@@ -242,7 +239,7 @@ namespace Promitor.Tests.Unit.Configuration
         public async Task RuntimeConfiguration_HasConfiguredPortInStatsDEndpoint_UsesConfigured()
         {
             // Arrange
-            var port = _faker.Random.Int();
+            var port = BogusGenerator.Random.Int();
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
                 .WithStatsDMetricSink(port: port)
                 .GenerateAsync();

--- a/src/Promitor.Tests.Unit/Discovery/Query/AppServiceResourceDiscoveryQueryUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Discovery/Query/AppServiceResourceDiscoveryQueryUnitTest.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
-using Bogus;
 using Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes;
 using Xunit;
 
 namespace Promitor.Tests.Unit.Discovery.Query
 {
     [Category("Unit")]
-    public class AppServiceResourceDiscoveryQueryUnitTest
+    public class AppServiceResourceDiscoveryQueryUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Fact]
         public void DetermineAppDetails_FunctionAppWithoutSlot_ProvidesAppNameWithDefaultSlot()
         {
             // Arrange
-            var functionAppName = _faker.Name.FirstName();
+            var functionAppName = BogusGenerator.Name.FirstName();
             var functionAppDiscoveryQuery = new FunctionAppDiscoveryQuery();
 
             // Act
@@ -30,8 +27,8 @@ namespace Promitor.Tests.Unit.Discovery.Query
         public void DetermineAppDetails_FunctionAppWithSlot_ProvidesAppNameWithDefaultSlot()
         {
             // Arrange
-            var appName = _faker.Name.FirstName();
-            var slotName = _faker.Name.FirstName();
+            var appName = BogusGenerator.Name.FirstName();
+            var slotName = BogusGenerator.Name.FirstName();
             var functionAppName = $"{appName}/{slotName}";
             var functionAppDiscoveryQuery = new FunctionAppDiscoveryQuery();
 
@@ -59,7 +56,7 @@ namespace Promitor.Tests.Unit.Discovery.Query
         public void DetermineAppDetails_WebAppWithoutSlot_ProvidesAppNameWithDefaultSlot()
         {
             // Arrange
-            var webAppName = _faker.Name.FirstName();
+            var webAppName = BogusGenerator.Name.FirstName();
             var webAppDiscoveryQuery = new WebAppDiscoveryQuery();
 
             // Act
@@ -74,8 +71,8 @@ namespace Promitor.Tests.Unit.Discovery.Query
         public void DetermineAppDetails_WebAppWithSlot_ProvidesAppNameWithDefaultSlot()
         {
             // Arrange
-            var appName = _faker.Name.FirstName();
-            var slotName = _faker.Name.FirstName();
+            var appName = BogusGenerator.Name.FirstName();
+            var slotName = BogusGenerator.Name.FirstName();
             var webAppName = $"{appName}/{slotName}";
             var webAppDiscoveryQuery = new WebAppDiscoveryQuery();
 

--- a/src/Promitor.Tests.Unit/Discovery/Query/SqlDatabaseResourceDiscoveryQueryUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Discovery/Query/SqlDatabaseResourceDiscoveryQueryUnitTest.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
-using Bogus;
 using Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes;
 using Xunit;
 
 namespace Promitor.Tests.Unit.Discovery.Query
 {
     [Category("Unit")]
-    public class SqlDatabaseResourceDiscoveryQueryUnitTest
+    public class SqlDatabaseResourceDiscoveryQueryUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Fact]
         public void GetParentResourceNameFromResourceUri_ValidResourceUri_GetsServerName()
         {
             // Arrange
-            var serverName = _faker.Name.FirstName();
+            var serverName = BogusGenerator.Name.FirstName();
             var resourceUri = $"/subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Sql/servers/{serverName}/databases/promitor-3";
             var sqlDatabaseDiscoveryQuery = new SqlDatabaseDiscoveryQuery();
 

--- a/src/Promitor.Tests.Unit/Discovery/Query/SqlElasticPoolDiscoveryQueryUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Discovery/Query/SqlElasticPoolDiscoveryQueryUnitTest.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
-using Bogus;
 using Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes;
 using Xunit;
 
 namespace Promitor.Tests.Unit.Discovery.Query
 {
     [Category("Unit")]
-    public class SqlElasticPoolDiscoveryQueryUnitTest
+    public class SqlElasticPoolDiscoveryQueryUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Fact]
         public void GetParentResourceNameFromResourceUri_ValidResourceUri_GetsServerName()
         {
             // Arrange
-            var serverName = _faker.Name.FirstName();
+            var serverName = BogusGenerator.Name.FirstName();
             var resourceUri = $"/subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.Sql/servers/{serverName}/elasticpools/promitor-pool";
             var elasticPoolDiscoveryQuery = new SqlElasticPoolDiscoveryQuery();
 

--- a/src/Promitor.Tests.Unit/Discovery/Query/SynapseApacheSparkPoolDiscoveryQueryUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Discovery/Query/SynapseApacheSparkPoolDiscoveryQueryUnitTest.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
-using Bogus;
 using Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes;
 using Xunit;
 
 namespace Promitor.Tests.Unit.Discovery.Query
 {
     [Category("Unit")]
-    public class SynapseApacheSparkPoolDiscoveryQueryUnitTest
+    public class SynapseApacheSparkPoolDiscoveryQueryUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Fact]
         public void GetParentResourceNameFromResourceUri_ValidResourceUri_GetsServerName()
         {
             // Arrange
-            var workspaceName = _faker.Name.FirstName();
+            var workspaceName = BogusGenerator.Name.FirstName();
             var resourceUri = $"/subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/sparkpool";
             var apacheSparkPoolDiscoveryQuery = new SynapseApacheSparkPoolDiscoveryQuery();
 

--- a/src/Promitor.Tests.Unit/Discovery/Query/SynapseSqlPoolDiscoveryQueryUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Discovery/Query/SynapseSqlPoolDiscoveryQueryUnitTest.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
-using Bogus;
 using Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes;
 using Xunit;
 
 namespace Promitor.Tests.Unit.Discovery.Query
 {
     [Category("Unit")]
-    public class SynapseSqlPoolDiscoveryQueryUnitTest
+    public class SynapseSqlPoolDiscoveryQueryUnitTest : UnitTest
     {
-        private readonly Faker _faker = new Faker();
-
         [Fact]
         public void GetParentResourceNameFromResourceUri_ValidResourceUri_GetsServerName()
         {
             // Arrange
-            var workspaceName = _faker.Name.FirstName();
+            var workspaceName = BogusGenerator.Name.FirstName();
             var resourceUri = $"/subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/sqlpool";
             var sqlPoolDiscoveryQuery = new SynapseSqlPoolDiscoveryQuery();
 

--- a/src/Promitor.Tests.Unit/Generators/Config/BogusScraperRuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/BogusScraperRuntimeConfigurationGenerator.cs
@@ -144,11 +144,16 @@ namespace Promitor.Tests.Unit.Generators.Config
 
         private static PrometheusScrapingEndpointSinkConfiguration GeneratePrometheusScrapingEndpointSinkConfiguration()
         {
+            var prometheusLabelConfiguration = new Faker<LabelConfiguration>()
+                .StrictMode(true)
+                .RuleFor(labelConfiguration => labelConfiguration.Transformation, faker => faker.PickRandom<LabelTransformation>())
+                .Generate();
             var prometheusScrapingEndpointSinkConfiguration = new Faker<PrometheusScrapingEndpointSinkConfiguration>()
                 .StrictMode(true)
                 .RuleFor(promConfiguration => promConfiguration.BaseUriPath, faker => faker.System.DirectoryPath())
                 .RuleFor(promConfiguration => promConfiguration.MetricUnavailableValue, faker => faker.Random.Double(min: 1))
                 .RuleFor(promConfiguration => promConfiguration.EnableMetricTimestamps, faker => faker.Random.Bool())
+                .RuleFor(promConfiguration => promConfiguration.Labels, faker => prometheusLabelConfiguration)
                 .Generate();
             return prometheusScrapingEndpointSinkConfiguration;
         }

--- a/src/Promitor.Tests.Unit/Metrics/MetricSinkWriterTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MetricSinkWriterTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Bogus;
 using JustEat.StatsD;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -15,18 +14,16 @@ using Xunit;
 namespace Promitor.Tests.Unit.Metrics
 {
     [Category("Unit")]
-    public class MetricSinkWriterTests
+    public class MetricSinkWriterTests : UnitTest
     {
-        private readonly Faker _bogus = new Faker();
-        
         [Theory]
         [InlineData("")]
         [InlineData(null)]
         public async Task ReportMetricAsync_WriteToOneSinkWithoutMetricName_ThrowsException(string metricName)
         {
             // Arrange
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricSink = new Mock<IMetricSink>();
             var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink> { metricSink.Object }, NullLogger<MetricSinkWriter>.Instance);
@@ -42,8 +39,8 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToOneSinkWithoutMetricDescription_Succeeds(string metricDescription)
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricSink = new Mock<IMetricSink>();
             var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink> { metricSink.Object }, NullLogger<MetricSinkWriter>.Instance);
@@ -56,8 +53,8 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToOneSinkWithoutScrapeResult_ThrowsException()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             ScrapeResult scrapeResult = null;
             var metricSink = new Mock<IMetricSink>();
             var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink> { metricSink.Object }, NullLogger<MetricSinkWriter>.Instance);
@@ -71,9 +68,9 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToNoSinks_Succeeds()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink>(), NullLogger<MetricSinkWriter>.Instance);
 
@@ -85,9 +82,9 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToOneSink_Succeeds()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricSink = new Mock<IMetricSink>();
             var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink> { metricSink.Object }, NullLogger<MetricSinkWriter>.Instance);
@@ -103,9 +100,9 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToMultipleSinks_Succeeds()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var firstSink = new Mock<IMetricSink>();
             var secondSink = new Mock<IMetricSink>();
@@ -123,9 +120,9 @@ namespace Promitor.Tests.Unit.Metrics
         public async Task ReportMetricAsync_WriteToStatsDSink_Succeeds()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
             var statsdMetricSink = new StatsdMetricSink(statsDPublisherMock.Object, NullLogger<StatsdMetricSink>.Instance);

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/AtlassianStatuspageMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/AtlassianStatuspageMetricSinkTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Promitor.Core.Metrics;
@@ -13,18 +12,16 @@ using Xunit;
 namespace Promitor.Tests.Unit.Metrics.Sinks
 {
     [Category("Unit")]
-    public class AtlassianStatuspageMetricSinkTests
+    public class AtlassianStatuspageMetricSinkTests : UnitTest
     {
-        private readonly Faker _bogus = new Faker();
-
         [Theory]
         [InlineData("")]
         [InlineData(null)]
         public async Task ReportMetricAsync_InputDoesNotContainMetricName_ThrowsException(string metricName)
         {
             // Arrange
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var systemMetricConfigOptions = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration();
             var atlassianStatuspageClientMock = new Mock<IAtlassianStatuspageClient>();
@@ -41,8 +38,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMetricDescription_Succeeds(string metricDescription)
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricValue = BogusGenerator.Random.Double();
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
             var systemMetricConfigOptions = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration();
@@ -58,8 +55,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMeasuredMetric_ThrowsException()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             var systemMetricConfigOptions = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration();
             var atlassianStatuspageClientMock = new Mock<IAtlassianStatuspageClient>();
             var metricSink = new AtlassianStatuspageMetricSink(atlassianStatuspageClientMock.Object, systemMetricConfigOptions, NullLogger<AtlassianStatuspageMetricSink>.Instance);
@@ -73,10 +70,10 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithMetricValueAndPromitorToSystemMetricMapping_SuccessfullyWritesMetric()
         {
             // Arrange
-            var promitorMetricName = _bogus.Name.FirstName();
-            var systemMetricId = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var promitorMetricName = BogusGenerator.Name.FirstName();
+            var systemMetricId = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
             var systemMetricConfigOptions = BogusAtlassianStatuspageMetricSinkConfigurationGenerator.GetSinkConfiguration(systemMetricId: systemMetricId, promitorMetricName: promitorMetricName);
@@ -95,9 +92,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         {
             // Arrange
             const double expectedDefaultValue = 0;
-            var promitorMetricName = _bogus.Name.FirstName();
-            var systemMetricId = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var promitorMetricName = BogusGenerator.Name.FirstName();
+            var systemMetricId = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             double? metricValue = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
@@ -118,9 +115,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         {
             // Arrange
             const double expectedDefaultValue = 0;
-            var promitorMetricName = _bogus.Name.FirstName();
-            var systemMetricId = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var promitorMetricName = BogusGenerator.Name.FirstName();
+            var systemMetricId = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             double? metricValue = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.Internal;
-using Bogus;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -23,18 +22,16 @@ using Xunit;
 namespace Promitor.Tests.Unit.Metrics.Sinks
 {
     [Category("Unit")]
-    public class PrometheusScrapingEndpointMetricSinkTests
+    public class PrometheusScrapingEndpointMetricSinkTests : UnitTest
     {
-        private readonly Faker _bogus = new Faker();
-
         [Theory]
         [InlineData("")]
         [InlineData(null)]
         public async Task ReportMetricAsync_InputDoesNotContainMetricName_ThrowsException(string metricName)
         {
             // Arrange
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
             var prometheusConfiguration = CreatePrometheusConfiguration();
@@ -52,8 +49,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMetricDescription_Succeeds(string metricDescription)
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
             var prometheusConfiguration = CreatePrometheusConfiguration();
@@ -69,8 +66,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMeasuredMetric_ThrowsException()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
             var prometheusConfiguration = CreatePrometheusConfiguration();
             var metricFactoryMock = CreatePrometheusMetricFactoryMock();
@@ -85,9 +82,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithMetricValue_SuccessfullyWritesMetric()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
             var prometheusConfiguration = CreatePrometheusConfiguration();
@@ -107,10 +104,10 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithTwoMetricValues_SuccessfullyWritesMultipleMetrics()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var firstMetricValue = _bogus.Random.Double();
-            var secondMetricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var firstMetricValue = BogusGenerator.Random.Double();
+            var secondMetricValue = BogusGenerator.Random.Double();
             var firstMetric = MeasuredMetric.CreateWithoutDimension(firstMetricValue);
             var secondMetric = MeasuredMetric.CreateWithoutDimension(secondMetricValue);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(firstMetric);
@@ -134,12 +131,12 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithTwoMetricValuesOfWhichOneIsMultiDimensional_SuccessfullyWritesMultipleMetrics()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var firstMetricValue = _bogus.Random.Double();
-            var secondMetricValue = _bogus.Random.Double();
-            var dimensionName = _bogus.Name.FirstName();
-            var dimensionValue = _bogus.Name.FirstName();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var firstMetricValue = BogusGenerator.Random.Double();
+            var secondMetricValue = BogusGenerator.Random.Double();
+            var dimensionName = BogusGenerator.Name.FirstName();
+            var dimensionValue = BogusGenerator.Name.FirstName();
             var expectedDimensionName = dimensionName.ToLower();
             var timeSeries = new TimeSeriesElement
             {
@@ -170,9 +167,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithUpperCaseLabelNames_SuccessfullyWritesMetricWithLowercaseLabels()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var mutatedLabels = scrapeResult.Labels.ToDictionary(kvp => kvp.Key.ToUpper(), kvp => kvp.Value);
             scrapeResult.Labels.Clear();
@@ -197,9 +194,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithMetricValueAndTimestampFlag_SuccessfullyWritesMetricWithRespectToTimestampFlag(bool includeTimestampsInMetrics)
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
             var prometheusConfiguration = CreatePrometheusConfiguration(enableMetricsTimestamps: includeTimestampsInMetrics);
@@ -223,8 +220,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         {
             // Arrange
             double expectedMeasuredMetric = expectedDefaultValue??double.NaN; // If nothing is configured, NaN is used.
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             double? metricValue = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
@@ -247,11 +244,11 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithOneDimensions_SuccessfullyWritesMetric()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
-            var dimensionName = _bogus.Name.FirstName();
-            var dimensionValue = _bogus.Name.FirstName();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
+            var dimensionName = BogusGenerator.Name.FirstName();
+            var dimensionValue = BogusGenerator.Name.FirstName();
             var expectedDimensionName = dimensionName.ToLower();
             var timeSeries = new TimeSeriesElement
             {
@@ -277,13 +274,13 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithDefaultMetricLabelsConfigured_SuccessfullyWritesMetric()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
-            var firstLabelName = _bogus.Name.FirstName();
-            var secondLabelName = _bogus.Name.FirstName();
-            var firstLabelValue = _bogus.Name.FirstName();
-            var secondLabelValue = _bogus.Name.FirstName();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
+            var firstLabelName = BogusGenerator.Name.FirstName();
+            var secondLabelName = BogusGenerator.Name.FirstName();
+            var firstLabelValue = BogusGenerator.Name.FirstName();
+            var secondLabelValue = BogusGenerator.Name.FirstName();
             var expectedFirstLabelName = firstLabelName.ToLower();
             var expectedSecondLabelName = secondLabelName.ToLower();
             var configuredLabels = new Dictionary<string, string>
@@ -310,12 +307,12 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithMetricLabelWithSameKeyAsScrapeResult_SuccessfullyWritesMetricWithLabelValueFromScrapeResult()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
-            var labelName = _bogus.Name.FirstName();
-            var scrapeResultLabelValue = _bogus.Name.FirstName();
-            var metricConfigLabelValue = _bogus.Name.FirstName();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
+            var labelName = BogusGenerator.Name.FirstName();
+            var scrapeResultLabelValue = BogusGenerator.Name.FirstName();
+            var metricConfigLabelValue = BogusGenerator.Name.FirstName();
             var expectedLabelName = labelName.ToLower();
             var configuredLabels = new Dictionary<string, string>
             {

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Bogus;
 using JustEat.StatsD;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -13,18 +12,16 @@ using Xunit;
 namespace Promitor.Tests.Unit.Metrics.Sinks
 {
     [Category("Unit")]
-    public class StatsDMetricSinkTests
+    public class StatsDMetricSinkTests : UnitTest
     {
-        private readonly Faker _bogus = new Faker();
-
         [Theory]
         [InlineData("")]
         [InlineData(null)]
         public async Task ReportMetricAsync_InputDoesNotContainMetricName_ThrowsException(string metricName)
         {
             // Arrange
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var scrapeResult = ScrapeResultGenerator.Generate(metricValue);
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
             var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, NullLogger<StatsdMetricSink>.Instance);
@@ -40,8 +37,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMetricDescription_Succeeds(string metricDescription)
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricValue = BogusGenerator.Random.Double();
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
@@ -56,8 +53,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_InputDoesNotContainMeasuredMetric_ThrowsException()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
             var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, NullLogger<StatsdMetricSink>.Instance);
 
@@ -70,9 +67,9 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         public async Task ReportMetricAsync_GetsValidInputWithMetricValue_SuccessfullyWritesMetric()
         {
             // Arrange
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
-            var metricValue = _bogus.Random.Double();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
@@ -90,8 +87,8 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         {
             // Arrange
             const double expectedDefaultValue = 0;
-            var metricName = _bogus.Name.FirstName();
-            var metricDescription = _bogus.Lorem.Sentence();
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
             double? metricValue = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             var measuredMetric = MeasuredMetric.CreateWithoutDimension(metricValue);

--- a/src/Promitor.Tests.Unit/Prometheus/LabelTransformerTests.cs
+++ b/src/Promitor.Tests.Unit/Prometheus/LabelTransformerTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Promitor.Integrations.Sinks.Prometheus.Configuration;
+using Promitor.Integrations.Sinks.Prometheus.Labels;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Prometheus
+{
+    [Category("Unit")]
+    public class LabelTransformerTests : UnitTest
+    {
+        [Fact]
+        public void TransformLabels_NoTransformationWithDifferentCases_NoTransformationWasApplied()
+        {
+            // Arrange
+            var inputLabels = new Dictionary<string, string>
+            {
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+            };
+
+            // Act
+            var transformedLabels = LabelTransformer.TransformLabels(LabelTransformation.None, inputLabels);
+
+            // Assert
+            Assert.Equal(inputLabels.Count, transformedLabels.Count);
+            foreach (var inputLabel in inputLabels)
+            {
+                Assert.True(transformedLabels.ContainsKey(inputLabel.Key));
+                Assert.Equal(inputLabel.Value, transformedLabels[inputLabel.Key]);
+            }
+        }
+
+        [Fact]
+        public void TransformLabels_TransformationToLowercase_LabelValuesTransformedToLowercase()
+        {
+            // Arrange
+            var inputLabels = new Dictionary<string, string>
+            {
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName().ToUpper()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName()},
+                {BogusGenerator.Name.FirstName(), BogusGenerator.Name.FirstName().ToUpperInvariant()}
+            };
+
+            // Act
+            var transformedLabels = LabelTransformer.TransformLabels(LabelTransformation.Lowercase, inputLabels);
+
+            // Assert
+            Assert.Equal(inputLabels.Count, transformedLabels.Count);
+            foreach (var inputLabel in inputLabels)
+            {
+                Assert.True(transformedLabels.ContainsKey(inputLabel.Key));
+                Assert.Equal(inputLabel.Value.ToLower(), transformedLabels[inputLabel.Key]);
+            }
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Prometheus/StringExtensionTests.cs
+++ b/src/Promitor.Tests.Unit/Prometheus/StringExtensionTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Prometheus
 {
     [Category("Unit")]
-    public class StringExtensionTests
+    public class StringExtensionTests : UnitTest
     {
         [Fact]
         public void SanitizeForPrometheusLabelKey_ValidKey_IdenticalOutput()

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -15,6 +15,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Validation\Metrics\**" />
+    <Compile Remove="Validation\Misc\**" />
+    <EmbeddedResource Remove="Validation\Metrics\**" />
+    <EmbeddedResource Remove="Validation\Misc\**" />
+    <None Remove="Validation\Metrics\**" />
+    <None Remove="Validation\Misc\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Files\valid-sample.yaml" />
   </ItemGroup>
 
@@ -40,12 +49,6 @@
     <ProjectReference Include="..\Promitor.Core.Scraping\Promitor.Core.Scraping.csproj" />
     <ProjectReference Include="..\Promitor.Agents.Scraper\Promitor.Agents.Scraper.csproj" />
     <ProjectReference Include="..\Promitor.Integrations.Sinks.Statsd\Promitor.Integrations.Sinks.Statsd.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Validation\Metrics\ResourceTypes\" />
-    <Folder Include="Validation\Metrics\Sinks\" />
-    <Folder Include="Validation\Misc\" />
   </ItemGroup>
 
 </Project>

--- a/src/Promitor.Tests.Unit/Serialization/AutoMapperTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/AutoMapperTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization
 {
-    public class AutoMapperTests
+    public class AutoMapperTests : UnitTest
     {
         [Fact]
         public void VerifyConfigurationsAreValid()

--- a/src/Promitor.Tests.Unit/Serialization/DeserializationContextTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializationContextTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization
 {
-    public class DeserializationContextTests
+    public class DeserializationContextTests : UnitTest
     {
         [Fact]
         public void GetSuggestions_NoFieldsConfigured_Empty()

--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
@@ -8,7 +8,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Tests.Unit.Serialization.DeserializerTests
 {
-    public class DeserializationTests
+    public class DeserializationTests : UnitTest
     {
         private static readonly TimeSpan defaultInterval = TimeSpan.FromMinutes(5);
 

--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -9,7 +9,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Tests.Unit.Serialization.DeserializerTests
 {
-    public class ValidationTests
+    public class ValidationTests : UnitTest
     {
         private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
         private readonly TestDeserializer _deserializer = new TestDeserializer();

--- a/src/Promitor.Tests.Unit/Serialization/ErrorReporterTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/ErrorReporterTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization
 {
     [Category("Unit")]
-    public class ErrorReporterTests
+    public class ErrorReporterTests : UnitTest
     {
         private readonly ErrorReporter _errorReporter = new ErrorReporter();
 

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
-    public class DefaultTests
+    public class DefaultTests : UnitTest
     {
         private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
             new FieldDeserializationInfoBuilder<TestConfig, string>();

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
-    public class MapUsingDeserializerTests
+    public class MapUsingDeserializerTests : UnitTest
     {
         private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
             new FieldDeserializationInfoBuilder<TestConfig, string>();

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
@@ -5,7 +5,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
-    public class MapUsingTests
+    public class MapUsingTests : UnitTest
     {
         private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
             new FieldDeserializationInfoBuilder<TestConfig, string>();

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
-    public class RequiredTests
+    public class RequiredTests : UnitTest
     {
         private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
             new FieldDeserializationInfoBuilder<TestConfig, string>();

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
-    public class SetPropertyTests
+    public class SetPropertyTests : UnitTest
     {
         private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
             new FieldDeserializationInfoBuilder<TestConfig, string>();

--- a/src/Promitor.Tests.Unit/Serialization/FieldValidators/CronExpressionValidatorTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldValidators/CronExpressionValidatorTests.cs
@@ -7,7 +7,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace Promitor.Tests.Unit.Serialization.FieldValidators
 {
-    public class CronExpressionValidatorTests
+    public class CronExpressionValidatorTests : UnitTest
     {
         private readonly CronExpressionValidator _validator = new CronExpressionValidator();
 

--- a/src/Promitor.Tests.Unit/Serialization/YamlMappingNodeExtensionTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/YamlMappingNodeExtensionTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization
 {
     [Category("Unit")]
-    public class YamlMappingNodeExtensionTests
+    public class YamlMappingNodeExtensionTests : UnitTest
     {
         [Fact]
         public void GetString_PropertySpecified_ReturnsValue()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/AggregationDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/AggregationDeserializerTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class AggregationDeserializerTests
+    public class AggregationDeserializerTests : UnitTest
     {
         private readonly AggregationDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetadataDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetadataDeserializerTests.cs
@@ -10,7 +10,7 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class AzureMetadataDeserializerTests
+    public class AzureMetadataDeserializerTests : UnitTest
     {
         private readonly AzureMetadataDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
@@ -10,7 +10,7 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class AzureMetricConfigurationDeserializerTests
+    public class AzureMetricConfigurationDeserializerTests : UnitTest
     {
         private readonly AzureMetricConfigurationDeserializer _deserializer;
         private readonly Mock<IDeserializer<MetricDimensionV1>> _dimensionDeserializer;

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureResourceCollectionDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureResourceCollectionDeserializerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class AzureResourceDiscoveryGroupDeserializerTests
+    public class AzureResourceDiscoveryGroupDeserializerTests : UnitTest
     {
         private readonly AzureResourceDiscoveryGroupDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricAggregationDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricAggregationDeserializerTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class MetricAggregationDeserializerTests
+    public class MetricAggregationDeserializerTests : UnitTest
     {
         private readonly MetricAggregationDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
@@ -10,7 +10,7 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class MetricDefaultsDeserializerTests
+    public class MetricDefaultsDeserializerTests : UnitTest
     {
         private readonly MetricDefaultsDeserializer _deserializer;
         private readonly Mock<IDeserializer<AggregationV1>> _aggregationDeserializer;

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
@@ -12,7 +12,7 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class MetricDefinitionDeserializerTests
+    public class MetricDefinitionDeserializerTests : UnitTest
     {
         private readonly Mock<IDeserializer<AzureMetricConfigurationV1>> _azureMetricConfigurationDeserializer;
         private readonly Mock<IDeserializer<ScrapingV1>> _scrapingDeserializer;

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDimensionDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDimensionDeserializerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class MetricDimensionDeserializerTests
+    public class MetricDimensionDeserializerTests : UnitTest
     {
         private readonly MetricDimensionDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/ScrapingDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/ScrapingDeserializerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class ScrapingDeserializerTests
+    public class ScrapingDeserializerTests : UnitTest
     {
         private readonly ScrapingDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/SecretDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/SecretDeserializerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class SecretDeserializerTests
+    public class SecretDeserializerTests : UnitTest
     {
         private readonly SecretDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
@@ -12,7 +12,7 @@ using YamlDotNet.RepresentationModel;
 namespace Promitor.Tests.Unit.Serialization.v1.Core
 {
     [Category("Unit")]
-    public class V1DeserializerTests
+    public class V1DeserializerTests : UnitTest
     {
         private readonly Mock<IDeserializer<AzureMetadataV1>> _metadataDeserializer;
         private readonly Mock<IDeserializer<MetricDefaultsV1>> _defaultsDeserializer;

--- a/src/Promitor.Tests.Unit/Serialization/v1/Mapping/MetricDefinitionV1MappingTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Mapping/MetricDefinitionV1MappingTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Serialization.v1.Mapping
 {
     [Category("Unit")]
-    public class MetricDefinitionV1MappingTests
+    public class MetricDefinitionV1MappingTests : UnitTest
     {
         private readonly IMapper _mapper;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/ResourceDeserializerTest.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/ResourceDeserializerTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Promitor.Tests.Unit.Serialization.v1.Providers
 {
-    public abstract class ResourceDeserializerTest<TDeserializer>
+    public abstract class ResourceDeserializerTest<TDeserializer> : UnitTest
     {
         protected ILogger<TDeserializer> Logger = NullLogger<TDeserializer>.Instance;
         protected abstract IDeserializer<AzureResourceDefinitionV1> CreateDeserializer();

--- a/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
@@ -22,7 +22,7 @@ namespace Promitor.Tests.Unit.Serialization.v1
     /// caught.
     /// </summary>
     [Category("Unit")]
-    public class V1SerializationTests
+    public class V1SerializationTests : UnitTest
     {
         private readonly V1Deserializer _v1Deserializer;
         private readonly ConfigurationSerializer _configurationSerializer;

--- a/src/Promitor.Tests.Unit/UnitTest.cs
+++ b/src/Promitor.Tests.Unit/UnitTest.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+using Bogus;
+
+namespace Promitor.Tests.Unit
+{
+    [Category("Unit")]
+    public class UnitTest
+    {
+        protected Faker BogusGenerator { get; } = new Faker();
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Authentication/AzureAuthenticationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Authentication/AzureAuthenticationValidationStepTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Authentication
 {
     [Category("Unit")]
-    public class AzureAuthenticationValidationStepTests
+    public class AzureAuthenticationValidationStepTests : UnitTest
     {
         [Fact]
         public void ServicePrinciple_IdentityIdInYamlIsValid_Succeeds()

--- a/src/Promitor.Tests.Unit/Validation/ResourceDiscovery/AzureLandscapeValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/ResourceDiscovery/AzureLandscapeValidationStepTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.ResourceDiscovery
 {
     [Category("Unit")]
-    public class AzureLandscapeValidationStepTests
+    public class AzureLandscapeValidationStepTests : UnitTest
     {
         [Fact]
         public void Validate_AzureLandscapeIsFullyConfigured_Success()

--- a/src/Promitor.Tests.Unit/Validation/ResourceDiscovery/ResourceDiscoveryGroupValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/ResourceDiscovery/ResourceDiscoveryGroupValidationStepTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.ResourceDiscovery
 {
     [Category("Unit")]
-    public class ResourceDiscoveryGroupValidationStepTests
+    public class ResourceDiscoveryGroupValidationStepTests : UnitTest
     {
         [Fact]
         public void Validate_ResourceDiscoveryGroupsAreFullyConfigured_Success()

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/GeneralMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/GeneralMetricsDeclarationValidationStepTests.cs
@@ -11,7 +11,7 @@ using MetricsDeclarationBuilder = Promitor.Tests.Unit.Builders.Metrics.v1.Metric
 namespace Promitor.Tests.Unit.Validation.Scraper.Metrics
 {
     [Category("Unit")]
-    public class GeneralMetricsDeclarationValidationStepTests
+    public class GeneralMetricsDeclarationValidationStepTests : UnitTest
     {
         private readonly IMapper _mapper;
 

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/MetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/MetricsDeclarationValidationStepsTests.cs
@@ -3,7 +3,7 @@ using Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping;
 
 namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
 {
-    public class MetricsDeclarationValidationStepsTests
+    public class MetricsDeclarationValidationStepsTests : UnitTest
     {
         protected IMapper Mapper { get; }
 

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/AtlassianStatuspageMetricSinkValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/AtlassianStatuspageMetricSinkValidationStepTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.Sinks
 {
     [Category("Unit")]
-    public class AtlassianStatuspageMetricSinkValidationStepTests
+    public class AtlassianStatuspageMetricSinkValidationStepTests : UnitTest
     {
         private readonly IMapper _mapper;
 

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkValidationStepTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.Sinks
 {
     [Category("Unit")]
-    public class PrometheusScrapingEndpointMetricSinkValidationStepTests
+    public class PrometheusScrapingEndpointMetricSinkValidationStepTests : UnitTest
     {
         [Fact]
         public void Validate_PrometheusScrapingEndpointIsFullyConfigured_Success()

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/StatsDMetricSinkValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/StatsDMetricSinkValidationStepTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.Sinks
 {
     [Category("Unit")]
-    public class StatsDMetricSinkValidationStepTests
+    public class StatsDMetricSinkValidationStepTests : UnitTest
     {
         [Fact]
         public void Validate_StatsDIsFullyConfigured_Success()

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Misc/ConfigurationPathValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Misc/ConfigurationPathValidationStepTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Scraper.Misc
 {
     [Category("Unit")]
-    public class ConfigurationPathValidationStepTests
+    public class ConfigurationPathValidationStepTests : UnitTest
     {
         [Fact]
         public void ConfigurationPath_FileDoesNotExist_Fails()

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Misc/ResourceDiscoveryValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Misc/ResourceDiscoveryValidationStepTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Promitor.Tests.Unit.Validation.Scraper.Misc
 {
     [Category("Unit")]
-    public class AzureLandscapeValidationStepTests
+    public class AzureLandscapeValidationStepTests : UnitTest
     {
         private readonly IMapper _mapper;
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Provide capability to transform metric labels in Prometheus and refactored unit tests.

## Example

Given this metric with custom labels:

```yaml
metrics:
- name: promitor_demo_servicebus_messagecount_discovered
  description: "Average percentage of memory usage on an Azure App Plan"
  resourceType: ServiceBusNamespace
  labels:
    app: promitor
    tier: MESSAGING
  azureMetricConfiguration:
    metricName: ActiveMessages
    aggregation:
      type: Average
  resources:
  - namespace: promitor-messaging
```

### No transformation

```
# HELP promitor_demo_servicebus_messagecount_discovered Average percentage of memory usage on an Azure App Plan
# TYPE promitor_demo_servicebus_messagecount_discovered gauge
promitor_demo_servicebus_messagecount_discovered{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor/providers/Microsoft.ServiceBus/namespaces/promitor-messaging",instance_name="promitor-messaging",entity_name="shipment-requests",app="promitor",tier="MESSAGING"} 0.8 1619377081532
```

### Lowercasing

```
# HELP promitor_demo_servicebus_messagecount_discovered Average percentage of memory usage on an Azure App Plan
# TYPE promitor_demo_servicebus_messagecount_discovered gauge
promitor_demo_servicebus_messagecount_discovered{resource_group="promitor",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourcegroups/promitor/providers/microsoft.servicebus/namespaces/promitor-messaging",instance_name="promitor-messaging",entity_name="orders",app="promitor",tier="messaging"} 0 1619377017433
```

Fixes #1596