### PR TITLE
fix: typo in Azure Synapse (Workspace) doc

### DIFF
--- a/docs/configuration/v2.x/metrics/synapse-workspace.md
+++ b/docs/configuration/v2.x/metrics/synapse-workspace.md
@@ -33,7 +33,7 @@ Example:
   - workspaceName: promitor-synapse
     resourceGroupName: promitor-sources
   resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
-  - name: synapse-apache-spark-pools
+  - name: synapse-workspaces
 ```
 
 <!-- markdownlint-disable MD033 -->


### PR DESCRIPTION
Fix typo in Azure Synapse (Workspace) doc (wrong name for resource discovery group)