### PR TITLE
 test(resource-discovery): Provide unit tests for AzureResourceGroupsDiscoveryBackgroundJob

### DIFF
--- a/src/Promitor.Tests.Unit/Agents/ResourceDiscovery/AzureResourceGroupsDiscoveryBackgroundJobTests.cs
+++ b/src/Promitor.Tests.Unit/Agents/ResourceDiscovery/AzureResourceGroupsDiscoveryBackgroundJobTests.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using Promitor.Agents.ResourceDiscovery.Graph.Model;
+using Promitor.Agents.ResourceDiscovery.Graph.Repositories.Interfaces;
+using Promitor.Agents.ResourceDiscovery.Scheduling;
+using Promitor.Core.Metrics.Interfaces;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Agents.ResourceDiscovery
+{
+    public class AzureResourceGroupsDiscoveryBackgroundJobTests
+    {
+        private readonly Mock<IAzureResourceRepository> _azureResourceRepository;
+        private readonly Mock<ISystemMetricsPublisher> _systemMetricsPublisher;
+        private readonly AzureSubscriptionDiscoveryBackgroundJob _azureResourceGroupsDiscoveryBackgroundJob;
+        private readonly Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation> firstPage;
+        private readonly Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation> secondPage;
+
+        public AzureResourceGroupsDiscoveryBackgroundJobTests()
+        {
+            _azureResourceRepository = new Mock<IAzureResourceRepository>(MockBehavior.Strict);
+            _systemMetricsPublisher = new Mock<ISystemMetricsPublisher>(MockBehavior.Strict);
+            var logger = new Mock<ILogger<AzureSubscriptionDiscoveryBackgroundJob>>(MockBehavior.Loose);
+            _azureResourceGroupsDiscoveryBackgroundJob = new AzureSubscriptionDiscoveryBackgroundJob("jobName", _azureResourceRepository.Object, _systemMetricsPublisher.Object, logger.Object);
+
+            firstPage = new Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation>()
+            {
+                PageInformation = new Promitor.Core.Contracts.PageInformation { CurrentPage = 1, PageSize = 1, TotalRecords = 1 },
+                Result = new List<AzureSubscriptionInformation>() { new AzureSubscriptionInformation { TenantId = "TenantId", Id = "ID", Name = "Name" } }
+            };
+            secondPage = new Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation>()
+            {
+                PageInformation = new Promitor.Core.Contracts.PageInformation { CurrentPage = 2, PageSize = 1, TotalRecords = 1 },
+                Result = new List<AzureSubscriptionInformation>() { new AzureSubscriptionInformation { TenantId = "TenantId", Id = "ID", Name = "Name" } }
+            };
+            _azureResourceRepository.Setup(r => r.DiscoverAzureSubscriptionsAsync(1000, 1)).ReturnsAsync(firstPage);
+            _azureResourceRepository.Setup(r => r.DiscoverAzureSubscriptionsAsync(1000, 2)).ReturnsAsync(secondPage);
+            _systemMetricsPublisher.Setup(p => p.WriteGaugeMeasurementAsync(It.IsAny<string>(), It.IsAny<string>(), 1, It.IsAny<Dictionary<string, string>>(), true)).Returns(Task.CompletedTask);
+        }
+
+        [Fact]
+        public async Task AzureResourceGroupsDiscoveryBackgroundJob_Execution_Succeeds()
+        {
+            // Act
+            await _azureResourceGroupsDiscoveryBackgroundJob.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            _systemMetricsPublisher.Verify(p => p.WriteGaugeMeasurementAsync("promitor_azure_landscape_subscription_info", It.IsAny<string>(), 1,
+                It.Is<Dictionary<string, string>>(d =>
+                d["tenant_id"] == "TenantId" &&
+                d["subscription_id"] == "ID" &&
+                d["subscription_name"] == "Name"
+                )
+                , true), Times.Once);
+        }
+
+        [Fact]
+        public async Task AzureResourceGroupsDiscoveryBackgroundJob_Execution_LoopsOnMultiplePages()
+        {
+            // Arrange
+            firstPage.PageInformation.TotalRecords = 2;
+
+            // Act
+            await _azureResourceGroupsDiscoveryBackgroundJob.ExecuteAsync(CancellationToken.None);
+
+            // Assert
+            _systemMetricsPublisher.Verify(p => p.WriteGaugeMeasurementAsync("promitor_azure_landscape_subscription_info", It.IsAny<string>(), 1,
+                It.Is<Dictionary<string, string>>(d =>
+                d["tenant_id"] == "TenantId" &&
+                d["subscription_id"] == "ID" &&
+                d["subscription_name"] == "Name"
+                )
+                , true), Times.Exactly(2));
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #2052 by providing unit tests for AzureResourceGroupsDiscoveryBackgroundJob

<!-- markdownlint-enable -->
