### PR TITLE
fix: Ensure scraper works without resource discovery

### DIFF
--- a/src/Promitor.Agents.Scraper/Discovery/Interfaces/IResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/Interfaces/IResourceDiscoveryRepository.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Promitor.Agents.Core.Contracts;
+using Promitor.Core.Contracts;
+
+namespace Promitor.Agents.Scraper.Discovery.Interfaces
+{
+    public interface IResourceDiscoveryRepository
+    {
+        Task<List<AzureResourceDefinition>> GetResourceDiscoveryGroupAsync(string resourceDiscoveryGroupName);
+        Task<AgentHealthReport> GetHealthAsync();
+    }
+}

--- a/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryRepository.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using GuardNet;
+using Promitor.Agents.Core.Contracts;
+using Promitor.Agents.Scraper.Discovery.Interfaces;
 using Promitor.Core.Contracts;
 
 namespace Promitor.Agents.Scraper.Discovery
 {
-    public class ResourceDiscoveryRepository
+    public class ResourceDiscoveryRepository : IResourceDiscoveryRepository
     {
         private readonly ResourceDiscoveryClient _resourceDiscoveryClient;
 
@@ -33,6 +35,11 @@ namespace Promitor.Agents.Scraper.Discovery
             while (pagedPayload.HasMore);
 
             return results;
+        }
+
+        public async Task<AgentHealthReport> GetHealthAsync()
+        {
+            return await _resourceDiscoveryClient.GetHealthAsync();
         }
     }
 }

