### PR TITLE
docs: Update Resource Type to ServiceBusNamespace in metrics-declarat…

### DIFF
--- a/docs/walkthrough/scrape-promitor-with-prometheus-on-azure-kubernetes-service.md
+++ b/docs/walkthrough/scrape-promitor-with-prometheus-on-azure-kubernetes-service.md
@@ -179,7 +179,7 @@ metricDefaults:
 metrics:
   - name: demo_queue_size
     description: "Amount of active messages of the 'demo_queue' queue"
-    resourceType: ServiceBusQueue
+    resourceType: ServiceBusNamespace
     azureMetricConfiguration:
       metricName: ActiveMessages
       aggregation:


### PR DESCRIPTION
…ion.yaml

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper
- [ ] Add entry to changelog

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

Updated Walkthough documentation to use 'ServiceBusNamespace', instead of 'ServiceBusQueue' resource type in metrics-declaration.yaml template.

This fixes an issue where promitor-agent-scraper fails the metrics-declaration validation on start up and crashes, due to invalid resource type.
<!-- markdownlint-enable -->