### PR TITLE
[WIP] Filter tags with regex

### DIFF
--- a/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
@@ -163,5 +163,18 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Query
             var lastDictionaryEntry = allowedTags.Last();
             _queryBuilder.AppendLine($"tags['{lastDictionaryEntry.Key}'] =~ '{lastDictionaryEntry.Value}'");
         }
+
+        private void FilterByTags(Dictionary<string, list> allowedTags)
+        {
+            _queryBuilder.Append("| where ");
+            for (int counter = 0; counter < allowedTags.Count - 1; counter++)
+            {
+                var dictionaryEntry = allowedTags.ElementAt(counter);
+                _queryBuilder.Append($"tags['{dictionaryEntry.Key}'] matches regex @'{dictionaryEntry.Value}' or ");
+            }
+
+            var lastDictionaryEntry = allowedTags.Last();
+            _queryBuilder.AppendLine($"tags['{lastDictionaryEntry.Key}'] matches regex @'{lastDictionaryEntry.Value}'");
+        }
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
@@ -157,11 +157,11 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Query
             for (int counter = 0; counter < allowedTags.Count - 1; counter++)
             {
                 var dictionaryEntry = allowedTags.ElementAt(counter);
-                _queryBuilder.Append($"tags['{dictionaryEntry.Key}'] == '{dictionaryEntry.Value}' or ");
+                _queryBuilder.Append($"tags['{dictionaryEntry.Key}'] =~ '{dictionaryEntry.Value}' or ");
             }
 
             var lastDictionaryEntry = allowedTags.Last();
-            _queryBuilder.AppendLine($"tags['{lastDictionaryEntry.Key}'] == '{lastDictionaryEntry.Value}'");
+            _queryBuilder.AppendLine($"tags['{lastDictionaryEntry.Key}'] =~ '{lastDictionaryEntry.Value}'");
         }
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
@@ -151,20 +151,7 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Query
             _queryBuilder.AppendLine($"{fieldName} =~ '{allowedValues.Last()}'");
         }
 
-        private void FilterByTags(Dictionary<string,string> allowedTags)
-        {
-            _queryBuilder.Append("| where ");
-            for (int counter = 0; counter < allowedTags.Count - 1; counter++)
-            {
-                var dictionaryEntry = allowedTags.ElementAt(counter);
-                _queryBuilder.Append($"tags['{dictionaryEntry.Key}'] =~ '{dictionaryEntry.Value}' or ");
-            }
-
-            var lastDictionaryEntry = allowedTags.Last();
-            _queryBuilder.AppendLine($"tags['{lastDictionaryEntry.Key}'] =~ '{lastDictionaryEntry.Value}'");
-        }
-
-        private void FilterByTags(Dictionary<string, list> allowedTags)
+        private void FilterByTags(Dictionary<string, string> allowedTags)
         {
             _queryBuilder.Append("| where ");
             for (int counter = 0; counter < allowedTags.Count - 1; counter++)


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

Support this case: https://github.com/tomkerkhove/promitor/discussions/1779
<!-- markdownlint-enable -->