### PR TITLE
docs: List new releases in changelog

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,13 +6,8 @@ version:
 
 #### Scraper
 
-- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers  ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
- | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
-- {{% tag fixed %}} Honor flag not to include timestamps in system metrics for Prometheus ([#1915](https://github.com/tomkerkhove/promitor/pull/1915))
-- {{% tag fixed %}} Improve performance for scraping large amoung of Azure resrouces to reduce CPU usage ([#1834](https://github.com/tomkerkhove/promitor/issues/1834))
+None.
 
 #### Resource Discovery
 
-- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
- | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
-- {{% tag fixed %}} Ensure Resource Discovery background jobs handle paging well  to reduce CPU usage ([#2018](https://github.com/tomkerkhove/promitor/issues/2018))
+None.

--- a/changelog/content/released/v0.8.0-resource-discovery.md
+++ b/changelog/content/released/v0.8.0-resource-discovery.md
@@ -1,0 +1,12 @@
+---
+subtitle: "released on 2022-06-23"
+date: 2022-06-23T10:38:47+02:00
+weight: 1017
+version: Resource Discovery - v0.8.0
+---
+
+- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
+ | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
+- {{% tag fixed %}} Ensure Resource Discovery background jobs handle paging well to reduce CPU usage ([#2018](https://github.com/tomkerkhove/promitor/issues/2018))
+
+Full release notes can be found [here](https://github.com/tomkerkhove/promitor/releases/tag/ResourceDiscovery-v0.8.0).

--- a/changelog/content/released/v0.8.0-resource-discovery.md
+++ b/changelog/content/released/v0.8.0-resource-discovery.md
@@ -5,7 +5,7 @@ weight: 1017
 version: Resource Discovery - v0.8.0
 ---
 
-- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
+- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers ([docs](https://docs.promitor.io/v2.7/scraping/providers/mysql/)
  | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
 - {{% tag fixed %}} Ensure Resource Discovery background jobs handle paging well to reduce CPU usage ([#2018](https://github.com/tomkerkhove/promitor/issues/2018))
 

--- a/changelog/content/released/v2.7.0-scraper.md
+++ b/changelog/content/released/v2.7.0-scraper.md
@@ -1,0 +1,13 @@
+---
+subtitle: "released on 2022-06-23"
+date: 2022-06-23T10:38:47+02:00
+weight: 1016
+version: Scraper - v2.7.0
+---
+
+- {{% tag added %}} Provide scraper for Azure Database for MySQL Servers  ([docs](https://docs.promitor.io/v2.x/scraping/providers/mysql/)
+ | [#1880](https://github.com/tomkerkhove/promitor/issues/324))
+- {{% tag fixed %}} Honor flag not to include timestamps in system metrics for Prometheus ([#1915](https://github.com/tomkerkhove/promitor/pull/1915))
+- {{% tag fixed %}} Improve performance for scraping large amoung of Azure resrouces to reduce CPU usage ([#1834](https://github.com/tomkerkhove/promitor/issues/1834))
+
+Full release notes can be found [here](https://github.com/tomkerkhove/promitor/releases/tag/Scraper-v2.7.0).


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
