### PR TITLE
fix: Provide all metric labels in OpenTelemetry & StatsD

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -7,6 +7,8 @@ version:
 #### Scraper
 
 - {{% tag added %}} Provide custom formatting for emitting metrics using StatsD sink in Geneva format
+- {{% tag added %}} Provide support for all label scenarios in StatsD & OpenTelemetry metric sink. This includes 
+dimensions, customer & default labels.
 - {{% tag added %}} Provide Azure Log Analytics scraper ([docs](https://docs.promitor.io/v2.9/scraping/providers/log-analytics/)| [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
 
 #### Resource Discovery

--- a/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Providers/MetricsDeclarationProvider.cs
@@ -69,6 +69,7 @@ namespace Promitor.Core.Scraping.Configuration.Providers
                     metric.LogAnalyticsConfiguration.Aggregation.Interval ??= config.MetricDefaults.Aggregation?.Interval;
                 }
             }
+
             return config;
         }
 

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Metrics\Sinks\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/AtlassianStatusPageMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/AtlassianStatusPageMetricSink.cs
@@ -6,28 +6,28 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Promitor.Core;
 using Promitor.Core.Metrics.Sinks;
+using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Integrations.Sinks.Atlassian.Statuspage.Configuration;
+using Promitor.Integrations.Sinks.Core;
 
 namespace Promitor.Integrations.Sinks.Atlassian.Statuspage
 {
-    public class AtlassianStatuspageMetricSink : IMetricSink
+    public class AtlassianStatuspageMetricSink : MetricSink, IMetricSink
     {
-        private readonly ILogger<AtlassianStatuspageMetricSink> _logger;
         private readonly IAtlassianStatuspageClient _atlassianStatusPageClient;
         private readonly IOptionsMonitor<AtlassianStatusPageSinkConfiguration> _sinkConfiguration;
 
-        public MetricSinkType Type { get; } = MetricSinkType.AtlassianStatuspage;
+        public MetricSinkType Type => MetricSinkType.AtlassianStatuspage;
 
-        public AtlassianStatuspageMetricSink(IAtlassianStatuspageClient atlassianStatusPageClient, IOptionsMonitor<AtlassianStatusPageSinkConfiguration> sinkConfiguration, ILogger<AtlassianStatuspageMetricSink> logger)
+        public AtlassianStatuspageMetricSink(IAtlassianStatuspageClient atlassianStatusPageClient, IMetricsDeclarationProvider metricsDeclarationProvider, IOptionsMonitor<AtlassianStatusPageSinkConfiguration> sinkConfiguration, ILogger<AtlassianStatuspageMetricSink> logger)
+            : base(metricsDeclarationProvider, logger)
         {
             Guard.NotNull(atlassianStatusPageClient, nameof(atlassianStatusPageClient));
             Guard.NotNull(sinkConfiguration, nameof(sinkConfiguration));
             Guard.NotNull(sinkConfiguration.CurrentValue, nameof(sinkConfiguration.CurrentValue));
-            Guard.NotNull(logger, nameof(logger));
 
             _atlassianStatusPageClient = atlassianStatusPageClient;
             _sinkConfiguration = sinkConfiguration;
-            _logger = logger;
         }
 
         public async Task ReportMetricAsync(string metricName, string metricDescription, ScrapeResult scrapeResult)
@@ -59,7 +59,7 @@ namespace Promitor.Integrations.Sinks.Atlassian.Statuspage
                 await _atlassianStatusPageClient.ReportMetricAsync(systemMetricMapping.Id, metricValue);
             }
 
-            _logger.LogTrace("Metric {MetricName} with value {MetricValue} was written to Atlassian Statuspage", metricName, metricValue);
+            Logger.LogTrace("Metric {MetricName} with value {MetricValue} was written to Atlassian Statuspage", metricName, metricValue);
         }
     }
 }

