### PR TITLE
fix: Provide correct resource group name for runtime metric labels

### DIFF
--- a/src/Promitor.Core.Scraping/Scraper.cs
+++ b/src/Promitor.Core.Scraping/Scraper.cs
@@ -125,7 +125,7 @@ namespace Promitor.Core.Scraping
             var labels = new Dictionary<string, string>
             {
                 {"metric_name", scrapeDefinition.PrometheusMetricDefinition.Name},
-                {"resource_group", scrapeDefinition.Resource.ResourceGroupName},
+                {"resource_group", scrapeDefinition.ResourceGroupName},
                 {"resource_name", scrapeDefinition.Resource.ResourceName},
                 {"resource_type", scrapeDefinition.Resource.ResourceType.ToString()},
                 {"subscription_id", scrapeDefinition.SubscriptionId}


### PR DESCRIPTION
Provide correct resource group name for runtime metric labels so that they are always reported correctly.

Relates to #1304