### PR TITLE
Document fix for authenticating to Azure clouds other than public

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -10,4 +10,4 @@ None.
 
 #### Resource Discovery
 
-None.
+- {{% tag fixed %}} Support for authenticating to Azure clouds other than public ([#1646](https://github.com/tomkerkhove/promitor/issues/1646))


### PR DESCRIPTION
Relates to #1646