### PR TITLE
fix: Added Order By to Graph Queries

### DIFF
--- a/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/Query/GraphQueryBuilder.cs
@@ -135,6 +135,19 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Query
             return this;
         }
 
+        public GraphQueryBuilder OrderByAsc(params string[] fields)
+        {
+            _queryBuilder.Append("| order by ");
+            for (int fieldCount = 0; fieldCount < fields.Length - 1; fieldCount++)
+            {
+                _queryBuilder.Append($"{fields[fieldCount]} asc, ");
+            }
+
+            _queryBuilder.AppendLine($"{fields.Last()} asc");
+
+            return this;
+        }
+
         public string Build()
         {
             return _queryBuilder.ToString().Trim();

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/Repositories/AzureResourceRepository.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/Repositories/AzureResourceRepository.cs
@@ -81,7 +81,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Repositories
         {
             var query = @"ResourceContainers
 | where type == ""microsoft.resources/subscriptions""
-| project tenantId, subscriptionId, name, state=properties[""state""], spendingLimit=properties[""subscriptionPolicies""][""spendingLimit""], quotaId=properties[""subscriptionPolicies""][""quotaId""], authorizationSource=properties[""authorizationSource""]";
+| project tenantId, subscriptionId, name, state=properties[""state""], spendingLimit=properties[""subscriptionPolicies""][""spendingLimit""], quotaId=properties[""subscriptionPolicies""][""quotaId""], authorizationSource=properties[""authorizationSource""]
+| order by tenantId asc, subscriptionId asc, name asc";
 
             var unparsedResults = await _azureResourceGraph.QueryAzureLandscapeAsync("Discover Azure Subscriptions", query, pageSize, currentPage);
             var foundSubscriptionInformation = ParseQueryResults(unparsedResults.Result, row => new AzureSubscriptionInformation
@@ -102,7 +103,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.Repositories
         {
             var query = @"ResourceContainers
 | where type == ""microsoft.resources/subscriptions/resourcegroups""
-| project tenantId, subscriptionId, name, location, provisioningState=properties[""provisioningState""], managedBy";
+| project tenantId, subscriptionId, name, location, provisioningState=properties[""provisioningState""], managedBy
+| order by tenantId asc, subscriptionId asc, name asc";
 
             var unparsedResults = await _azureResourceGraph.QueryAzureLandscapeAsync("Discover Azure Resource Groups", query, pageSize, currentPage);
             var foundResourceGroupInformation = ParseQueryResults(unparsedResults.Result, row => new AzureResourceGroupInformation

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryQuery.cs
@@ -42,7 +42,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                 .WithResourceGroupsWithName(criteriaDefinition.Include.ResourceGroups)
                 .WithinRegions(criteriaDefinition.Include.Regions)
                 .WithTags(criteriaDefinition.Include.Tags)
-                .Project(ProjectedFieldNames);
+                .Project(ProjectedFieldNames)
+                .OrderByAsc(ProjectedFieldNames);
 
             return graphQueryBuilder;
         }


### PR DESCRIPTION
Address possible issues when queries span multiple pages due to missing deterministic sort. 

Graph queries will now be made with an "order by" clause to provide deterministic sorting and therefore result ordering suitable for pagination.
