### PR TITLE
fix: Reduce the number of API calls to retrieve metric definitions through caching

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,8 +6,9 @@ version:
 
 #### Scraper
 
-- {{% tag fixed %}} Fix "Try it out" capability for end-users in Swagger UI when using reverse proxies
+- {{% tag fixed %}} Fix "Try it out" capability for end-users in Swagger UI when using reverse proxies ([#1898](https://github.com/tomkerkhove/promitor/pull/1898))
+- {{% tag changed %}} Reduce amount of API calls to scrape metrics for Azure services ([#1914](https://github.com/tomkerkhove/promitor/issues/1914))
 
 #### Resource Discovery
 
-- {{% tag fixed %}} Fix "Try it out" capability for end-users in Swagger UI when using reverse proxies
+- {{% tag fixed %}} Fix "Try it out" capability for end-users in Swagger UI when using reverse proxies ([#1898](https://github.com/tomkerkhove/promitor/pull/1898))

--- a/src/Promitor.Agents.Core/RequestHandlers/ThrottlingRequestHandler.cs
+++ b/src/Promitor.Agents.Core/RequestHandlers/ThrottlingRequestHandler.cs
@@ -43,7 +43,7 @@ namespace Promitor.Agents.Core.RequestHandlers
 
             await AvailableRateLimitingCallsAsync(response);
             AvailableThrottlingStatusAsync(wasRequestThrottled);
-
+            
             return response;
         }
 

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -4,7 +4,7 @@
         <name>Promitor.Agents.Scraper</name>
     </assembly>
     <members>
-        <member name="M:Promitor.Agents.Scraper.AzureMonitorClientFactory.CreateIfNotExists(Microsoft.Azure.Management.ResourceManager.Fluent.AzureEnvironment,System.String,System.String,Promitor.Core.Metrics.Sinks.MetricSinkWriter,Promitor.Core.Metrics.Prometheus.Collectors.Interfaces.IAzureScrapingPrometheusMetricsCollector,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorLoggingConfiguration},Microsoft.Extensions.Logging.ILoggerFactory)">
+        <member name="M:Promitor.Agents.Scraper.AzureMonitorClientFactory.CreateIfNotExists(Microsoft.Azure.Management.ResourceManager.Fluent.AzureEnvironment,System.String,System.String,Promitor.Core.Metrics.Sinks.MetricSinkWriter,Promitor.Core.Metrics.Prometheus.Collectors.Interfaces.IAzureScrapingPrometheusMetricsCollector,Microsoft.Extensions.Caching.Memory.IMemoryCache,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorLoggingConfiguration},Microsoft.Extensions.Logging.ILoggerFactory)">
             <summary>
             Provides an Azure Monitor client
             </summary>
@@ -13,6 +13,7 @@
             <param name="subscriptionId">Id of the Azure subscription</param>
             <param name="metricSinkWriter">Writer to send metrics to all configured sinks</param>
             <param name="azureScrapingPrometheusMetricsCollector">Metrics collector to write metrics to Prometheus</param>
+            <param name="memoryCache">Memory cache to store items in</param>
             <param name="configuration">Configuration of Promitor</param>
             <param name="azureMonitorLoggingConfiguration">Options for Azure Monitor logging</param>
             <param name="loggerFactory">Factory to create loggers with</param>

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -38,6 +38,7 @@ namespace Promitor.Agents.Scraper
             string openApiDescription = BuildOpenApiDescription(Configuration);
 
             services.UseWebApi()
+                .AddMemoryCache()
                 .AddResourceDiscoveryClient(promitorUserAgent)
                 .AddAtlassianStatuspageClient(promitorUserAgent, Configuration)
                 .AddUsability()

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using GuardNet;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Rest;
@@ -26,9 +27,10 @@ namespace Promitor.Integrations.AzureMonitor
 {
     public class AzureMonitorClient
     {
-        private readonly ILogger _logger;
         private readonly IAzure _authenticatedAzureSubscription;
         private readonly AzureCredentialsFactory _azureCredentialsFactory = new AzureCredentialsFactory();
+        private readonly IMemoryCache _memoryCache;
+        private readonly ILogger _logger;
 
         /// <summary>
         ///     Constructor
@@ -41,13 +43,15 @@ namespace Promitor.Integrations.AzureMonitor
         /// <param name="metricSinkWriter">Writer to send metrics to all configured sinks</param>
         /// <param name="azureScrapingPrometheusMetricsCollector">Metrics collector to write metrics to Prometheus</param>
         /// <param name="loggerFactory">Factory to create loggers with</param>
-        public AzureMonitorClient(AzureEnvironment azureCloud, string tenantId, string subscriptionId, AzureAuthenticationInfo azureAuthenticationInfo, MetricSinkWriter metricSinkWriter, IAzureScrapingPrometheusMetricsCollector azureScrapingPrometheusMetricsCollector, ILoggerFactory loggerFactory, IOptions<AzureMonitorLoggingConfiguration> azureMonitorLoggingConfiguration)
+        public AzureMonitorClient(AzureEnvironment azureCloud, string tenantId, string subscriptionId, AzureAuthenticationInfo azureAuthenticationInfo, MetricSinkWriter metricSinkWriter, IAzureScrapingPrometheusMetricsCollector azureScrapingPrometheusMetricsCollector, IMemoryCache memoryCache, ILoggerFactory loggerFactory, IOptions<AzureMonitorLoggingConfiguration> azureMonitorLoggingConfiguration)
         {
             Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
             Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
             Guard.NotNull(azureAuthenticationInfo, nameof(azureAuthenticationInfo));
             Guard.NotNull(azureMonitorLoggingConfiguration, nameof(azureMonitorLoggingConfiguration));
+            Guard.NotNull(memoryCache, nameof(memoryCache));
 
+            _memoryCache = memoryCache;
             _logger = loggerFactory.CreateLogger<AzureMonitorClient>();
             _authenticatedAzureSubscription = CreateAzureClient(azureCloud, tenantId, subscriptionId, azureAuthenticationInfo, loggerFactory, metricSinkWriter, azureScrapingPrometheusMetricsCollector, azureMonitorLoggingConfiguration);
         }
@@ -71,7 +75,7 @@ namespace Promitor.Integrations.AzureMonitor
 
             // Get all metrics
             var startQueryingTime = DateTime.UtcNow;
-            var metricsDefinitions = await _authenticatedAzureSubscription.MetricDefinitions.ListByResourceAsync(resourceId);
+            var metricsDefinitions = await GetMetricDefinitionsAsync(resourceId);
             var metricDefinition = metricsDefinitions.SingleOrDefault(definition => definition.Name.Value.ToUpper() == metricName.ToUpper());
             if (metricDefinition == null)
             {
@@ -104,6 +108,21 @@ namespace Promitor.Integrations.AzureMonitor
             }
 
             return measuredMetrics;
+        }
+
+        private async Task<IReadOnlyList<IMetricDefinition>> GetMetricDefinitionsAsync(string resourceId)
+        {
+            // Get cached metric definitions
+            if (_memoryCache.TryGetValue(resourceId, out IReadOnlyList<IMetricDefinition> metricDefinitions))
+            {
+                return metricDefinitions;
+            }
+            
+            // Get from API and cache it
+            var foundMetricDefinitions = await _authenticatedAzureSubscription.MetricDefinitions.ListByResourceAsync(resourceId);
+            _memoryCache.Set(resourceId, foundMetricDefinitions, TimeSpan.FromMinutes(30));
+
+            return foundMetricDefinitions;
         }
 
         private TimeSpan DetermineAggregationInterval(string metricName, TimeSpan requestedAggregationInterval, IReadOnlyList<MetricAvailability> availableMetricPeriods)

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -27,6 +27,7 @@ namespace Promitor.Integrations.AzureMonitor
 {
     public class AzureMonitorClient
     {
+        private readonly TimeSpan _metricDefinitionCacheDuration = TimeSpan.FromHours(1);
         private readonly IAzure _authenticatedAzureSubscription;
         private readonly AzureCredentialsFactory _azureCredentialsFactory = new AzureCredentialsFactory();
         private readonly IMemoryCache _memoryCache;
@@ -110,6 +111,7 @@ namespace Promitor.Integrations.AzureMonitor
             return measuredMetrics;
         }
 
+
         private async Task<IReadOnlyList<IMetricDefinition>> GetMetricDefinitionsAsync(string resourceId)
         {
             // Get cached metric definitions
@@ -120,7 +122,7 @@ namespace Promitor.Integrations.AzureMonitor
             
             // Get from API and cache it
             var foundMetricDefinitions = await _authenticatedAzureSubscription.MetricDefinitions.ListByResourceAsync(resourceId);
-            _memoryCache.Set(resourceId, foundMetricDefinitions, TimeSpan.FromMinutes(30));
+            _memoryCache.Set(resourceId, foundMetricDefinitions, _metricDefinitionCacheDuration);
 
             return foundMetricDefinitions;
         }

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -43,6 +43,7 @@ namespace Promitor.Integrations.AzureMonitor
         /// <param name="azureMonitorLoggingConfiguration">Options for Azure Monitor logging</param>
         /// <param name="metricSinkWriter">Writer to send metrics to all configured sinks</param>
         /// <param name="azureScrapingPrometheusMetricsCollector">Metrics collector to write metrics to Prometheus</param>
+        /// <param name="memoryCache">Memory cache to store items in for performance optimizations</param>
         /// <param name="loggerFactory">Factory to create loggers with</param>
         public AzureMonitorClient(AzureEnvironment azureCloud, string tenantId, string subscriptionId, AzureAuthenticationInfo azureAuthenticationInfo, MetricSinkWriter metricSinkWriter, IAzureScrapingPrometheusMetricsCollector azureScrapingPrometheusMetricsCollector, IMemoryCache memoryCache, ILoggerFactory loggerFactory, IOptions<AzureMonitorLoggingConfiguration> azureMonitorLoggingConfiguration)
         {

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -111,7 +111,6 @@ namespace Promitor.Integrations.AzureMonitor
             return measuredMetrics;
         }
 
-
         private async Task<IReadOnlyList<IMetricDefinition>> GetMetricDefinitionsAsync(string resourceId)
         {
             // Get cached metric definitions


### PR DESCRIPTION
Reduce the number of API calls to retrieve metric definitions through caching.

Fixes  #1914