--- a/src/Promitor.Integrations.Sinks.Core/MetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Core/MetricSink.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Promitor.Core;
+using Promitor.Core.Metrics;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
+
+namespace Promitor.Integrations.Sinks.Core
+{
+    public class MetricSink
+    {
+        protected ILogger Logger { get; }
+        protected IMetricsDeclarationProvider MetricsDeclarationProvider { get; }
+
+        protected MetricSink(IMetricsDeclarationProvider metricsDeclarationProvider, ILogger logger)
+        {
+            Guard.NotNull(metricsDeclarationProvider, nameof(metricsDeclarationProvider));
+            Guard.NotNull(logger, nameof(logger));
+
+            MetricsDeclarationProvider = metricsDeclarationProvider;
+            Logger = logger;
+        }
+
+        public Dictionary<string, string> DetermineLabels(string metricName, ScrapeResult scrapeResult, MeasuredMetric measuredMetric, Func<string, string> mutateLabelName = null)
+        {
+            var metricDefinition = MetricsDeclarationProvider.GetPrometheusDefinition(metricName);
+            var defaultLabels = MetricsDeclarationProvider.GetDefaultLabels();
+
+            var labels = new Dictionary<string, string>(scrapeResult.Labels.Select(label =>
+            {
+                var labelName = DetermineLabelName(label.Value, mutateLabelName);
+                return new KeyValuePair<string, string>(labelName, label.Value);
+            }));
+
+            if (measuredMetric.IsDimensional)
+            {
+                labels.Add(DetermineLabelName(measuredMetric.DimensionName, mutateLabelName), measuredMetric.DimensionValue);
+            }
+
+            if (metricDefinition?.Labels?.Any() == true)
+            {
+                foreach (var customLabel in metricDefinition.Labels)
+                {
+                    var customLabelKey = DetermineLabelName(customLabel.Key, mutateLabelName);
+                    if (labels.ContainsKey(customLabelKey))
+                    {
+                        Logger.LogWarning("Custom label {CustomLabelName} was already specified with value '{LabelValue}' instead of '{CustomLabelValue}'. Ignoring...", customLabel.Key, labels[customLabelKey], customLabel.Value);
+                        continue;
+                    }
+
+                    labels.Add(customLabelKey, customLabel.Value);
+                }
+            }
+
+            foreach (var defaultLabel in defaultLabels)
+            {
+                var defaultLabelKey = DetermineLabelName(defaultLabel.Key, mutateLabelName);
+                if (labels.ContainsKey(defaultLabelKey) == false)
+                {
+                    labels.Add(defaultLabelKey, defaultLabel.Value);
+                }
+            }
+
+            // Add the tenant id
+            var metricsDeclaration = MetricsDeclarationProvider.Get(applyDefaults: true);
+            if (labels.ContainsKey("tenant_id") == false)
+            {
+                labels.Add("tenant_id", metricsDeclaration.AzureMetadata.TenantId);
+            }
+
+            var orderedLabels = labels.OrderBy(kvp => kvp.Key).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            return orderedLabels;
+        }
+
+        private static string DetermineLabelName(string originalLabelName, Func<string, string> mutateLabelName)
+        {
+            return mutateLabelName!= null ? mutateLabelName.Invoke(originalLabelName) : originalLabelName;
+        }
+    }
+}

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -14,13 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flurl" Version="3.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Promitor.Core.Scraping\Promitor.Core.Scraping.csproj" />
-    <ProjectReference Include="..\Promitor.Integrations.Sinks.Core\Promitor.Integrations.Sinks.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
@@ -9,17 +9,20 @@ using GuardNet;
 using Microsoft.Extensions.Logging;
 using Promitor.Core;
 using Promitor.Core.Metrics.Sinks;
