### PR TITLE
fix: Ensure Resource Discovery increments current page to reduce CPU usage

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -9,6 +9,7 @@ version:
 - {{% tag added %}} Provide scraper for Azure Database for MySQL Servers  ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
  | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
 - {{% tag fixed %}} Honor flag not to include timestamps in system metrics for Prometheus ([#1915](https://github.com/tomkerkhove/promitor/pull/1915))
+- {{% tag fixed %}} CPU usage of Promitor Agent Resource Discovery goes insane ([#2018](https://github.com/tomkerkhove/promitor/pull/2051))
 
 #### Resource Discovery
 

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
@@ -31,9 +31,10 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
             Logger.LogTrace("Discovering Azure Resource Groups...");
 
             PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups = null;
+            int currentPage = -1
             do
             {
-                var currentPage = discoveredResourceGroups != null ? discoveredResourceGroups.PageInformation.CurrentPage + 1 : 0;
+                currentPage = currentPage + 1;
             
                 // Discover Azure subscriptions
                 discoveredResourceGroups = await AzureResourceRepository.DiscoverAzureResourceGroupsAsync(pageSize: 1000, currentPage: currentPage);

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
@@ -30,11 +30,13 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
         {
             Logger.LogTrace("Discovering Azure Resource Groups...");
 
-            PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups;
+            PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups = null;
             do
             {
+                var currentPage = discoveredResourceGroups != null ? discoveredResourceGroups.PageInformation.CurrentPage + 1 : 0;
+            
                 // Discover Azure subscriptions
-                discoveredResourceGroups = await AzureResourceRepository.DiscoverAzureResourceGroupsAsync(pageSize: 1000, currentPage: 0);
+                discoveredResourceGroups = await AzureResourceRepository.DiscoverAzureResourceGroupsAsync(pageSize: 1000, currentPage: currentPage);
 
                 // Report discovered information as metric
                 foreach (var resourceGroupInformation in discoveredResourceGroups.Result)

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
@@ -30,7 +30,7 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
         {
             Logger.LogTrace("Discovering Azure Resource Groups...");
 
-            PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups = null;
+            PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups;
             var currentPage = 1;
             do
             {

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureResourceGroupsDiscoveryBackgroundJob.cs
@@ -31,11 +31,9 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
             Logger.LogTrace("Discovering Azure Resource Groups...");
 
             PagedPayload<AzureResourceGroupInformation> discoveredResourceGroups = null;
-            int currentPage = -1
+            var currentPage = 1;
             do
             {
-                currentPage = currentPage + 1;
-            
                 // Discover Azure subscriptions
                 discoveredResourceGroups = await AzureResourceRepository.DiscoverAzureResourceGroupsAsync(pageSize: 1000, currentPage: currentPage);
 
@@ -44,6 +42,8 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
                 {
                     ReportDiscoveredAzureInfo(resourceGroupInformation);
                 }
+                
+                currentPage++;
             }
             while (discoveredResourceGroups.HasMore);
 

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureSubscriptionDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureSubscriptionDiscoveryBackgroundJob.cs
@@ -33,15 +33,18 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
             // Discover Azure subscriptions
 
             PagedPayload<AzureSubscriptionInformation> discoveredLandscape;
+            var currentPage = 1;
             do
             {
-                discoveredLandscape = await AzureResourceRepository.DiscoverAzureSubscriptionsAsync(pageSize: 1000, currentPage: 0);
+                discoveredLandscape = await AzureResourceRepository.DiscoverAzureSubscriptionsAsync(pageSize: 1000, currentPage: currentPage);
 
                 // Report discovered information as metric
                 foreach (var discoveredLandscapeItem in discoveredLandscape.Result)
                 {
                     ReportDiscoveredAzureInfo(discoveredLandscapeItem);
                 }
+
+                currentPage++;
             }
             while (discoveredLandscape.HasMore);
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Correct paging issue when fetching resources from Azure resource discovery.

Fixes #2018 

<!-- markdownlint-enable -->
