### PR TITLE
fix: Honor flag not to include timestamps in system metrics for Prometheus

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,7 @@ version:
 
 - {{% tag added %}} Provide scraper for Azure Database for MySQL Servers  ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
  | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
+- {{% tag fixed %}} Honor flag not to include timestamps in system metrics for Prometheus ([#1915](https://github.com/tomkerkhove/promitor/pull/1915))
 
 #### Resource Discovery
 

--- a/src/Promitor.Core/Metrics/Prometheus/Collectors/PrometheusMetricsCollector.cs
+++ b/src/Promitor.Core/Metrics/Prometheus/Collectors/PrometheusMetricsCollector.cs
@@ -30,7 +30,7 @@ namespace Promitor.Core.Metrics.Prometheus.Collectors
             // Order labels alphabetically
             var orderedLabels = labels.OrderByDescending(kvp => kvp.Key).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-            var gauge = _metricFactory.CreateGauge(name, help: description, includeTimestamp: true, labelNames: orderedLabels.Keys.ToArray());
+            var gauge = _metricFactory.CreateGauge(name, help: description, includeTimestamp: includeTimestamp, labelNames: orderedLabels.Keys.ToArray());
             gauge.WithLabels(orderedLabels.Values.ToArray()).Set(value);
         }
     }

--- a/src/Promitor.sln
+++ b/src/Promitor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32505.173
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Agents", "Agents", "{710EC1C2-88E8-4D5C-A2DA-89C321CB7D48}"
 EndProject
@@ -61,6 +61,19 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Promitor.Integrations.Sinks.Atlassian.Statuspage", "Promitor.Integrations.Sinks.Atlassian.Statuspage\Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj", "{B30E58FF-47AD-41FC-94D2-DE4B9B6AD06B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Promitor.Integrations.Azure", "Promitor.Integrations.Azure\Promitor.Integrations.Azure.csproj", "{3D8F595A-3F37-4C20-A20E-6CF4ED06F298}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Grafana", "Grafana", "{961DBAFB-900C-4C09-94F5-642313A5DEFD}"
+	ProjectSection(SolutionItems) = preProject
+		..\config\grafana\dashboard-config.json = ..\config\grafana\dashboard-config.json
+		..\config\grafana\dashboards.yml = ..\config\grafana\dashboards.yml
+		..\config\grafana\datasources.yml = ..\config\grafana\datasources.yml
+		..\config\grafana\grafana.ini = ..\config\grafana\grafana.ini
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Prometheus", "Prometheus", "{614F1E5A-0E5C-4189-9B1C-FD596A959CBF}"
+	ProjectSection(SolutionItems) = preProject
+		..\config\prometheus\prometheus.yml = ..\config\prometheus\prometheus.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +164,8 @@ Global
 		{EE3568F2-BB20-4BD2-BD21-AE43E5B1EB77} = {05524B1B-9965-4E36-9626-A2823B8588AA}
 		{B30E58FF-47AD-41FC-94D2-DE4B9B6AD06B} = {59D7FFBC-3929-48AD-8C9C-242280D01CBD}
 		{3D8F595A-3F37-4C20-A20E-6CF4ED06F298} = {59D7FFBC-3929-48AD-8C9C-242280D01CBD}
+		{961DBAFB-900C-4C09-94F5-642313A5DEFD} = {1C184DB7-C5E5-41F4-9E0C-8A798B9ED0CA}
+		{614F1E5A-0E5C-4189-9B1C-FD596A959CBF} = {1C184DB7-C5E5-41F4-9E0C-8A798B9ED0CA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B47A777A-C793-453F-8F4F-7703551DFC4C}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #1915

<!-- markdownlint-enable -->
