### PR TITLE
fix: missing authority host param and resource management endpoint when init the client

### DIFF
--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -243,9 +243,9 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
         private async Task<ResourceGraphClient> CreateClientAsync()
         {
             var azureEnvironment = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureEnvironment();
-            var azureAuthoriyHost = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureAuthorityHost();
+            var azureAuthorityHost = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureAuthorityHost();
 
-            var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthoriyHost);
+            var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthorityHost);
 
             var baseUri = new Uri(azureEnvironment.ResourceManagerEndpoint);
 

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -247,7 +247,7 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
 
             var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthoriyHost);
 
-            var baseUri = new System.Uri(azureEnvironment.ResourceManagerEndpoint);
+            var baseUri = new Uri(azureEnvironment.ResourceManagerEndpoint);
 
             var resourceGraphClient = new ResourceGraphClient(baseUri ,credentials);
 

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -246,10 +246,9 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
             var azureAuthorityHost = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureAuthorityHost();
 
             var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthorityHost);
+            var resourceManagerBaseUri = new Uri(azureEnvironment.ResourceManagerEndpoint);
 
-            var baseUri = new Uri(azureEnvironment.ResourceManagerEndpoint);
-
-            var resourceGraphClient = new ResourceGraphClient(baseUri ,credentials);
+            var resourceGraphClient = new ResourceGraphClient(resourceManagerBaseUri, credentials);
 
             var version = Promitor.Core.Version.Get();
             var promitorUserAgent = UserAgent.Generate("Resource-Discovery", version);

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -245,10 +245,11 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
             var azureEnvironment = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureEnvironment();
             var azureAuthoriyHost = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureAuthorityHost();
 
-            _logger.LogInformation($"AzureAuthorityHost: {azureAuthoriyHost.ToString()}");
-
             var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthoriyHost);
-            var resourceGraphClient = new ResourceGraphClient(credentials);
+
+            var baseUri = new System.Uri(azureEnvironment.ResourceManagerEndpoint);
+
+            var resourceGraphClient = new ResourceGraphClient(baseUri ,credentials);
 
             var version = Promitor.Core.Version.Get();
             var promitorUserAgent = UserAgent.Generate("Resource-Discovery", version);

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -243,8 +243,11 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
         private async Task<ResourceGraphClient> CreateClientAsync()
         {
             var azureEnvironment = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureEnvironment();
+            var azureAuthoriyHost = _resourceDeclarationMonitor.CurrentValue.AzureLandscape.Cloud.GetAzureAuthorityHost();
 
-            var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo);
+            _logger.LogInformation($"AzureAuthorityHost: {azureAuthoriyHost.ToString()}");
+
+            var credentials = await AzureAuthenticationFactory.GetTokenCredentialsAsync(azureEnvironment.ManagementEndpoint, TenantId, _azureAuthenticationInfo, azureAuthoriyHost);
             var resourceGraphClient = new ResourceGraphClient(credentials);
 
             var version = Promitor.Core.Version.Get();

--- a/src/Promitor.Core/Extensions/AzureCloudExtensions.cs
+++ b/src/Promitor.Core/Extensions/AzureCloudExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Identity;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Promitor.Core.Serialization.Enum;
 
@@ -23,6 +24,23 @@ namespace Promitor.Core.Extensions
                     return AzureEnvironment.AzureGermanCloud;
                 case AzureCloud.UsGov:
                     return AzureEnvironment.AzureUSGovernment;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(azureCloud), "No Azure environment is known for");
+            }
+        }
+
+        public static Uri GetAzureAuthorityHost(this AzureCloud azureCloud)
+        {
+            switch (azureCloud)
+            {
+                case AzureCloud.Global:
+                    return AzureAuthorityHosts.AzurePublicCloud;
+                case AzureCloud.China:
+                    return AzureAuthorityHosts.AzureChina;
+                case AzureCloud.Germany:
+                    return AzureAuthorityHosts.AzureGermany;
+                case AzureCloud.UsGov:
+                    return AzureAuthorityHosts.AzureGovernment;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(azureCloud), "No Azure environment is known for");
             }

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.37.1" />

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -88,7 +88,7 @@ namespace Promitor.Integrations.Azure.Authentication
                     tokenCredential = new ManagedIdentityCredential(authenticationInfo.IdentityId, tokenCredentialOptions);
                     break;
                 case AuthenticationMode.SystemAssignedManagedIdentity:
