### PR TITLE
feat: Provide capability to define default custom labels 

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,8 @@ version:
 
 - {{% tag added %}} Provide capability to transform metric labels in Prometheus ([docs](https://promitor.io/configuration/v2.x/runtime/scraper#prometheus-scraping-endpoint)
  | [#1596](https://github.com/tomkerkhove/promitor/issues/1596))
+- {{% tag added %}} Provide capability to define default custom labels  ([docs](https://promitor.io/configuration/v2.x/metrics/)
+ | [#1608](https://github.com/tomkerkhove/promitor/issues/1608))
 
 #### Resource Discovery
 

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -6,22 +6,13 @@ azureMetadata:
 metricDefaults:
   aggregation:
     interval: 00:05:00
+  labels:
+    geo: china
+    environment: dev
   scraping:
     # Every minute
     schedule: "0 * * ? * *"
 metrics:
-- name: promitor_demo_frontdoor_backend_health
-  description: "Average percentage of memory usage on an Azure App Plan"
-  resourceType: FrontDoor
-  labels:
-    app: promitor
-  azureMetricConfiguration:
-    metricName: BackendHealthPercentage
-    aggregation:
-      type: Average
-  resources:
-  - name: promitor-landscape
-    resourceGroupName: promitor-landscape
 - name: promitor_demo_appplan_percentage_cpu
   description: "Average percentage of memory usage on an Azure App Plan"
   resourceType: AppPlan
@@ -136,6 +127,9 @@ metrics:
 - name: promitor_demo_servicebus_messagecount_discovered
   description: "Average percentage of memory usage on an Azure App Plan"
   resourceType: ServiceBusNamespace
+  labels:
+    geo: europe
+    app: promitor
   azureMetricConfiguration:
     metricName: ActiveMessages
     aggregation:

--- a/docs/configuration/v1.x/metrics/index.md
+++ b/docs/configuration/v1.x/metrics/index.md
@@ -30,7 +30,6 @@ values are `v1`.
 - `metricDefaults.aggregation.interval` - The default interval which defines over
   what period measurements of a metric should be aggregated.
   a cron that fits your needs.
-- `metricDefaults.labels` - The default lebals that will be applied to all metrics. _(starting as of v1.6)_
 
 ### Metrics
 

--- a/docs/configuration/v2.x/metrics/index.md
+++ b/docs/configuration/v2.x/metrics/index.md
@@ -30,7 +30,7 @@ values are `v1`. *(Required)*
 - `metricDefaults.aggregation.interval` - The default interval which defines over
   what period measurements of a metric should be aggregated.
   a cron that fits your needs.
-- `metricDefaults.labels` - The default lebals that will be applied to all metrics. _(starting as of v1.6)_
+- `metricDefaults.labels` - The default labels that will be applied to all metrics. _(starting as of v2.3)_
 
 ### Metrics
 

--- a/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/MetricDefaults.cs
@@ -1,9 +1,13 @@
-﻿namespace Promitor.Core.Scraping.Configuration.Model
+﻿using System.Collections.Generic;
+
+namespace Promitor.Core.Scraping.Configuration.Model
 {
     public class MetricDefaults
     {
         public Aggregation Aggregation { get; set; } = new Aggregation();
 
         public Scraping Scraping { get; set; } = new Scraping();
+
+        public Dictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
@@ -26,7 +26,6 @@ namespace Promitor.Core.Scraping.Configuration.Providers.Interfaces
         ///     configuration elements to metrics where those values aren't specified. <c>false</c> otherwise
         /// </param>
         /// <param name="errorReporter">Used to report errors during the deserialization process.</param>
-        /// <returns></returns>
         MetricDefinition GetMetricDefinition(string metricName, bool applyDefaults = false, IErrorReporter errorReporter = null);
 
         /// <summary>
@@ -38,9 +37,16 @@ namespace Promitor.Core.Scraping.Configuration.Providers.Interfaces
         ///     configuration elements to metrics where those values aren't specified. <c>false</c> otherwise
         /// </param>
         /// <param name="errorReporter">Used to report errors during the deserialization process.</param>
-        /// <returns></returns>
         PrometheusMetricDefinition GetPrometheusDefinition(string metricName, bool applyDefaults = false, IErrorReporter errorReporter = null);
 
+        /// <summary>
+        ///     Get default metrics that are defined for all metrics
+        /// </summary>
+        /// <param name="applyDefaults">
+        ///     <c>true</c> if the provider should apply default values from top-level
+        ///     configuration elements to metrics where those values aren't specified. <c>false</c> otherwise
+        /// </param>
+        /// <param name="errorReporter">Used to report errors during the deserialization process.</param>
         Dictionary<string, string> GetDefaultLabels(bool applyDefaults = false, IErrorReporter errorReporter = null);
 
         /// <summary>

--- a/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/Interfaces/IMetricsDeclarationProvider.cs
@@ -1,4 +1,5 @@
-﻿using Promitor.Core.Scraping.Configuration.Model;
+﻿using System.Collections.Generic;
+using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Core.Scraping.Configuration.Model.Metrics;
 using Promitor.Core.Scraping.Configuration.Serialization;
 
@@ -39,6 +40,8 @@ namespace Promitor.Core.Scraping.Configuration.Providers.Interfaces
         /// <param name="errorReporter">Used to report errors during the deserialization process.</param>
         /// <returns></returns>
         PrometheusMetricDefinition GetPrometheusDefinition(string metricName, bool applyDefaults = false, IErrorReporter errorReporter = null);
+
+        Dictionary<string, string> GetDefaultLabels(bool applyDefaults = false, IErrorReporter errorReporter = null);
 
         /// <summary>
         ///     Gets the serialized metrics declaration

--- a/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
@@ -23,8 +24,14 @@ namespace Promitor.Core.Scraping.Configuration.Providers
 
         public virtual PrometheusMetricDefinition GetPrometheusDefinition(string metricName, bool applyDefaults = false, IErrorReporter errorReporter = null)
         {
-            var foundMetric = GetMetricDefinition(metricName,applyDefaults,errorReporter);
+            var foundMetric = GetMetricDefinition(metricName, applyDefaults, errorReporter);
             return foundMetric?.PrometheusMetricDefinition;
+        }
+
+        public virtual Dictionary<string, string> GetDefaultLabels(bool applyDefaults = false, IErrorReporter errorReporter = null)
+        {
+            var metricsDeclaration = Get(applyDefaults, errorReporter);
+            return metricsDeclaration.MetricDefaults?.Labels ?? new Dictionary<string, string>();
         }
 
         public virtual MetricDefinition GetMetricDefinition(string metricName, bool applyDefaults = false, IErrorReporter errorReporter = null)

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefaultsDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/MetricDefaultsDeserializer.cs
@@ -15,6 +15,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
             Map(defaults => defaults.Scraping)
                 .IsRequired()
                 .MapUsingDeserializer(scrapingDeserializer);
+            Map(defaults => defaults.Labels);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricDefaultsV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/MetricDefaultsV1.cs
@@ -1,4 +1,6 @@
-﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model
+﻿using System.Collections.Generic;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model
 {
     /// <summary>
     /// Contains default settings that apply to all metrics.
@@ -14,5 +16,10 @@
         /// The default scraping settings.
         /// </summary>
         public ScrapingV1 Scraping { get; set; }
+
+        /// <summary>
+        /// The default metric labels.
+        /// </summary>
+        public Dictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
@@ -54,6 +54,10 @@ namespace Promitor.Tests.Unit.Serialization.v1
                     Scraping = new ScrapingV1
                     {
                         Schedule = "1 2 3 4 5"
+                    },
+                    Labels = new Dictionary<string, string>
+                    {
+                        {"geo", "china"}
                     }
                 },
                 Metrics = new List<MetricDefinitionV1>
@@ -147,6 +151,7 @@ namespace Promitor.Tests.Unit.Serialization.v1
             Assert.Equal("promitor-group", deserializedModel.AzureMetadata.ResourceGroupName);
             Assert.Equal(TimeSpan.FromMinutes(7), deserializedModel.MetricDefaults.Aggregation.Interval);
             Assert.Equal("1 2 3 4 5", deserializedModel.MetricDefaults.Scraping.Schedule);
+            Assert.Equal("china", deserializedModel.MetricDefaults.Labels["geo"]);
 
             // Check first metric
             Assert.Equal("promitor_demo_generic_queue_size", deserializedModel.Metrics.ElementAt(0).Name);


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #1608

### Example

Assuming this configuration:
```yaml
version: v1
azureMetadata:
  tenantId: c8819874-9e56-4e3f-b1a8-1c0325138f27
  subscriptionId: 0f9d7fea-99e8-4768-8672-06a28514f77e
  resourceGroupName: promitor
metricDefaults:
  aggregation:
    interval: 00:05:00
  labels:
    geo: china
    environment: dev
  scraping:
    # Every minute
    schedule: "0 * * ? * *"
metrics:
- name: promitor_demo_function_memory_discovery
  description: "Average memory for an Azure Function App"
  resourceType: FunctionApp
  azureMetricConfiguration:
    metricName: MemoryWorkingSet
    aggregation:
      type: Average
  resourceDiscoveryGroups:
  - name: function-app-landscape
- name: promitor_demo_servicebus_messagecount_discovered
  description: "Average percentage of memory usage on an Azure App Plan"
  resourceType: ServiceBusNamespace
  labels:
    geo: europe
    app: promitor
  azureMetricConfiguration:
    metricName: ActiveMessages
    aggregation:
      type: Average
  resourceDiscoveryGroups:
  - name: service-bus-landscape
```

It generates the following input:
```
# HELP promitor_demo_function_memory_discovery Average memory for an Azure Function App
# TYPE promitor_demo_function_memory_discovery gauge
promitor_demo_function_memory_discovery{resource_group="promitor-sources",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.Web/sites/promitor-function-app",instance_name="promitor-function-app",slot_name="production",geo="china",environment="dev"} 40055547.66101695 1619636185372
# HELP promitor_demo_servicebus_messagecount_discovered Average percentage of memory usage on an Azure App Plan
# TYPE promitor_demo_servicebus_messagecount_discovered gauge
promitor_demo_servicebus_messagecount_discovered{resource_group="keda-demos",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/keda-demos/providers/Microsoft.ServiceBus/namespaces/keda-demos",instance_name="keda-demos",entity_name="orders",geo="europe",app="promitor",environment="dev"} 0 1619636186009
```

Hence that the metric-level label for `geo` wins over the default one.