### PR TITLE
ci: Assign permissions for unit tests to be reported.

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -7,6 +7,12 @@ on:
     - .github/workflows/ci-code.yml
     - src/**
 
+# Assign permissions for unit tests to be reported.
+# See https://github.com/dorny/test-reporter/issues/168
+permissions:
+  statuses: write
+  checks: write
+
 jobs:
   verify_codebase:
     name: Verify Codebase


### PR DESCRIPTION
Relates to https://github.com/tomkerkhove/promitor/issues/2053
Being tested in https://github.com/tomkerkhove/promitor/pull/2054