--- a/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Promitor.Agents.Core.Contracts;
+using Promitor.Agents.Scraper.Discovery.Interfaces;
+using Promitor.Core.Contracts;
+
+namespace Promitor.Agents.Scraper.Discovery
+{
+    public class StubResourceDiscoveryRepository : IResourceDiscoveryRepository
+    {
+        private static readonly List<AzureResourceDefinition> emptyResourceDefinitions = new List<AzureResourceDefinition>();
+        private static readonly AgentHealthReport healthReport = new AgentHealthReport();
+
+        public Task<List<AzureResourceDefinition>> GetResourceDiscoveryGroupAsync(string resourceDiscoveryGroupName)
+        {
+            return Task.FromResult(emptyResourceDefinitions);
+        }
+
+        public Task<AgentHealthReport> GetHealthAsync()
+        {
+            return Task.FromResult(healthReport);
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -248,7 +248,7 @@
             the same scraping schedule.
             </summary>
         </member>
-        <member name="M:Promitor.Agents.Scraper.Scheduling.ResourcesScrapingJob.#ctor(System.String,Promitor.Core.Scraping.Configuration.Model.MetricsDeclaration,Promitor.Agents.Scraper.Discovery.ResourceDiscoveryRepository,Promitor.Core.Metrics.Sinks.MetricSinkWriter,Promitor.Core.Scraping.Factories.MetricScraperFactory,Promitor.Agents.Scraper.AzureMonitorClientFactory,Promitor.Core.Metrics.Prometheus.Collectors.Interfaces.IAzureScrapingPrometheusMetricsCollector,Microsoft.Extensions.Caching.Memory.IMemoryCache,Promitor.Agents.Scraper.Scheduling.IScrapingMutex,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorIntegrationConfiguration},Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorLoggingConfiguration},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Scheduling.ResourcesScrapingJob})">
+        <member name="M:Promitor.Agents.Scraper.Scheduling.ResourcesScrapingJob.#ctor(System.String,Promitor.Core.Scraping.Configuration.Model.MetricsDeclaration,Promitor.Agents.Scraper.Discovery.Interfaces.IResourceDiscoveryRepository,Promitor.Core.Metrics.Sinks.MetricSinkWriter,Promitor.Core.Scraping.Factories.MetricScraperFactory,Promitor.Agents.Scraper.AzureMonitorClientFactory,Promitor.Core.Metrics.Prometheus.Collectors.Interfaces.IAzureScrapingPrometheusMetricsCollector,Microsoft.Extensions.Caching.Memory.IMemoryCache,Promitor.Agents.Scraper.Scheduling.IScrapingMutex,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorIntegrationConfiguration},Microsoft.Extensions.Options.IOptions{Promitor.Integrations.AzureMonitor.Configuration.AzureMonitorLoggingConfiguration},Microsoft.Extensions.Logging.ILoggerFactory,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Scheduling.ResourcesScrapingJob})">
             <summary>
             Create a metrics scraping job for one or more resources, either enumerated specifically or
             identified via resource definition groups. All metrics included are expected to have
@@ -337,12 +337,13 @@
             <param name="configuration">Configuration of Promitor</param>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddResourceDiscoveryClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String)">
+        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddResourceDiscoveryClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>
                 Add the Promitor Resource Discovery client
             </summary>
             <param name="services">Collections of services in application</param>
             <param name="promitorUserAgent">User agent for Promitor</param>
+            <param name="configuration"></param>
         </member>
         <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddAtlassianStatuspageClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>

--- a/src/Promitor.Agents.Scraper/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Extensions/IServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using JustEat.StatsD;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using Promitor.Agents.Core.Configuration.Server;
 using Promitor.Agents.Core.Configuration.Telemetry;

--- a/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
+++ b/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
@@ -4,25 +4,26 @@ using System.Threading.Tasks;
 using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Promitor.Agents.Scraper.Discovery;
+using Promitor.Agents.Scraper.Discovery.Interfaces;
 
 namespace Promitor.Agents.Scraper.Health
 {
     public class ResourceDiscoveryHealthCheck : IHealthCheck
     {
-        private readonly ResourceDiscoveryClient _resourceDiscoveryClient;
+        private readonly IResourceDiscoveryRepository _resourceDiscoveryRepository;
 
-        public ResourceDiscoveryHealthCheck(ResourceDiscoveryClient resourceDiscoveryClient)
+        public ResourceDiscoveryHealthCheck(IResourceDiscoveryRepository resourceDiscoveryRepository)
         {
-            Guard.NotNull(resourceDiscoveryClient, nameof(resourceDiscoveryClient));
+            Guard.NotNull(resourceDiscoveryRepository, nameof(resourceDiscoveryRepository));
 
-            _resourceDiscoveryClient = resourceDiscoveryClient;
+            _resourceDiscoveryRepository = resourceDiscoveryRepository;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
         {
             try
             {
-                var resourceDiscoveryHealthReport = await _resourceDiscoveryClient.GetHealthAsync();
+                var resourceDiscoveryHealthReport = await _resourceDiscoveryRepository.GetHealthAsync();
                 if (resourceDiscoveryHealthReport.Status == HealthStatus.Healthy)
                 {
                     return HealthCheckResult.Healthy("Successfully contacted Promitor Resource Discovery");

--- a/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
+++ b/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Promitor.Agents.Scraper.Discovery;
 using Promitor.Agents.Scraper.Discovery.Interfaces;
 
 namespace Promitor.Agents.Scraper.Health

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Discovery\Interfaces\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CronScheduler.Extensions.Scheduler;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Promitor.Agents.Scraper.Discovery;
+using Promitor.Agents.Scraper.Discovery.Interfaces;
 using Promitor.Core.Contracts;
 using Promitor.Core.Metrics.Prometheus.Collectors.Interfaces;
 using Promitor.Core.Metrics.Sinks;
@@ -28,7 +30,7 @@ namespace Promitor.Agents.Scraper.Scheduling
     public class ResourcesScrapingJob : MetricScrapingJob, IScheduledJob
     {
         private readonly MetricsDeclaration _metricsDeclaration;
-        private readonly ResourceDiscoveryRepository _resourceDiscoveryRepository;
+        private readonly IResourceDiscoveryRepository _resourceDiscoveryRepository;
         private readonly MetricSinkWriter _metricSinkWriter;
         private readonly MetricScraperFactory _metricScraperFactory;
         private readonly IAzureScrapingPrometheusMetricsCollector _azureScrapingPrometheusMetricsCollector;
@@ -61,7 +63,7 @@ namespace Promitor.Agents.Scraper.Scheduling
         /// <param name="logger">logger to use for scraping detail</param>
         public ResourcesScrapingJob(string jobName,
             MetricsDeclaration metricsDeclaration,
-            ResourceDiscoveryRepository resourceDiscoveryRepository,
+            IResourceDiscoveryRepository resourceDiscoveryRepository,
             MetricSinkWriter metricSinkWriter,
             MetricScraperFactory metricScraperFactory,
             AzureMonitorClientFactory azureMonitorClientFactory,
@@ -165,7 +167,7 @@ namespace Promitor.Agents.Scraper.Scheduling
                         throw new NullReferenceException("Metric within metrics declaration was null.");
                     }
 
-                    if (metric.ResourceDiscoveryGroups != null)
+                    if (metric.ResourceDiscoveryGroups?.Any() == true)
                     {
                         foreach (var resourceDiscoveryGroup in metric.ResourceDiscoveryGroups)
                         {
@@ -182,7 +184,7 @@ namespace Promitor.Agents.Scraper.Scheduling
                         }
                     }
 
-                    if (metric.Resources != null)
+                    if (metric.Resources?.Any() == true)
                     {
                         foreach (var resourceDefinition in metric.Resources)
                         {

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Promitor.Agents.Scraper.Discovery;
 using Promitor.Agents.Scraper.Discovery.Interfaces;
 using Promitor.Core.Contracts;
 using Promitor.Core.Metrics.Prometheus.Collectors.Interfaces;

--- a/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Promitor.Agents.Core.Observability;
 using Promitor.Agents.Scraper;
 using Promitor.Agents.Scraper.Discovery;
+using Promitor.Agents.Scraper.Discovery.Interfaces;
 using Promitor.Agents.Scraper.Scheduling;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Core.Scraping.Factories;
@@ -97,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 builder.AddJob(jobServices =>
                         new ResourcesScrapingJob(jobName,
                             metricsDeclaration,
-                            jobServices.GetService<ResourceDiscoveryRepository>(),
+                            jobServices.GetService<IResourceDiscoveryRepository>(),
                             metricSinkWriter,
                             jobServices.GetService<MetricScraperFactory>(),
                             azureMonitorClientFactory,

--- a/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Promitor.Agents.Core.Observability;
 using Promitor.Agents.Scraper;
-using Promitor.Agents.Scraper.Discovery;
 using Promitor.Agents.Scraper.Discovery.Interfaces;
 using Promitor.Agents.Scraper.Scheduling;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -41,7 +41,7 @@ namespace Promitor.Agents.Scraper
 
             services.UseWebApi()
                 .AddMemoryCache()
-                .AddResourceDiscoveryClient(promitorUserAgent)
+                .AddResourceDiscoveryClient(promitorUserAgent, Configuration)
                 .AddAtlassianStatuspageClient(promitorUserAgent, Configuration)
                 .AddUsability()
                 .AddHttpCorrelation(options => options.UpstreamService.ExtractFromRequest = true)


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #2104

<!-- markdownlint-enable -->