+using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
+using Promitor.Integrations.Sinks.Core;
 
 namespace Promitor.Integrations.Sinks.OpenTelemetry
 {
-    public class OpenTelemetryCollectorMetricSink : IMetricSink
+    public class OpenTelemetryCollectorMetricSink : MetricSink, IMetricSink
     {
         private readonly ILogger<OpenTelemetryCollectorMetricSink> _logger;
         private static readonly Meter azureMonitorMeter = new Meter("Promitor.Scraper.Metrics.AzureMonitor", "1.0");
 
         public MetricSinkType Type => MetricSinkType.OpenTelemetryCollector;
 
-        public OpenTelemetryCollectorMetricSink(ILogger<OpenTelemetryCollectorMetricSink> logger)
+        public OpenTelemetryCollectorMetricSink(IMetricsDeclarationProvider metricsDeclarationProvider, ILogger<OpenTelemetryCollectorMetricSink> logger)
+            : base(metricsDeclarationProvider, logger)
         {
             Guard.NotNull(logger, nameof(logger));
 
@@ -38,7 +41,9 @@ namespace Promitor.Integrations.Sinks.OpenTelemetry
             {
                 var metricValue = measuredMetric.Value ?? 0;
                 
-                var reportMetricTask = ReportMetricAsync(metricName, metricDescription, metricValue, scrapeResult.Labels);
+                var metricLabels = base.DetermineLabels(metricName, scrapeResult, measuredMetric);
+
+                var reportMetricTask = ReportMetricAsync(metricName, metricDescription, metricValue, metricLabels);
                 reportMetricTasks.Add(reportMetricTask);
             }
 

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Promitor.Core.Scraping\Promitor.Core.Scraping.csproj" />
+    <ProjectReference Include="..\Promitor.Integrations.Sinks.Core\Promitor.Integrations.Sinks.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Promitor.Core.Scraping\Promitor.Core.Scraping.csproj" />
+    <ProjectReference Include="..\Promitor.Integrations.Sinks.Core\Promitor.Integrations.Sinks.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Promitor.Core.Scraping\Promitor.Core.Scraping.csproj" />
+    <ProjectReference Include="..\Promitor.Integrations.Sinks.Core\Promitor.Integrations.Sinks.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -9,17 +9,19 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Promitor.Core;
 using Promitor.Core.Metrics.Sinks;
+using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
+using Promitor.Integrations.Sinks.Core;
 using Promitor.Integrations.Sinks.Statsd.Configuration;
 
 namespace Promitor.Integrations.Sinks.Statsd
 {
-    public class StatsdMetricSink : IMetricSink
+    public class StatsdMetricSink : MetricSink, IMetricSink
     {
-        private readonly ILogger<StatsdMetricSink> _logger;
         private readonly IStatsDPublisher _statsDPublisher;
         private readonly IOptionsMonitor<StatsdSinkConfiguration> _statsDConfiguration;       
 
-        public StatsdMetricSink(IStatsDPublisher statsDPublisher, IOptionsMonitor<StatsdSinkConfiguration> configuration, ILogger<StatsdMetricSink> logger)
+        public StatsdMetricSink(IStatsDPublisher statsDPublisher, IMetricsDeclarationProvider metricsDeclarationProvider, IOptionsMonitor<StatsdSinkConfiguration> configuration, ILogger<StatsdMetricSink> logger)
+            : base(metricsDeclarationProvider, logger)
         {
             Guard.NotNull(statsDPublisher, nameof(statsDPublisher));
             Guard.NotNull(logger, nameof(logger));
@@ -27,7 +29,6 @@ namespace Promitor.Integrations.Sinks.Statsd
 
             _statsDPublisher = statsDPublisher;
             _statsDConfiguration = configuration;
-            _logger = logger;
         }
 
         public MetricSinkType Type => MetricSinkType.StatsD;
@@ -78,7 +79,7 @@ namespace Promitor.Integrations.Sinks.Statsd
             Guard.NotNullOrEmpty(metricName, nameof(metricName));
             Guard.NotNull(_statsDConfiguration.CurrentValue, nameof(_statsDConfiguration.CurrentValue));
             Guard.NotNull(_statsDConfiguration.CurrentValue.Geneva, new ArgumentException ("Geneva formatter settings are required", nameof(_statsDConfiguration.CurrentValue.Geneva)));
-
+            
             var bucket = JsonConvert.SerializeObject(new
             {
                 _statsDConfiguration.CurrentValue.Geneva?.Account,
@@ -96,7 +97,7 @@ namespace Promitor.Integrations.Sinks.Statsd
 
         private void LogMetricWritten(string metricName, double metricValue)
         {
-            _logger.LogTrace("Metric {MetricName} with value {MetricValue} was written to StatsD server", metricName, metricValue);
+            Logger.LogTrace("Metric {MetricName} with value {MetricValue} was written to StatsD server", metricName, metricValue);
         }
     }
 }

--- a/src/Promitor.sln
+++ b/src/Promitor.sln
@@ -82,7 +82,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OpenTelemetry", "OpenTeleme
 		..\config\opentelemetry-collector\collector-config.yaml = ..\config\opentelemetry-collector\collector-config.yaml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Promitor.Integrations.LogAnalytics", "Promitor.Integrations.LogAnalytics\Promitor.Integrations.LogAnalytics.csproj", "{2427547B-090A-460D-A631-A41D71545281}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Promitor.Integrations.LogAnalytics", "Promitor.Integrations.LogAnalytics\Promitor.Integrations.LogAnalytics.csproj", "{2427547B-090A-460D-A631-A41D71545281}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Promitor.Integrations.Sinks.Core", "Promitor.Integrations.Sinks.Core\Promitor.Integrations.Sinks.Core.csproj", "{25F056A7-481E-48E1-A22B-1D13BB4F4239}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -157,6 +159,10 @@ Global
 		{2427547B-090A-460D-A631-A41D71545281}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2427547B-090A-460D-A631-A41D71545281}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2427547B-090A-460D-A631-A41D71545281}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25F056A7-481E-48E1-A22B-1D13BB4F4239}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25F056A7-481E-48E1-A22B-1D13BB4F4239}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25F056A7-481E-48E1-A22B-1D13BB4F4239}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25F056A7-481E-48E1-A22B-1D13BB4F4239}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -186,6 +192,7 @@ Global
 		{614F1E5A-0E5C-4189-9B1C-FD596A959CBF} = {1C184DB7-C5E5-41F4-9E0C-8A798B9ED0CA}
 		{F6988AF7-6E1E-431B-B2A4-C485D5E8CF64} = {1C184DB7-C5E5-41F4-9E0C-8A798B9ED0CA}
 		{2427547B-090A-460D-A631-A41D71545281} = {59D7FFBC-3929-48AD-8C9C-242280D01CBD}
+		{25F056A7-481E-48E1-A22B-1D13BB4F4239} = {59D7FFBC-3929-48AD-8C9C-242280D01CBD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B47A777A-C793-453F-8F4F-7703551DFC4C}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #2180
