### PR TITLE
fix(otel): Provide correct job name in OpenTelemetry Collector

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -12,6 +12,7 @@ version:
 | [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
 - {{% tag fixed %}} Fixed a bug where startup throws scheduling exception due to metric misconfiguration
 - {{% tag fixed %}} Fixed a bug where resource discovery for Azure Container Instances was not working
+- {{% tag fixed %}} Fixed a bug where Promitor was reported as `unknown_service:dotnet` job in OpenTelemetry Collector
 
 #### Resource Discovery
 

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -56,7 +56,6 @@
             </summary>
             <param name="app">Application Builder</param>
             <param name="configuration">Configuration of the scraper agent</param>
-            <param name="logger"></param>
         </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.ObjectExtensions.Clone``1(``0)">
             <summary>
@@ -371,13 +370,14 @@
             </summary>
             <param name="services">Collections of services in application</param>
         </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.UseMetricSinks(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Startup})">
+        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.UseMetricSinks(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,System.String,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Startup})">
             <summary>
                 Adds the required metric sinks
             </summary>
             <param name="services">Collections of services in application</param>
             <param name="configuration">Configuration of the application</param>
-            <param name="logger"></param>
+            <param name="agentVersion">Version of Promitor Scraper agent</param>
+            <param name="logger">Logger to write logs to</param>
         </member>
         <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddScrapingMutex(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -56,6 +56,7 @@
             </summary>
             <param name="app">Application Builder</param>
             <param name="configuration">Configuration of the scraper agent</param>
+            <param name="logger">Logger to write logs to</param>
         </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.ObjectExtensions.Clone``1(``0)">
             <summary>

--- a/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
@@ -14,6 +14,7 @@ namespace Promitor.Agents.Scraper.Extensions
         /// </summary>
         /// <param name="app">Application Builder</param>
         /// <param name="configuration">Configuration of the scraper agent</param>
+        /// <param name="logger">Logger to write logs to</param>
         public static IApplicationBuilder UseMetricSinks(this IApplicationBuilder app, IConfiguration configuration, ILogger<Startup> logger)
         {
             var metricSinkConfiguration = configuration.GetSection("metricSinks").Get<MetricSinkConfiguration>();

--- a/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
@@ -14,7 +14,6 @@ namespace Promitor.Agents.Scraper.Extensions
         /// </summary>
         /// <param name="app">Application Builder</param>
         /// <param name="configuration">Configuration of the scraper agent</param>
-        /// <param name="logger"></param>
         public static IApplicationBuilder UseMetricSinks(this IApplicationBuilder app, IConfiguration configuration, ILogger<Startup> logger)
         {
             var metricSinkConfiguration = configuration.GetSection("metricSinks").Get<MetricSinkConfiguration>();

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -53,8 +53,8 @@ namespace Promitor.Agents.Scraper
 
             services.AddHealthChecks()
                    .AddResourceDiscoveryHealthCheck(Configuration);
-            
-            services.UseMetricSinks(Configuration, _logger)
+
+            services.UseMetricSinks(Configuration, agentVersion, _logger)
                 .AddSystemMetrics()
                 .AddScrapingMutex(Configuration)
                 .ScheduleMetricScraping();


### PR DESCRIPTION
```diff
# HELP otel_azure_container_instance_cpu_usage_discovered Average cpu usage of our container instance
# TYPE otel_azure_container_instance_cpu_usage_discovered gauge
- otel_azure_container_instance_cpu_usage_discovered{app="promitor",instance="15cdf614-d987-4fbb-b6f5-1df5cc071ac9",instance_name="promitor-testing-resource-eu-aci",job="unknown_service:dotnet",resource_group="promitor-testing-infrastructure-europe",resource_uri="subscriptions/63c590b6-4947-4898-92a3-cae91a31b5e4/resourceGroups/promitor-testing-infrastructure-europe/providers/Microsoft.ContainerInstance/containerGroups/promitor-testing-resource-eu-aci",subscription_id="63c590b6-4947-4898-92a3-cae91a31b5e4"} 0 1677336928582
+ otel_azure_container_instance_cpu_usage_discovered{app="promitor",instance="15cdf614-d987-4fbb-b6f5-1df5cc071ac9",instance_name="promitor-testing-resource-eu-aci",job="promitor-scraper",resource_group="promitor-testing-infrastructure-europe",resource_uri="subscriptions/63c590b6-4947-4898-92a3-cae91a31b5e4/resourceGroups/promitor-testing-infrastructure-europe/providers/Microsoft.ContainerInstance/containerGroups/promitor-testing-resource-eu-aci",subscription_id="63c590b6-4947-4898-92a3-cae91a31b5e4"} 0 1677336928582
```

Closes #2179