### PR TITLE
fix: Geneva MDM does not supporting doubles (#2223)Co-authored-by: Sagi Vaknin <sagivaknin@microsoft.com>

### DIFF
--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -87,7 +87,7 @@ namespace Promitor.Integrations.Sinks.Statsd
                 Dims = labels
             });
 
-            _statsDPublisher.Gauge(metricValue, bucket);
+            _statsDPublisher.Gauge(Math.Round(metricValue, MidpointRounding.AwayFromZero), bucket);
 
             LogMetricWritten(metricName, metricValue);
 

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
@@ -131,7 +131,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         }
 
         [Fact]
-        public async Task ReportMetricAsync_UsesValidInputWithGenevaFormat_SuccessfullyWritesMetric()
+        public async Task ReportMetricAsync_UsesValidInputWithGenevaFormat_SuccessfullyWritesMetricWithRounding()
         {
             // Arrange
             var metricName = BogusGenerator.Name.FirstName();
@@ -144,6 +144,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
             var statsDSinkConfiguration = CreateStatsDConfiguration(metricFormat, genevaConfiguration);
             var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, statsDSinkConfiguration, NullLogger<StatsdMetricSink>.Instance);
+            var expectedMetricValue = Math.Round(metricValue, MidpointRounding.AwayFromZero);
 
             var bucket = JsonConvert.SerializeObject(new
             {
@@ -157,7 +158,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             await metricSink.ReportMetricAsync(metricName, metricDescription, scrapeResult);
 
             // Assert
-            statsDPublisherMock.Verify(mock => mock.Gauge(metricValue, bucket), Times.Once());
+            statsDPublisherMock.Verify(mock => mock.Gauge(expectedMetricValue, bucket), Times.Once());
         }
 
         private GenevaConfiguration GenerateGenevaConfiguration()


### PR DESCRIPTION
…the numbers.

<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #
Fix an issue with Geneva MDM container for StatsDSink.
<!-- markdownlint-enable -->
