### PR TITLE
fix: Don't schedule scraping jobs when metrics are misconfigured

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,7 @@ version:
 
 - {{% tag added %}} Provide custom formatting for emitting metrics using StatsD sink in Geneva format
 - {{% tag added %}} Provide Azure Log Analytics scraper ([docs](https://docs.promitor.io/v2.9/scraping/providers/log-analytics/)| [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
+- {{% tag fixed %}} Fixed a bug where startup throws scheduling exception due to metric misconfiguration
 
 #### Resource Discovery
 

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -7,7 +7,8 @@ version:
 #### Scraper
 
 - {{% tag added %}} Provide custom formatting for emitting metrics using StatsD sink in Geneva format
-- {{% tag added %}} Provide Azure Log Analytics scraper ([docs](https://docs.promitor.io/v2.9/scraping/providers/log-analytics/)| [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
+- {{% tag added %}} Provide Azure Log Analytics scraper ([docs](https://docs.promitor.io/v2.9/scraping/providers/log-analytics/)
+| [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
 - {{% tag fixed %}} Fixed a bug where startup throws scheduling exception due to metric misconfiguration
 
 #### Resource Discovery

--- a/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/SchedulingExtensions.cs
@@ -14,6 +14,7 @@ using Promitor.Core.Scraping.Factories;
 using Promitor.Core.Metrics.Sinks;
 using Promitor.Core.Scraping.Configuration.Model;
 using Promitor.Integrations.AzureMonitor.Configuration;
+using Promitor.Core.Scraping.Configuration.Serialization;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,7 +30,12 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var serviceProviderToCreateJobsWith = services.BuildServiceProvider();
             var metricsProvider = serviceProviderToCreateJobsWith.GetRequiredService<IMetricsDeclarationProvider>();
-            var allMetrics = metricsProvider.Get(applyDefaults: true);
+            var errorReporter = new ErrorReporter();
+            var allMetrics = metricsProvider.Get(applyDefaults: true, errorReporter: errorReporter);
+            if (errorReporter.HasErrors)
+            {
+                return services;
+            }
 
             // this is relied on as non-null down the stack
             var loggerFactory = serviceProviderToCreateJobsWith.GetRequiredService<ILoggerFactory>();


### PR DESCRIPTION
Don't schedule scraping jobs when metrics are misconfigured, otherwise the following exception will be thrown:
```
█████╗ ██████╗ ██████╗ 

██╔══██╗██╔══██╗██╔═══██╗████╗ ████║██║╚══██╔══╝██╔═══██╗██╔══██╗

██████╔╝██████╔╝██║   ██║██╔████╔██║██║   ██║   ██║   ██║██████╔╝

██╔═══╝ ██╔══██╗██║   ██║██║╚██╔╝██║██║   ██║   ██║   ██║██╔══██╗

██║     ██║  ██║╚██████╔╝██║ ╚═╝ ██║██║   ██║   ╚██████╔╝██║  ██║

╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
[09:14:39 INF] Booting up Promitor v1.0.0 running .NET .NET 6.0.10 - Thank you for using Promitor!
[09:14:39 INF] Running .NET 6.0.10 on Linux (alpine.3.16-x64 | Linux 5.10.102.1-microsoft-standard-WSL2 #1 SMP Wed Mar 2 00:30:59 UTC 2022).
[09:14:39 INF] Using configuration folder '/config/'
[09:14:41 INF] The following metric sinks were configured and are being enabled:
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Metric Sink                  │ Details                                   ┃
┠──────────────────────────────┼───────────────────────────────────────────┨
┃ StatsD                       │ Url: graphite:8125.                       ┃
┃ Prometheus Scraping Endpoint │ Url: /metrics.                            ┃
┃ Atlassian Statuspage         │ Page ID: 4mwc0ny6bgw1.                    ┃
┃ OpenTelemetry Collector      │ Url: http://opentelemetry-collector:4317. ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                          Configured Metric Sinks                           
[09:14:42 FTL] Promitor Scraper Agent has encountered an unexpected error. Please open an issue at https://github.com/tomkerkhove/promitor/issues to let us know about it.
System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Microsoft.Extensions.DependencyInjection.SchedulingExtensions.GroupMetricsByScrapingInterval(MetricsDeclaration allMetrics) in C:\Code\GitHub\promitor-core\src\Promitor.Agents.Scraper\Scheduling\SchedulingExtensions.cs:line 64
   at Microsoft.Extensions.DependencyInjection.SchedulingExtensions.ScheduleMetricScraping(IServiceCollection services) in C:\Code\GitHub\promitor-core\src\Promitor.Agents.Scraper\Scheduling\SchedulingExtensions.cs:line 47
   at Promitor.Agents.Scraper.Startup.ConfigureServices(IServiceCollection services) in C:\Code\GitHub\promitor-core\src\Promitor.Agents.Scraper\Startup.cs:line 57
```