-                    tokenCredential = new ManagedIdentityCredential( "",tokenCredentialOptions);
+                    tokenCredential = new ManagedIdentityCredential(options:tokenCredentialOptions);
                     break;
                 default:
                     tokenCredential = new DefaultAzureCredential();

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -69,7 +69,7 @@ namespace Promitor.Integrations.Azure.Authentication
         /// <summary>
         ///     Gets a valid token using a Service Principal or a Managed Identity
         /// </summary>
-        public static async Task<TokenCredentials> GetTokenCredentialsAsync(string resource, string tenantId, AzureAuthenticationInfo authenticationInfo)
+        public static async Task<TokenCredentials> GetTokenCredentialsAsync(string resource, string tenantId, AzureAuthenticationInfo authenticationInfo, System.Uri azureAuthoriyHost)
         {
             Guard.NotNullOrWhitespace(resource, nameof(resource));
             Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
@@ -77,16 +77,18 @@ namespace Promitor.Integrations.Azure.Authentication
 
             TokenCredential tokenCredential;
 
+            var tokenCredentialOptions = new TokenCredentialOptions { AuthorityHost = azureAuthoriyHost };
+
             switch (authenticationInfo.Mode)
             {
                 case AuthenticationMode.ServicePrincipal:
-                    tokenCredential = new ClientSecretCredential(tenantId, authenticationInfo.IdentityId, authenticationInfo.Secret);
+                    tokenCredential = new ClientSecretCredential(tenantId, authenticationInfo.IdentityId, authenticationInfo.Secret, tokenCredentialOptions);
                     break;
                 case AuthenticationMode.UserAssignedManagedIdentity:
-                    tokenCredential = new ManagedIdentityCredential(authenticationInfo.IdentityId);
+                    tokenCredential = new ManagedIdentityCredential(authenticationInfo.IdentityId, tokenCredentialOptions);
                     break;
                 case AuthenticationMode.SystemAssignedManagedIdentity:
-                    tokenCredential = new ManagedIdentityCredential();
+                    tokenCredential = new ManagedIdentityCredential( "",tokenCredentialOptions);
                     break;
                 default:
                     tokenCredential = new DefaultAzureCredential();

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -69,7 +69,7 @@ namespace Promitor.Integrations.Azure.Authentication
         /// <summary>
         ///     Gets a valid token using a Service Principal or a Managed Identity
         /// </summary>
-        public static async Task<TokenCredentials> GetTokenCredentialsAsync(string resource, string tenantId, AzureAuthenticationInfo authenticationInfo, System.Uri azureAuthoriyHost)
+        public static async Task<TokenCredentials> GetTokenCredentialsAsync(string resource, string tenantId, AzureAuthenticationInfo authenticationInfo, System.Uri azureAuthorityHost)
         {
             Guard.NotNullOrWhitespace(resource, nameof(resource));
             Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
@@ -77,7 +77,7 @@ namespace Promitor.Integrations.Azure.Authentication
 
             TokenCredential tokenCredential;
 
-            var tokenCredentialOptions = new TokenCredentialOptions { AuthorityHost = azureAuthoriyHost };
+            var tokenCredentialOptions = new TokenCredentialOptions { AuthorityHost = azureAuthorityHost };
 
             switch (authenticationInfo.Mode)
             {

--- a/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
@@ -78,7 +78,7 @@ namespace Promitor.Tests.Unit.Azure
         }
 
         [Fact]
-        public void GetAzureAuthorityHost_ForAzureGlobalCloud_ProvidesCorrectEnvironmentInfo()
+        public void GetAzureAuthorityHost_ForAzureGlobalCloud_ProvidesCorrectAuthorityHost()
         {
             // Arrange
             var azureCloud = AzureCloud.Global;
@@ -92,7 +92,7 @@ namespace Promitor.Tests.Unit.Azure
         }
 
         [Fact]
-        public void GetAzureAuthorityHost_ForAzureChinaCloud_ProvidesCorrectEnvironmentInfo()
+        public void GetAzureAuthorityHost_ForAzureChinaCloud_ProvidesCorrectAuthorityHost()
         {
             // Arrange
             var azureCloud = AzureCloud.China;
@@ -106,7 +106,7 @@ namespace Promitor.Tests.Unit.Azure
         }
 
         [Fact]
-        public void GetAzureAuthorityHost_ForAzureGermanCloud_ProvidesCorrectEnvironmentInfo()
+        public void GetAzureAuthorityHost_ForAzureGermanCloud_ProvidesCorrectAuthorityHost()
         {
             // Arrange
             var azureCloud = AzureCloud.Germany;
@@ -120,7 +120,7 @@ namespace Promitor.Tests.Unit.Azure
         }
 
         [Fact]
-        public void GetAzureAuthorityHost_ForAzureUSGovernmentCloud_ProvidesCorrectEnvironmentInfo()
+        public void GetAzureAuthorityHost_ForAzureUSGovernmentCloud_ProvidesCorrectAuthorityHost()
         {
             // Arrange
             var azureCloud = AzureCloud.UsGov;

--- a/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
@@ -124,7 +124,7 @@ namespace Promitor.Tests.Unit.Azure
         {
             // Arrange
             var azureCloud = AzureCloud.UsGov;
-            var expectedEnvironment = AzureAuthorityHosts.AzureGovernment;
+            var expectedAuthorityHost = AzureAuthorityHosts.AzureGovernment;
 
             // Act
             var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();

--- a/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Azure.Identity;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Promitor.Core.Extensions;
 using Promitor.Core.Serialization.Enum;
@@ -74,6 +75,72 @@ namespace Promitor.Tests.Unit.Azure
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(()=> azureCloud.GetAzureEnvironment());
+        }
+
+        [Fact]
+        public void GetAzureAuthorityHost_ForAzureGlobalCloud_ProvidesCorrectEnvironmentInfo()
+        {
+            // Arrange
+            var azureCloud = AzureCloud.Global;
+            var expectedAuthorityHost = AzureAuthorityHosts.AzurePublicCloud;
+
+            // Act
+            var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
+
+            // Assert
+            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+        }
+
+        [Fact]
+        public void GetAzureAuthorityHost_ForAzureChinaCloud_ProvidesCorrectEnvironmentInfo()
+        {
+            // Arrange
+            var azureCloud = AzureCloud.China;
+            var expectedAuthorityHost = AzureAuthorityHosts.AzureChina;
+
+            // Act
+            var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
+
+            // Assert
+            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+        }
+
+        [Fact]
+        public void GetAzureAuthorityHost_ForAzureGermanCloud_ProvidesCorrectEnvironmentInfo()
+        {
+            // Arrange
+            var azureCloud = AzureCloud.Germany;
+            var expectedAuthorityHost = AzureAuthorityHosts.AzureGermany;
+
+            // Act
+            var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
+
+            // Assert
+            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+        }
+
+        [Fact]
+        public void GetAzureAuthorityHost_ForAzureUSGovernmentCloud_ProvidesCorrectEnvironmentInfo()
+        {
+            // Arrange
+            var azureCloud = AzureCloud.UsGov;
+            var expectedEnvironment = AzureAuthorityHosts.AzureGovernment;
+
+            // Act
+            var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
+
+            // Assert
+            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+        }
+
+        [Fact]
+        public void GetAzureAuthorityHost_ForUnspecifiedAzureCloud_ThrowsException()
+        {
+            // Arrange
+            var azureCloud = AzureCloud.Unspecified;
+
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => azureCloud.GetAzureAuthorityHost());
         }
     }
 }

--- a/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureCloudUnitTests.cs
@@ -88,7 +88,7 @@ namespace Promitor.Tests.Unit.Azure
             var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
 
             // Assert
-            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+            Assert.True(expectedAuthorityHost.Equals(actualAuthorityHost));
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Promitor.Tests.Unit.Azure
             var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
 
             // Assert
-            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+            Assert.True(expectedAuthorityHost.Equals(actualAuthorityHost));
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Promitor.Tests.Unit.Azure
             var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
 
             // Assert
-            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+            Assert.True(expectedAuthorityHost.Equals(actualAuthorityHost));
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace Promitor.Tests.Unit.Azure
             var actualAuthorityHost = azureCloud.GetAzureAuthorityHost();
 
             // Assert
-            PromitorAssert.Equal(expectedAuthorityHost, actualAuthorityHost);
+            Assert.True(expectedAuthorityHost.Equals(actualAuthorityHost));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

### Issue

Relates to https://github.com/tomkerkhove/promitor/issues/1646

### Description

This PR fixes 2 parts:
- First one is adding the AuthorityHost for the TokenCredentialOptions, since this value will be different for each Cloud
- Second one is similar to the first but with the ResourceGraphClient which will need the baseUri of the Managment Resource Endpoint
<!-- markdownlint-enable -->