### PR TITLE
chore: Use ubuntu-latest instead of pinning to Ubuntu 16 for Azure Pipelines

### DIFF
--- a/build/azure-devops/agents-ci-discovery.yml
+++ b/build/azure-devops/agents-ci-discovery.yml
@@ -31,7 +31,7 @@ stages:
    - job: DetermineVersion
      displayName: Determine Version
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - template: templates/versioning/determine-pr-version.yml
@@ -48,7 +48,7 @@ stages:
      displayName: Build Codebase
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/build/build-solution.yml
        parameters:
@@ -81,7 +81,7 @@ stages:
      displayName: Run Unit Tests
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/tests/run-unit-tests.yml
        parameters:
@@ -111,7 +111,7 @@ stages:
      displayName: Build Docker Image (Linux)
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      variables:
        Tags.Experimental: 'experimental-$(OS.Name)'
        OS.Name: 'linux'

--- a/build/azure-devops/agents-ci-scraper.yml
+++ b/build/azure-devops/agents-ci-scraper.yml
@@ -29,7 +29,7 @@ stages:
    - job: DetermineVersion
      displayName: Determine Version
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - template: templates/versioning/determine-pr-version.yml
@@ -46,7 +46,7 @@ stages:
      displayName: Build Codebase
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/build/build-solution.yml
        parameters:
@@ -79,7 +79,7 @@ stages:
      displayName: Run Unit Tests
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/tests/run-unit-tests.yml
        parameters:
@@ -117,7 +117,7 @@ stages:
      displayName: Build Docker Image (Linux)
      condition: succeeded()
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      variables:
        Image.TaggedName.OSAgnostic: '$(Image.Name):$(Image.Tag)'
        Tags.Experimental: 'experimental-$(OS.Name)'

--- a/build/azure-devops/agents-resource-discovery-release-official.yml
+++ b/build/azure-devops/agents-resource-discovery-release-official.yml
@@ -63,7 +63,7 @@ stages:
    - job: DetermineVersion
      displayName: Determine Version
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/versioning/determine-major-minor-version.yml
      - template: templates/utils/persist-variable.yml
@@ -76,7 +76,7 @@ stages:
   dependsOn: Init
   displayName: Linux Docker image
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   variables:
   - name: OS.Name
     value: 'linux'
@@ -213,7 +213,7 @@ stages:
     - job: CreateRelease
       displayName: Create Release
       pool:
-        vmImage: ubuntu-16.04
+        vmImage: ubuntu-latest
       steps:
       - download: current
         artifact: variables

--- a/build/azure-devops/agents-scraper-release-official.yml
+++ b/build/azure-devops/agents-scraper-release-official.yml
@@ -46,7 +46,7 @@ stages:
    - job: DetermineVersion
      displayName: Determine Version
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - template: templates/versioning/determine-major-minor-version.yml
      - template: templates/utils/persist-variable.yml
@@ -84,7 +84,7 @@ stages:
    - job: BuildLinux
      displayName: Build Linux Docker image
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      variables:
        OS.Name: 'linux'
      steps:
@@ -260,7 +260,7 @@ stages:
     - job: CreateRelease
       displayName: Create Release
       pool:
-        vmImage: ubuntu-16.04
+        vmImage: ubuntu-latest
       steps:
       - download: current
         artifact: variables

--- a/build/azure-devops/docs-ci.yml
+++ b/build/azure-devops/docs-ci.yml
@@ -23,7 +23,7 @@ stages:
    - job: Lint
      displayName: Lint
      pool:
-       vmImage: ubuntu-16.04
+       vmImage: ubuntu-latest
      steps:
      - powershell: |
          $prNumber = '$(System.PullRequest.PullRequestNumber)'


### PR DESCRIPTION
Use ubuntu-latest instead of pinning to Ubuntu 16 for Azure Pipelines which are deprecated.

Relates to https://github.com/actions/virtual-environments/issues/3287