### PR TITLE
feat: Provide scraper for Azure Monitor Autoscale

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,6 +6,8 @@ version:
 
 #### Scraper
 
+- {{% tag added %}} Provide scraper for Azure Monitor Autoscale ([docs](https://promitor.io/configuration/v2.x/metrics/monitor-autoscale)
+ | [#1593](https://github.com/tomkerkhove/promitor/issues/1593))
 - {{% tag added %}} Provide capability to transform metric labels in Prometheus ([docs](https://promitor.io/configuration/v2.x/runtime/scraper#prometheus-scraping-endpoint)
 - {{% tag added %}} Provide capability to limit the amount of resources to query when using filters/dimensions ([docs](https://promitor.io/configuration/v2.x/metrics)
  | [#1596](https://github.com/tomkerkhove/promitor/issues/1596))

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -30,6 +30,8 @@ resourceDiscoveryGroups:
   type: IoTHub
 - name: key-vaults
   type: KeyVault
+- name: autoscaling-rules
+  type: MonitorAutoscale
 - name: network-interfaces
   type: NetworkInterface
 - name: postgres-databases

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -14,6 +14,31 @@ metricDefaults:
     # Every minute
     schedule: "0 * * ? * *"
 metrics:
+- name: promitor_demo_appplan_autoscale_instances_current_discovered
+  description: "Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale"
+  resourceType: MonitorAutoscale
+  labels:
+    app: promitor
+  azureMetricConfiguration:
+    metricName: ObservedCapacity
+    aggregation:
+      type: Average
+  resourceDiscoveryGroups:
+  - name: autoscaling-rules
+- name: promitor_demo_appplan_autoscale_observed_capacity
+  description: "Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale"
+  resourceType: MonitorAutoscale
+  labels:
+    app: promitor
+  azureMetricConfiguration:
+    metricName: MetricThreshold
+    dimension:
+      name: MetricTriggerRule
+    aggregation:
+      type: Average
+  resources:
+  - autoscaleSettingsName: app-service-autoscaling-rules
+    resourceGroupName: demo
 - name: promitor_demo_appplan_percentage_cpu
   description: "Average percentage of memory usage on an Azure App Plan"
   resourceType: AppPlan

--- a/docs/configuration/v2.x/metrics/index.md
+++ b/docs/configuration/v2.x/metrics/index.md
@@ -147,6 +147,7 @@ We also provide a simplified way to scrape the following Azure resources:
 - [Azure Key Vault](key-vault)
 - [Azure Kubernetes Service](kubernetes)
 - [Azure Logic Apps](logic-apps)
+- [Azure Monitor Autoscale](monitor-autoscale)
 - [Azure Network Gateway](network-gateway)
 - [Azure Network Interface](network-interface)
 - [Azure Service Bus Namespace](service-bus-namespace)

--- a/docs/configuration/v2.x/metrics/monitor-autoscale.md
+++ b/docs/configuration/v2.x/metrics/monitor-autoscale.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Azure Monitor Autoscale Declaration
+---
+
+## Azure Monitor Autoscale
+
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.3-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
+
+You can declare to scrape an Azure Monitor Autoscale via the `MonitorAutoscale`
+resource type.
+
+When using declared resources, the following fields need to be provided:
+
+- `autoscaleSettingsName` - The name of the Azure Monitor Autoscale settings
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftinsightsautoscalesettings).
+
+Example:
+
+```yaml
+- name: promitor_demo_appplan_autoscale_observed_capacity
+  description: "Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale"
+  resourceType: MonitorAutoscale
+  labels:
+    app: promitor
+  azureMetricConfiguration:
+    metricName: ObservedCapacity
+    aggregation:
+      type: Average
+  resources: # Optional, required when no resource discovery is configured
+  - autoscaleSettingsName: app-service-autoscaling-rules
+  resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
+  - name: autoscaling-rules
+```
+
+<!-- markdownlint-disable MD033 -->
+[&larr; back to metrics declarations](/configuration/v2.x/metrics)<br />
+[&larr; back to introduction](/)
+<!-- markdownlint-enable -->

--- a/docs/configuration/v2.x/resource-discovery.md
+++ b/docs/configuration/v2.x/resource-discovery.md
@@ -105,6 +105,7 @@ Dynamic resource discovery is supported for the following scrapers:
 - [Azure Key Vault](metrics/key-vault)
 - [Azure Kubernetes Service](metrics/kubernetes)
 - [Azure Logic Apps](metrics/logic-apps)
+- [Azure Monitor Autoscale](metrics/monitor-autoscale)
 - [Azure Network Gateway](metrics/network-gateway)
 - [Azure Network Interface](metrics/network-interface)
 - [Azure Service Bus Namespace](metrics/service-bus-namespace)

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -42,6 +42,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new KubernetesServiceDiscoveryQuery();
                 case ResourceType.LogicApp:
                     return new LogicAppDiscoveryQuery();
+                case ResourceType.MonitorAutoscale:
+                    return new MonitorAutoscaleDiscoveryQuery();
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayDiscoveryQuery();
                 case ResourceType.NetworkInterface:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/MonitorAutoscaleDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/MonitorAutoscaleDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class MonitorAutoscaleDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.insights/autoscalesettings" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var autoscaleSettingsName = resultRowEntry[3]?.ToString();
+            
+            var resource = new MonitorAutoscaleResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), autoscaleSettingsName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -49,6 +49,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new KubernetesServiceMetricValidator();
                 case ResourceType.LogicApp:
                     return new LogicAppMetricValidator();
+                case ResourceType.MonitorAutoscale:
+                    return new MonitorAutoscaleMetricValidator();
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayMetricValidator();
                 case ResourceType.NetworkInterface:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/MonitorAutoscaleMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/MonitorAutoscaleMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class MonitorAutoscaleMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<MonitorAutoscaleResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.AutoscaleSettingsName))
+                {
+                    yield return "No Azure Monitor Autoscale settings name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -38,6 +38,7 @@
         SqlElasticPool = 33,
         SynapseApacheSparkPool = 34,
         SynapseSqlPool = 35,
-        SynapseWorkspace = 36
+        SynapseWorkspace = 36,
+        MonitorAutoscale = 37
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/MonitorAutoscaleResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/MonitorAutoscaleResourceDefinition.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class MonitorAutoscaleResourceDefinition : AzureResourceDefinition
+    {
+        public MonitorAutoscaleResourceDefinition(string subscriptionId, string resourceGroupName, string autoscaleSettingsName)
+            : base(ResourceType.MonitorAutoscale, subscriptionId, resourceGroupName, autoscaleSettingsName)
+        {
+            AutoscaleSettingsName = autoscaleSettingsName;
+        }
+
+        public string AutoscaleSettingsName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -78,6 +78,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.LogicApp:
                     var logicAppLogger = _loggerFactory.CreateLogger<LogicAppDeserializer>();
                     return new LogicAppDeserializer(logicAppLogger);
+                case ResourceType.MonitorAutoscale:
+                    var monitorAutoscaleLogger = _loggerFactory.CreateLogger<MonitorAutoscaleDeserializer>();
+                    return new MonitorAutoscaleDeserializer(monitorAutoscaleLogger);
                 case ResourceType.NetworkGateway:
                     var networkGatewayLogger = _loggerFactory.CreateLogger<NetworkGatewayDeserializer>();
                     return new NetworkGatewayDeserializer(networkGatewayLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -42,6 +42,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<KeyVaultResourceV1, KeyVaultResourceDefinition>();
             CreateMap<KubernetesServiceResourceV1, KubernetesServiceResourceDefinition>();
             CreateMap<LogicAppResourceV1, LogicAppResourceDefinition>();
+            CreateMap<MonitorAutoscaleResourceV1, MonitorAutoscaleResourceDefinition>();
             CreateMap<NetworkGatewayResourceV1, NetworkGatewayResourceDefinition>();
             CreateMap<NetworkInterfaceResourceV1, NetworkInterfaceResourceDefinition>();
             CreateMap<PostgreSqlResourceV1, PostgreSqlResourceDefinition>();
@@ -85,6 +86,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<KeyVaultResourceV1, KeyVaultResourceDefinition>()
                 .Include<KubernetesServiceResourceV1, KubernetesServiceResourceDefinition>()
                 .Include<LogicAppResourceV1, LogicAppResourceDefinition>()
+                .Include<MonitorAutoscaleResourceV1, MonitorAutoscaleResourceDefinition>()
                 .Include<NetworkGatewayResourceV1, NetworkGatewayResourceDefinition>()
                 .Include<NetworkInterfaceResourceV1, NetworkInterfaceResourceDefinition>()
                 .Include<PostgreSqlResourceV1, PostgreSqlResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/MonitorAutoscaleResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/MonitorAutoscaleResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Monitor Autoscale settings.
+    /// </summary>
+    public class MonitorAutoscaleResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Monitor Autoscale settings to get metrics for.
+        /// </summary>
+        public string AutoscaleSettingsName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/MonitorAutoscaleDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/MonitorAutoscaleDeserializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class MonitorAutoscaleDeserializer : ResourceDeserializer<MonitorAutoscaleResourceV1>
+    {
+        public MonitorAutoscaleDeserializer(ILogger<MonitorAutoscaleDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.AutoscaleSettingsName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -68,12 +68,14 @@ namespace Promitor.Core.Scraping.Factories
                     return new KeyVaultScraper(scraperConfiguration);
                 case ResourceType.KubernetesService:
                     return new KubernetesServiceScraper(scraperConfiguration);
+                case ResourceType.LogicApp:
+                    return new LogicAppScraper(scraperConfiguration);
+                case ResourceType.MonitorAutoscale:
+                    return new MonitorAutoscaleScraper(scraperConfiguration);
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayScraper(scraperConfiguration);
                 case ResourceType.NetworkInterface:
                     return new NetworkInterfaceScraper(scraperConfiguration);
-                case ResourceType.LogicApp:
-                    return new LogicAppScraper(scraperConfiguration);
                 case ResourceType.PostgreSql:
                     return new PostgreSqlScraper(scraperConfiguration);
                 case ResourceType.RedisCache:

--- a/src/Promitor.Core.Scraping/ResourceTypes/MonitorAutoscaleScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/MonitorAutoscaleScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class MonitorAutoscaleScraper : AzureMonitorScraper<MonitorAutoscaleResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Insights/autoscalesettings/{2}";
+
+        public MonitorAutoscaleScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, MonitorAutoscaleResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.AutoscaleSettingsName);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -205,6 +205,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithMonitorAutoscaleMetric(string metricName = "promitor-autoscale",
+            string metricDescription = "Description for a metric",
+            string autoscaleSettingsName = "promitor-autoscale-rules",
+            string azureMetricName = "ObservedCapacity",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new MonitorAutoscaleResourceV1
+            {
+                AutoscaleSettingsName = autoscaleSettingsName
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.MonitorAutoscale, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithCosmosDbMetric(string metricName = "promitor-cosmosdb",
             string metricDescription = "Description for a metric",
             string dbName = "promitor-cosmosdb",

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/MonitorAutoscaleDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/MonitorAutoscaleDeserializerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class MonitorAutoscaleDeserializerTests : ResourceDeserializerTest<MonitorAutoscaleDeserializer>
+    {
+        private readonly MonitorAutoscaleDeserializer _deserializer;
+
+        public MonitorAutoscaleDeserializerTests()
+        {
+            _deserializer = new MonitorAutoscaleDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_AutoscaleSettingsNameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<MonitorAutoscaleResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "autoscaleSettingsName: promitor-application-gateway",
+                "promitor-application-gateway",
+                r => r.AutoscaleSettingsName);
+        }
+
+        [Fact]
+        public void Deserialize_AutoscaleSettingsNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<MonitorAutoscaleResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.AutoscaleSettingsName);
+        }
+
+        [Fact]
+        public void Deserialize_AutoscaleSettingsNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "autoscaleSettingsName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new MonitorAutoscaleDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/MonitorAutoscaleMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/MonitorAutoscaleMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class MonitorAutoscaleMetricsDeclarationValidationStepsTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutMonitorAutoscaleName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(autoscaleSettingsName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void MonitorAutoscaleMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithMonitorAutoscaleMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}

--- a/src/Promitor.sln.DotSettings
+++ b/src/Promitor.sln.DotSettings
@@ -85,6 +85,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=APPKEY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Atlassian/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autoscale/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=containerregistry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=functionapp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kerkhove/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- markdownlint-disable -->

When implementing a new scraper; these tasks are completed:
- [x] Implement configuration
- [x] Implement validation
- [x] Implement scraping
- [x] Implement resource discovery
- [x] Provide unit tests
- [x] Test end-to-end
- [x] Document scraper
- [x] Add entry to changelog

**Metrics output:**
```
# HELP promitor_demo_appplan_autoscale_actions_scale Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale
# TYPE promitor_demo_appplan_autoscale_actions_scale gauge
promitor_demo_appplan_autoscale_actions_scale{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",scaledirection="Increase",app="promitor",geo="china",environment="dev"} 0 1620294180665
# HELP promitor_demo_appplan_autoscale_instances_current Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale
# TYPE promitor_demo_appplan_autoscale_instances_current gauge
promitor_demo_appplan_autoscale_instances_current{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",app="promitor",geo="china",environment="dev"} 2 1620294180987
# HELP promitor_demo_appplan_autoscale_observed_capacity Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale
# TYPE promitor_demo_appplan_autoscale_observed_capacity gauge
promitor_demo_appplan_autoscale_observed_capacity{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",metrictriggerrule="Auto created scale condition:microsoft.web/serverfarms:Average:CpuPercentage:PT10M:Increase",app="promitor",geo="china",environment="dev"} -1 1620294180806
promitor_demo_appplan_autoscale_observed_capacity{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",metrictriggerrule="unknown",app="promitor",geo="china",environment="dev"} -1 1620293739695
# HELP promitor_demo_appplan_autoscale_observed_metric Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale
# TYPE promitor_demo_appplan_autoscale_observed_metric gauge
promitor_demo_appplan_autoscale_observed_metric{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",metrictriggersource="unknown",app="promitor",geo="china",environment="dev"} -1 1620293739695
promitor_demo_appplan_autoscale_observed_metric{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",metrictriggersource="Auto created scale condition:microsoft.web/serverfarms:Average:CpuPercentage:PT10M",app="promitor",geo="china",environment="dev"} -1 1620294180887
# HELP promitor_demo_appplan_autoscale_instances_current_discovered Average amount of current instances for an Azure App Plan with Azure Monitor Autoscale
# TYPE promitor_demo_appplan_autoscale_instances_current_discovered gauge
promitor_demo_appplan_autoscale_instances_current_discovered{resource_group="demo",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/demo/providers/Microsoft.Insights/autoscalesettings/app-service-autoscaling-rules",instance_name="app-service-autoscaling-rules",app="promitor",geo="china",environment="dev"} 2 1620299642051
promitor_demo_appplan_autoscale_instances_current_discovered{resource_group="promitor-sources",subscription_id="0f9d7fea-99e8-4768-8672-06a28514f77e",resource_uri="subscriptions/0f9d7fea-99e8-4768-8672-06a28514f77e/resourceGroups/promitor-sources/providers/Microsoft.Insights/autoscalesettings/autoscale-promitor-app-plan",instance_name="autoscale-promitor-app-plan",app="promitor",geo="china",environment="dev"} -1 1620299642382
```

**Discovery output:**
```json
[
  {
    "$type": "Promitor.Core.Contracts.ResourceTypes.MonitorAutoscaleResourceDefinition, Promitor.Core.Contracts",
    "AutoscaleSettingsName": "app-service-autoscaling-rules",
    "ResourceType": "MonitorAutoscale",
    "SubscriptionId": "0f9d7fea-99e8-4768-8672-06a28514f77e",
    "ResourceGroupName": "demo",
    "ResourceName": "app-service-autoscaling-rules",
    "UniqueName": "app-service-autoscaling-rules"
  },
  {
    "$type": "Promitor.Core.Contracts.ResourceTypes.MonitorAutoscaleResourceDefinition, Promitor.Core.Contracts",
    "AutoscaleSettingsName": "autoscale-promitor-app-plan",
    "ResourceType": "MonitorAutoscale",
    "SubscriptionId": "0f9d7fea-99e8-4768-8672-06a28514f77e",
    "ResourceGroupName": "promitor-sources",
    "ResourceName": "autoscale-promitor-app-plan",
    "UniqueName": "autoscale-promitor-app-plan"
  }
]
R
```

Fixes #1593

<!-- markdownlint-enable -->