### PR TITLE
docs: Correct typo in documentation for allowed values for `authentication.mode`

### DIFF
--- a/changelog/content/deprecated/authentication-modes.md
+++ b/changelog/content/deprecated/authentication-modes.md
@@ -22,7 +22,7 @@ However, as of Promitor Scraper v2.2.0 & Resource Discovery v0.3.0, users can ch
 
 ```yaml
 authentication:
-  # Options are ServicePrincipal, SystemAssigedManagedIdentity, UserAssigedManagedIdentity.
+  # Options are ServicePrincipal, SystemAssignedManagedIdentity, UserAssignedManagedIdentity.
   mode: ServicePrincipal
   identityId: xxxx-xxxx-xxxx
 ```

--- a/docs/configuration/v2.x/runtime/resource-discovery.md
+++ b/docs/configuration/v2.x/runtime/resource-discovery.md
@@ -20,7 +20,7 @@ Here is a complete example of the runtime YAML:
 
 ```yaml
 authentication:
-  # Options are ServicePrincipal, SystemAssigedManagedIdentity, UserAssigedManagedIdentity.
+  # Options are ServicePrincipal, SystemAssignedManagedIdentity, UserAssignedManagedIdentity.
   mode: ServicePrincipal # Optional. Default: ServicePrincipal.
   identityId: xxxx-xxxx-xxxx # Optional.
 server:
@@ -44,15 +44,15 @@ telemetry:
 The Promitor runtime allows you to use various ways to authenticate to Azure:
 
 - `authentication.mode` - Defines authentication mode to use. Options are `ServicePrincipal`,
- `SystemAssigedManagedIdentity`, `UserAssigedManagedIdentity`. _(defaults to service principle)_
+ `SystemAssignedManagedIdentity`, `UserAssignedManagedIdentity`. _(defaults to service principle)_
 - `authentication.identityId` - Id of the Azure AD entity to authenticate with when integrating with Microsoft Azure.
- Required when using `ServicePrincipal` or `UserAssigedManagedIdentity`.
+ Required when using `ServicePrincipal` or `UserAssignedManagedIdentity`.
 
 Example:
 
 ```yaml
 authentication:
-  # Options are ServicePrincipal, SystemAssigedManagedIdentity, UserAssigedManagedIdentity.
+  # Options are ServicePrincipal, SystemAssignedManagedIdentity, UserAssignedManagedIdentity.
   mode: ServicePrincipal # Optional. Default: ServicePrincipal.
   identityId: xxxx-xxxx-xxxx # Optional.
 ```

--- a/docs/configuration/v2.x/runtime/scraper.md
+++ b/docs/configuration/v2.x/runtime/scraper.md
@@ -20,7 +20,7 @@ Here is a complete example of the runtime YAML:
 
 ```yaml
 authentication:
-  # Options are ServicePrincipal, SystemAssigedManagedIdentity, UserAssigedManagedIdentity.
+  # Options are ServicePrincipal, SystemAssignedManagedIdentity, UserAssignedManagedIdentity.
   mode: ServicePrincipal # Optional. Default: ServicePrincipal.
   identityId: xxxx-xxxx-xxxx # Optional.
 server:
@@ -61,15 +61,15 @@ the runtime._
 The Promitor runtime allows you to use various ways to authenticate to Azure:
 
 - `authentication.mode` - Defines authentication mode to use. Options are `ServicePrincipal`,
- `SystemAssigedManagedIdentity`, `UserAssigedManagedIdentity`. _(defaults to service principle)_
+ `SystemAssignedManagedIdentity`, `UserAssignedManagedIdentity`. _(defaults to service principle)_
 - `authentication.identityId` - Id of the Azure AD entity to authenticate with when integrating with Microsoft Azure.
- Required when using `ServicePrincipal` or `UserAssigedManagedIdentity`.
+ Required when using `ServicePrincipal` or `UserAssignedManagedIdentity`.
 
 Example:
 
 ```yaml
 authentication:
-  # Options are ServicePrincipal, SystemAssigedManagedIdentity, UserAssigedManagedIdentity.
+  # Options are ServicePrincipal, SystemAssignedManagedIdentity, UserAssignedManagedIdentity.
   mode: ServicePrincipal # Optional. Default: ServicePrincipal.
   identityId: xxxx-xxxx-xxxx # Optional.
 ```


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #1796

<!-- markdownlint-enable -->