### PR TITLE
Add support for NAT Gateways and Data Explorer clusters

### DIFF
--- a/build/azure-devops/variables/build.yml
+++ b/build/azure-devops/variables/build.yml
@@ -1,3 +1,3 @@
 variables:
-  DotNet.Sdk.Version: '6.0.402'
+  DotNet.Sdk.Version: '7.0.103'
   DotNet.Configuration: 'release'

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -10,9 +10,15 @@ version:
 - {{% tag added %}} Provide capability to read Azure AD service principal secret from a file
 - {{% tag added %}} Provide Azure Log Analytics scraper ([docs](https://docs.promitor.io/v2.9/scraping/providers/log-analytics/)
 | [#2132](https://github.com/tomkerkhove/promitor/pull/2132))
+- {{% tag added %}} Provide support for Azure Data Explorer Clusters. ([docs](https://docs.promitor.io/v2.9/scraping/providers/data-explorer-clusters.md)
+- {{% tag added %}} Provide support for Azure NAT Gateway. ([docs](https://docs.promitor.io/v2.9/scraping/providers/nat-gateway.md)
+- {{% tag changed %}} Migrate to .NET 7
 - {{% tag fixed %}} Fixed a bug where startup throws scheduling exception due to metric misconfiguration
 - {{% tag fixed %}} Fixed a bug where resource discovery for Azure Container Instances was not working
+- {{% tag fixed %}} Fixed a bug where Promitor was reported as `unknown_service:dotnet` job in OpenTelemetry Collector
 
 #### Resource Discovery
 
 - {{% tag added %}} Provide path to read app secret key from file
+- {{% tag added %}} Provide support for Azure Data Explorer Clusters. ([docs](https://docs.promitor.io/v2.9/scraping/providers/data-explorer-clusters.md)
+- {{% tag added %}} Provide support for Azure NAT Gateway. ([docs](https://docs.promitor.io/v2.9/scraping/providers/nat-gateway.md)

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -37,6 +37,8 @@ resourceDiscoveryGroups:
   type: IoTHub
 - name: key-vaults
   type: KeyVault
+- name: data-explorer-clusters
+  type: DataExplorerCluster
 - name: load-balancers
   type: LoadBalancer
 - name: autoscaling-rules
@@ -45,6 +47,8 @@ resourceDiscoveryGroups:
   type: MariaDb
 - name: mysql-servers
   type: MySql
+- name: nat-gateways
+  type: NatGateway
 - name: network-interfaces
   type: NetworkInterface
 - name: postgres-databases

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -321,6 +321,25 @@ metrics:
         type: Average
     resourceDiscoveryGroups:
     - name: container-instances
+  - name: promitor_demo_nat_gateway_DatapathAvailability
+    description: "DatapathAvailability usage of nat gateway"
+    resourceType: NatGateway
+    azureMetricConfiguration:
+      metricName: DatapathAvailability
+      aggregation:
+        type: Average
+    resourceDiscoveryGroups:
+      - name: nat-gateways
+  - name: promitor_demo_mysql_data_explorer_cluster_CPU
+    description: "CPU usage of Azure Data Explorer cluster"
+    resourceType: DataExplorerCluster
+    azureMetricConfiguration:
+      metricName: CPU
+      aggregation:
+        type: Average
+    resourceDiscoveryGroups:
+      - name: data-explorer-clusters
+
   # This uses our large-scale data set containing 1000+ Azure Logic App instances
   # Uncomment if you want to test with this scale
   # - name: azure_logic_apps_failed_run_discovery

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -21,7 +21,7 @@
     <PackageReference Include="CronScheduler.AspNetCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.3" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.2.0" />
     <PackageReference Include="Prometheus.Client" Version="5.2.0" />
     <PackageReference Include="Prometheus.Client.AspNetCore" Version="4.8.0" />

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.402-alpine3.16 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0.103-alpine3.16 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Agents.ResourceDiscovery/* Promitor.Agents.ResourceDiscovery/
@@ -13,7 +13,7 @@ COPY Promitor.Integrations.LogAnalytics/* Promitor.Integrations.LogAnalytics/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.10-alpine3.16 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:7.0.3-alpine3.16 AS runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="/config/"
 COPY --from=build /app .

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.windows
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.402 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0.103 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Agents.ResourceDiscovery/* Promitor.Agents.ResourceDiscovery/
@@ -13,7 +13,7 @@ COPY Promitor.Integrations.LogAnalytics/* Promitor.Integrations.LogAnalytics/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=%VERSION%
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.10 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:7.0.3 AS runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="c:/config/"
 COPY --from=build /app .

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -28,6 +28,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new ContainerRegistryDiscoveryQuery();
                 case ResourceType.CosmosDb:
                     return new CosmosDbDiscoveryQuery();
+                case ResourceType.DataExplorerCluster:
+                    return new DataExplorerClusterDiscoveryQuery();
                 case ResourceType.DataFactory:
                     return new DataFactoryDiscoveryQuery();
                 case ResourceType.DataShare:
@@ -58,6 +60,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new MonitorAutoscaleDiscoveryQuery();
                 case ResourceType.MySql:
                     return new MySqlResourceDiscoveryQuery();
+                case ResourceType.NatGateway:
+                    return new NatGatewayDiscoveryQuery();
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayDiscoveryQuery();
                 case ResourceType.NetworkInterface:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/DataExplorerClusterDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/DataExplorerClusterDiscoveryQuery.cs
@@ -1,0 +1,22 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class DataExplorerClusterDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.kusto/clusters" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var clusterName = resultRowEntry[2]?.ToString();
+            var resource = new DataExplorerClusterResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), clusterName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/NatGatewayDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/NatGatewayDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class NatGatewayDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/natgateways" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var natGatewayName = resultRowEntry[2]?.ToString();
+
+            var resource = new NatGatewayResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), natGatewayName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Docs\Open-Api.xml</DocumentationFile>
     <UserSecretsId>159d036b-3697-40d4-bdc4-7d9736521375</UserSecretsId>
@@ -35,7 +35,7 @@
     <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceGraph" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.2.0" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.402-alpine3.16 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0.103-alpine3.16 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Core/* Promitor.Core/
@@ -17,7 +17,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.10-alpine3.16 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:7.0.3-alpine3.16 as runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="/config/"
 

--- a/src/Promitor.Agents.Scraper/Dockerfile.windows
+++ b/src/Promitor.Agents.Scraper/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.402 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0.103 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Core/* Promitor.Core/
@@ -17,7 +17,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=%VERSION%
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.10 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:7.0.3 as runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="c:/config/"
 

--- a/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.Scraper/Docs/Open-Api.xml
@@ -56,7 +56,7 @@
             </summary>
             <param name="app">Application Builder</param>
             <param name="configuration">Configuration of the scraper agent</param>
-            <param name="logger"></param>
+            <param name="logger">Logger to write logs to</param>
         </member>
         <member name="M:Promitor.Agents.Scraper.Extensions.ObjectExtensions.Clone``1(``0)">
             <summary>
@@ -371,13 +371,14 @@
             </summary>
             <param name="services">Collections of services in application</param>
         </member>
-        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.UseMetricSinks(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Startup})">
+        <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.UseMetricSinks(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration,System.String,Microsoft.Extensions.Logging.ILogger{Promitor.Agents.Scraper.Startup})">
             <summary>
                 Adds the required metric sinks
             </summary>
             <param name="services">Collections of services in application</param>
             <param name="configuration">Configuration of the application</param>
-            <param name="logger"></param>
+            <param name="agentVersion">Version of Promitor Scraper agent</param>
+            <param name="logger">Logger to write logs to</param>
         </member>
         <member name="M:Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddScrapingMutex(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>

--- a/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Scraper/Extensions/IApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Promitor.Agents.Scraper.Extensions
         /// </summary>
         /// <param name="app">Application Builder</param>
         /// <param name="configuration">Configuration of the scraper agent</param>
-        /// <param name="logger"></param>
+        /// <param name="logger">Logger to write logs to</param>
         public static IApplicationBuilder UseMetricSinks(this IApplicationBuilder app, IConfiguration configuration, ILogger<Startup> logger)
         {
             var metricSinkConfiguration = configuration.GetSection("metricSinks").Get<MetricSinkConfiguration>();

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     <!--<DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>-->
   </PropertyGroup>
 
@@ -40,7 +40,7 @@
     <PackageReference Include="CronExpressionDescriptor" Version="2.19.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.2.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -53,8 +53,8 @@ namespace Promitor.Agents.Scraper
 
             services.AddHealthChecks()
                    .AddResourceDiscoveryHealthCheck(Configuration);
-            
-            services.UseMetricSinks(Configuration, _logger)
+
+            services.UseMetricSinks(Configuration, agentVersion, _logger)
                 .AddSystemMetrics()
                 .AddScrapingMutex(Configuration)
                 .ScheduleMetricScraping();

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -31,8 +31,12 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new ContainerRegistryMetricValidator();
                 case ResourceType.CosmosDb:
                     return new CosmosDbMetricValidator();
+                case ResourceType.DataExplorerCluster:
+                    return new DataExplorerClusterMetricValidator();
                 case ResourceType.DataFactory:
                     return new DataFactoryMetricValidator();
+                case ResourceType.DataExplorerCluster:
+                    return new DataExplorerClusterMetricValidator();
                 case ResourceType.DataShare:
                     return new DataShareMetricValidator();
                 case ResourceType.DeviceProvisioningService:
@@ -67,6 +71,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new MonitorAutoscaleMetricValidator();
                 case ResourceType.MySql:
                     return new MySqlMetricValidator();
+                case ResourceType.NatGateway:
+                    return new NatGatewayMetricValidator();
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayMetricValidator();
                 case ResourceType.NetworkInterface:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/DataExplorerClusterMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/DataExplorerClusterMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class DataExplorerClusterMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<DataExplorerClusterResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.ClusterName))
+                {
+                    yield return "No Azure Data Explorer cluster name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/NatGatewayMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/NatGatewayMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class NatGatewayMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<NatGatewayResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.NatGatewayName))
+                {
+                    yield return "No Azure Virtual Network NAT Gateway name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Steps/ConfigurationPathValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/ConfigurationPathValidationStep.cs
@@ -11,7 +11,7 @@ namespace Promitor.Agents.Scraper.Validation.Steps
     public class ConfigurationPathValidationStep : ValidationStep, IValidationStep
     {
         private readonly IOptions<MetricsConfiguration> _metricsConfiguration;
-        public string ComponentName { get; } = "Metrics Declaration Path";
+        public string ComponentName => "Metrics Declaration Path";
 
         public ConfigurationPathValidationStep(IOptions<MetricsConfiguration> metricsConfiguration, ILogger<ConfigurationPathValidationStep> logger) : base(logger)
         {
@@ -20,7 +20,7 @@ namespace Promitor.Agents.Scraper.Validation.Steps
 
         public ValidationResult Run()
         {
-            var absolutePath = _metricsConfiguration.Value?.AbsolutePath;
+            var absolutePath = _metricsConfiguration.Value.AbsolutePath;
             if (string.IsNullOrWhiteSpace(absolutePath))
             {
                 var errorMessage = "No scrape configuration path configured";

--- a/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/AtlassianStatuspageMetricSinkValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/AtlassianStatuspageMetricSinkValidationStep.cs
@@ -28,7 +28,7 @@ namespace Promitor.Agents.Scraper.Validation.Steps.Sinks
         public ValidationResult Run()
         {
             var currentRuntimeConfiguration = _runtimeConfiguration.Value;
-            var atlassianStatuspageConfiguration = currentRuntimeConfiguration?.MetricSinks?.AtlassianStatuspage;
+            var atlassianStatuspageConfiguration = currentRuntimeConfiguration.MetricSinks?.AtlassianStatuspage;
             if (atlassianStatuspageConfiguration == null)
             {
                 return ValidationResult.Successful(ComponentName);

--- a/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/OpenTelemetryCollectorMetricSinkValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/OpenTelemetryCollectorMetricSinkValidationStep.cs
@@ -20,12 +20,12 @@ namespace Promitor.Agents.Scraper.Validation.Steps.Sinks
             _runtimeConfiguration = runtimeConfiguration;
         }
 
-        public string ComponentName { get; } = "OpenTelemetry Collector Metric Sink";
+        public string ComponentName => "OpenTelemetry Collector Metric Sink";
 
         public ValidationResult Run()
         {
             var currentRuntimeConfiguration = _runtimeConfiguration.Value;
-            var openTelemetryCollectorSinkConfiguration = currentRuntimeConfiguration?.MetricSinks?.OpenTelemetryCollector;
+            var openTelemetryCollectorSinkConfiguration = currentRuntimeConfiguration.MetricSinks?.OpenTelemetryCollector;
             if (openTelemetryCollectorSinkConfiguration == null)
             {
                 return ValidationResult.Successful(ComponentName);

--- a/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/PrometheusScrapingEndpointMetricSinkValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/PrometheusScrapingEndpointMetricSinkValidationStep.cs
@@ -16,12 +16,12 @@ namespace Promitor.Agents.Scraper.Validation.Steps.Sinks
             _runtimeConfiguration = runtimeConfiguration;
         }
 
-        public string ComponentName { get; } = "Prometheus Scraping Endpoint Metric Sink";
+        public string ComponentName => "Prometheus Scraping Endpoint Metric Sink";
 
         public ValidationResult Run()
         {
             var currentRuntimeConfiguration = _runtimeConfiguration.Value;
-            var prometheusScrapingEndpointConfiguration = currentRuntimeConfiguration?.MetricSinks?.PrometheusScrapingEndpoint;
+            var prometheusScrapingEndpointConfiguration = currentRuntimeConfiguration.MetricSinks?.PrometheusScrapingEndpoint;
             if (prometheusScrapingEndpointConfiguration == null)
             {
                 return ValidationResult.Successful(ComponentName);

--- a/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/StatsDMetricSinkValidationStep.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Steps/Sinks/StatsDMetricSinkValidationStep.cs
@@ -21,12 +21,12 @@ namespace Promitor.Agents.Scraper.Validation.Steps.Sinks
             _runtimeConfiguration = runtimeConfiguration;
         }
 
-        public string ComponentName { get; } = "StatsD Metric Sink";
+        public string ComponentName => "StatsD Metric Sink";
 
         public ValidationResult Run()
         {
             var currentRuntimeConfiguration = _runtimeConfiguration.Value;
-            var statsDConfiguration = currentRuntimeConfiguration?.MetricSinks?.Statsd;
+            var statsDConfiguration = currentRuntimeConfiguration.MetricSinks?.Statsd;
             if (statsDConfiguration == null)
             {
                 return ValidationResult.Successful(ComponentName);

--- a/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
+++ b/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -50,5 +50,7 @@
         LoadBalancer = 45,
         MySql = 46,
         LogAnalytics = 47,
+        DataExplorerCluster = 48,
+        NatGateway = 49,
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/DataExplorerClusterResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/DataExplorerClusterResourceDefinition.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class DataExplorerClusterResourceDefinition : AzureResourceDefinition
+    {
+        public DataExplorerClusterResourceDefinition(string subscriptionId, string resourceGroupName, string clusterName)
+            : base(ResourceType.DataExplorerCluster, subscriptionId, resourceGroupName, clusterName)
+        {
+            ClusterName = clusterName;
+        }
+
+        public string ClusterName { get; }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceTypes/NatGatewayResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/NatGatewayResourceDefinition.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class NatGatewayResourceDefinition : AzureResourceDefinition
+    {
+        public NatGatewayResourceDefinition(string subscriptionId, string resourceGroupName, string natGatewayName)
+            : base(ResourceType.NatGateway, subscriptionId, resourceGroupName, natGatewayName)
+        {
+            NatGatewayName = natGatewayName;
+        }
+
+        public string NatGatewayName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -51,6 +51,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.CosmosDb:
                     var cosmosDbLogger = _loggerFactory.CreateLogger<CosmosDbDeserializer>();
                     return new CosmosDbDeserializer(cosmosDbLogger);
+                case ResourceType.DataExplorerCluster:
+                    var dataExplorerClusterLogger = _loggerFactory.CreateLogger<DataExplorerClusterDeserializer>();
+                    return new DataExplorerClusterDeserializer(dataExplorerClusterLogger);
                 case ResourceType.DataFactory:
                     var dataFactoryDeserializer = _loggerFactory.CreateLogger<DataFactoryDeserializer>();
                     return new DataFactoryDeserializer(dataFactoryDeserializer);
@@ -105,6 +108,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.MySql:
                     var mySqlLogger = _loggerFactory.CreateLogger<MySqlDeserializer>();
                     return new MySqlDeserializer(mySqlLogger);
+                case ResourceType.NatGateway:
+                    var natGatewayLogger = _loggerFactory.CreateLogger<NatGatewayDeserializer>();
+                    return new NatGatewayDeserializer(natGatewayLogger);
                 case ResourceType.NetworkGateway:
                     var networkGatewayLogger = _loggerFactory.CreateLogger<NetworkGatewayDeserializer>();
                     return new NetworkGatewayDeserializer(networkGatewayLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -34,6 +34,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<CdnResourceV1, CdnResourceDefinition>();
             CreateMap<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>();
             CreateMap<ContainerRegistryResourceV1, ContainerRegistryResourceDefinition>();
+            CreateMap<DataExplorerClusterResourceV1, DataExplorerClusterResourceDefinition>();
             CreateMap<DataFactoryResourceV1, DataFactoryResourceDefinition>();
             CreateMap<DataShareResourceV1, DataShareResourceDefinition>();
             CreateMap<DeviceProvisioningServiceResourceV1, DeviceProvisioningServiceResourceDefinition>();
@@ -53,6 +54,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<MariaDbResourceV1, MariaDbResourceDefinition>();
             CreateMap<MonitorAutoscaleResourceV1, MonitorAutoscaleResourceDefinition>();
             CreateMap<MySqlResourceV1, MySqlResourceDefinition>();
+            CreateMap<NatGatewayResourceV1, NatGatewayResourceDefinition>();
             CreateMap<NetworkGatewayResourceV1, NetworkGatewayResourceDefinition>();
             CreateMap<NetworkInterfaceResourceV1, NetworkInterfaceResourceDefinition>();
             CreateMap<PostgreSqlResourceV1, PostgreSqlResourceDefinition>();
@@ -89,6 +91,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<ContainerRegistryResourceV1, ContainerRegistryResourceDefinition>()
                 .Include<CdnResourceV1, CdnResourceDefinition>()
                 .Include<CosmosDbResourceV1, CosmosDbResourceDefinition>()
+                .Include<DataExplorerClusterResourceV1, DataExplorerClusterResourceDefinition>()
                 .Include<DataFactoryResourceV1, DataFactoryResourceDefinition>()
                 .Include<DataShareResourceV1, DataShareResourceDefinition>()
                 .Include<DeviceProvisioningServiceResourceV1, DeviceProvisioningServiceResourceDefinition>()
@@ -107,6 +110,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<MariaDbResourceV1, MariaDbResourceDefinition>()
                 .Include<MonitorAutoscaleResourceV1, MonitorAutoscaleResourceDefinition>()
                 .Include<MySqlResourceV1, MySqlResourceDefinition>()
+                .Include<NatGatewayResourceV1, NatGatewayResourceDefinition>()
                 .Include<NetworkGatewayResourceV1, NetworkGatewayResourceDefinition>()
                 .Include<NetworkInterfaceResourceV1, NetworkInterfaceResourceDefinition>()
                 .Include<PostgreSqlResourceV1, PostgreSqlResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/DataExplorerClusterResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/DataExplorerClusterResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape a Azure Data Explorer cluster.
+    /// </summary>
+    public class DataExplorerClusterResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Data Explorer Cluster to get metrics for.
+        /// </summary>
+        public string ClusterName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/NatGatewayResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/NatGatewayResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Network Gateway.
+    /// </summary>
+    public class NatGatewayResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Network Gateway to get metrics for.
+        /// </summary>
+        public string NatGatewayName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/DataExplorerClusterDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/DataExplorerClusterDeserializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class DataExplorerClusterDeserializer : ResourceDeserializer<DataExplorerClusterResourceV1>
+    {
+        public DataExplorerClusterDeserializer(ILogger<DataExplorerClusterDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.ClusterName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NatGatewayDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/NatGatewayDeserializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class NatGatewayDeserializer : ResourceDeserializer<NatGatewayResourceV1>
+    {
+        public NatGatewayDeserializer(ILogger<NatGatewayDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.NatGatewayName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -57,6 +57,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new ContainerRegistryScraper(scraperConfiguration);
                 case ResourceType.CosmosDb:
                     return new CosmosDbScraper(scraperConfiguration);
+                case ResourceType.DataExplorerCluster:
+                    return new DataExplorerClusterScraper(scraperConfiguration);
                 case ResourceType.DataFactory:
                     return new DataFactoryScraper(scraperConfiguration);
                 case ResourceType.DataShare:
@@ -93,6 +95,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new MonitorAutoscaleScraper(scraperConfiguration);
                 case ResourceType.MySql:
                     return new MySqlScraper(scraperConfiguration);
+                case ResourceType.NatGateway:
+                    return new NatGatewayScraper(scraperConfiguration);
                 case ResourceType.NetworkGateway:
                     return new NetworkGatewayScraper(scraperConfiguration);
                 case ResourceType.NetworkInterface:

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
@@ -21,7 +21,7 @@
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
-    <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Core.Scraping/ResourceTypes/DataExplorerClusterScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/DataExplorerClusterScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class DataExplorerClusterScraper : AzureMonitorScraper<DataExplorerClusterResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Kusto/clusters/{2}";
+
+        public DataExplorerClusterScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, DataExplorerClusterResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.ClusterName);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/NatGatewayScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/NatGatewayScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class NatGatewayScraper : AzureMonitorScraper<NatGatewayResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/natGateways/{2}";
+
+        public NatGatewayScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, NatGatewayResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.NatGatewayName);
+        }
+    }
+}

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core/Metrics/Sinks/MetricSinkWriter.cs
+++ b/src/Promitor.Core/Metrics/Sinks/MetricSinkWriter.cs
@@ -12,6 +12,8 @@ namespace Promitor.Core.Metrics.Sinks
         private readonly List<IMetricSink> _configuredSinks;
         private ILogger Logger { get; }
 
+        public List<MetricSinkType> EnabledMetricSinks { get; }
+
         public MetricSinkWriter(IEnumerable<IMetricSink> configuredSinks, ILogger<MetricSinkWriter> logger)
         {
             var metricSinks = configuredSinks?.ToList();
@@ -20,6 +22,8 @@ namespace Promitor.Core.Metrics.Sinks
 
             Logger = logger;
             _configuredSinks = metricSinks;
+            // ReSharper disable once AssignNullToNotNullAttribute (see guard above)
+            this.EnabledMetricSinks = metricSinks.Select(x => x.Type).Distinct().ToList();
         }
 
         public async Task ReportMetricAsync(string metricName, string metricDescription, ScrapeResult scrapedMetricResult)

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -19,9 +19,9 @@
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -17,8 +17,8 @@
     <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.8.2" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Integrations.AzureMonitor/ArmUserAgent.cs
+++ b/src/Promitor.Integrations.AzureMonitor/ArmUserAgent.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using GuardNet;
+using Promitor.Core;
+using Promitor.Core.Metrics.Sinks;
+
+namespace Promitor.Integrations.AzureMonitor
+{
+    public class ArmUserAgent
+    {
+        private const string EnabledText = "Enabled";
+        private const string DisabledText = "Disabled";
+        private const string ExtensionFormat = "{0} Prometheus/{1} OpenTelemetryCollector/{2} StatsD/{3} AtlassianStatuspage/{4}";
+
+        public static string Generate(string agentVersion, List<MetricSinkType> metricSinkInfo)
+        {
+            Guard.NotNullOrWhitespace(agentVersion, nameof(agentVersion));
+            Guard.NotNull(metricSinkInfo, nameof(metricSinkInfo));
+            Guard.For<ArgumentException>(() => metricSinkInfo.Count == 0, nameof(metricSinkInfo));
+            
+            var originalUserAgent = UserAgent.Generate("Scraper", agentVersion);
+
+            var prometheusState = GetRawState(MetricSinkType.PrometheusScrapingEndpoint, metricSinkInfo);
+            var openTelemetryState =  GetRawState(MetricSinkType.OpenTelemetryCollector, metricSinkInfo);
+            var statsDState =  GetRawState(MetricSinkType.StatsD, metricSinkInfo);
+            var statuspageState =  GetRawState(MetricSinkType.AtlassianStatuspage, metricSinkInfo);
+
+            return string.Format(ExtensionFormat, originalUserAgent, prometheusState, openTelemetryState, statsDState, statuspageState);
+        }
+
+        private static string GetRawState(MetricSinkType metricSinkType, List<MetricSinkType> enabledMetricSinks)
+        {
+            return enabledMetricSinks.Contains(metricSinkType)
+                ? EnabledText
+                : DisabledText;
+        }
+    }
+}

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/RequestHandlers/AzureResourceManagerThrottlingRequestHandler.cs
+++ b/src/Promitor.Integrations.AzureMonitor/RequestHandlers/AzureResourceManagerThrottlingRequestHandler.cs
@@ -61,7 +61,7 @@ namespace Promitor.Integrations.AzureMonitor.RequestHandlers
         protected override HttpRequestMessage BeforeSendingRequest(HttpRequestMessage request)
         {
             string agentVersion = Version.Get();
-            var promitorUserAgent = UserAgent.Generate("Scraper", agentVersion);
+            var promitorUserAgent = ArmUserAgent.Generate(agentVersion, _metricSinkWriter.EnabledMetricSinks);
             request.Headers.UserAgent.Clear();
             request.Headers.UserAgent.TryParseAdd(promitorUserAgent);
 

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+        <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Guard.Net" Version="3.0.0" />
       <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.9</RuntimeFrameworkVersion>
     </PropertyGroup>
 
@@ -11,7 +11,7 @@
       <PackageReference Include="Guard.Net" Version="3.0.0" />
       <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.1" />
       <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="3.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeFrameworkVersion>6.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -87,7 +87,7 @@ namespace Promitor.Integrations.Sinks.Statsd
                 Dims = labels
             });
 
-            _statsDPublisher.Gauge(metricValue, bucket);
+            _statsDPublisher.Gauge(Math.Round(metricValue, MidpointRounding.AwayFromZero), bucket);
 
             LogMetricWritten(metricName, metricValue);
 

--- a/src/Promitor.Tests.Integration/Clients/AgentClient.cs
+++ b/src/Promitor.Tests.Integration/Clients/AgentClient.cs
@@ -23,6 +23,11 @@ namespace Promitor.Tests.Integration.Clients
             Guard.NotNull(logger, nameof(logger));
 
             var baseUrl = configuration[baseUrlConfigKey];
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                throw new ArgumentException("Base URL is not configured");
+            }
+
             logger.LogInformation("Base URL for {AgentName} is '{Url}'", agentName, baseUrl);
 
             HttpClient = new HttpClient

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.5.0" />
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Promitor.Parsers.Prometheus.Http" Version="0.2.0" />

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
@@ -104,7 +104,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Arrange
             const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
             const int pageSize = 1000;
-            const int expectedTotalResourceCount = 1015;
+            const int expectedTotalResourceCount = 1012;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act & Assert
@@ -135,7 +135,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
-            const int expectedTotalResources = 1015;
+            const int expectedTotalResources = 1012;
             const int pageSize = 500;
             int expectedResourceCount = pageSize;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
@@ -287,7 +287,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "two-region-scenario";
-            const int expectedResourceCount = 412;
+            const int expectedResourceCount = 409;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act
@@ -303,7 +303,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
             // Arrange
             const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
             const int pageSize = 1000;
-            const int expectedTotalResourceCount = 1015;
+            const int expectedTotalResourceCount = 1012;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act & Assert
@@ -337,7 +337,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "logic-apps-unfiltered";
-            const int expectedTotalAmount = 1015;
+            const int expectedTotalAmount = 1012;
             const int pageSize = 500;
             var expectedResourceCount = pageSize;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
@@ -489,7 +489,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
         {
             // Arrange
             const string resourceDiscoveryGroupName = "two-region-scenario";
-            const int expectedResourceCount = 412;
+            const int expectedResourceCount = 409;
             var resourceDiscoveryClient = new ResourceDiscoveryClient(Configuration, Logger);
 
             // Act

--- a/src/Promitor.Tests.Unit/Azure/ArmUserAgentTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/ArmUserAgentTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Promitor.Core.Metrics.Sinks;
+using Promitor.Integrations.AzureMonitor;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Azure
+{
+    [Category("Unit")]
+    public class ArmUserAgentTests : UnitTest
+    {
+        private const string UserNameFormat = "App/Promitor Agent/Scraper Version/{0} Prometheus/{1} OpenTelemetryCollector/{2} StatsD/{3} AtlassianStatuspage/{4}";
+        private const string EnabledText = "Enabled";
+        private const string DisabledText = "Disabled";
+
+        [Fact]
+        public void Generate_AllSinksEnabled_ReturnsCorrectUserAgent()
+        {
+            // Arrange
+            var agentVersion = "1.2.3";
+            var enabledMetricSinks = new List<MetricSinkType>
+            {
+                MetricSinkType.PrometheusScrapingEndpoint,
+                MetricSinkType.AtlassianStatuspage,
+                MetricSinkType.StatsD,
+                MetricSinkType.OpenTelemetryCollector
+            };
+            var expectedUserAgent = string.Format(UserNameFormat, agentVersion, EnabledText, EnabledText, EnabledText, EnabledText);
+
+            // Act
+            var userAgent = ArmUserAgent.Generate(agentVersion, enabledMetricSinks);
+
+            // Assert
+            Assert.Equal(expectedUserAgent, userAgent);
+        }
+
+        [Fact]
+        public void Generate_AllSinksExceptPrometheusEnabled_ReturnsCorrectUserAgent()
+        {
+            // Arrange
+            var agentVersion = "1.2.3";
+            var enabledMetricSinks = new List<MetricSinkType>
+            {
+                MetricSinkType.AtlassianStatuspage,
+                MetricSinkType.StatsD,
+                MetricSinkType.OpenTelemetryCollector
+            };
+            var expectedUserAgent = string.Format(UserNameFormat, agentVersion, DisabledText, EnabledText, EnabledText, EnabledText);
+
+            // Act
+            var userAgent = ArmUserAgent.Generate(agentVersion, enabledMetricSinks);
+
+            // Assert
+            Assert.Equal(expectedUserAgent, userAgent);
+        }
+
+        [Fact]
+        public void Generate_NoMetricSinkTypesAreProvided_ThrowsArgumentException()
+        {
+            // Arrange
+            var agentVersion = "1.2.3";
+            var enabledMetricSinks = new List<MetricSinkType>();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ArmUserAgent.Generate(agentVersion, enabledMetricSinks));
+        }
+
+        [Fact]
+        public void Generate_MetricSinkTypesIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var agentVersion = "1.2.3";
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => ArmUserAgent.Generate(agentVersion, metricSinkInfo: null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void Generate_AgentVersionIsInvalid_ThrowsArgumentException(string agentVersion)
+        {
+            // Arrange
+            var enabledMetricSinks = new List<MetricSinkType>
+            {
+                MetricSinkType.AtlassianStatuspage,
+                MetricSinkType.StatsD,
+                MetricSinkType.OpenTelemetryCollector
+            };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => ArmUserAgent.Generate(agentVersion, enabledMetricSinks));
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -256,6 +256,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithDataExplorerClusterMetric(string metricName = "promitor-data-explorer-cluster",
+            string metricDescription = "Description for a metric",
+            string clusterName = "promitor-data-explorer-cluster",
+            string azureMetricName = "CPU",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new DataExplorerClusterResourceV1
+            {
+                ClusterName = clusterName
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.DataExplorerCluster, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithDataShareMetric(string metricName = "promitor-data-share",
             string metricDescription = "Description for a metric",
             string accountName = "promitor-data-share-account",
@@ -594,6 +612,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             };
 
             CreateAndAddMetricDefinition(ResourceType.PostgreSql, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+
+        public MetricsDeclarationBuilder WithNatGatewayMetric(string metricName = "promitor-nat-gateway",
+            string metricDescription = "Description for a metric",
+            string natGatewayName = "promitor-nat-gateway-name",
+            string azureMetricName = "ExpressRouteGatewayPacketsPerSecond",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new NatGatewayResourceV1
+            {
+                NatGatewayName = natGatewayName
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.NatGateway, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
 
             return this;
         }

--- a/src/Promitor.Tests.Unit/Metrics/MetricSinkWriterTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MetricSinkWriterTests.cs
@@ -120,6 +120,38 @@ namespace Promitor.Tests.Unit.Metrics
         }
 
         [Fact]
+        public void EnabledMetricSinks_NoSinks_ReturnsNothing()
+        {
+            // Arrange
+            var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink>(), NullLogger<MetricSinkWriter>.Instance);
+
+            // Act & Assert
+            Assert.Empty(metricSinkWriter.EnabledMetricSinks);
+        }
+
+        [Fact]
+        public void EnabledMetricSinks_MultipleSinks_ReturnsSinkTypes()
+        {
+            // Arrange
+            var firstSinkType = MetricSinkType.OpenTelemetryCollector;
+            var firstSink = new Mock<IMetricSink>();
+            firstSink.SetupGet(x => x.Type).Returns(firstSinkType);
+            var secondSinkType = MetricSinkType.PrometheusScrapingEndpoint;
+            var secondSink = new Mock<IMetricSink>();
+            secondSink.SetupGet(x => x.Type).Returns(secondSinkType);
+            var metricSinkWriter = new MetricSinkWriter(new List<IMetricSink> { firstSink.Object, secondSink.Object }, NullLogger<MetricSinkWriter>.Instance);
+
+            // Act
+            var enabledMetricSinks=metricSinkWriter.EnabledMetricSinks;
+
+            // Assert
+            Assert.NotEmpty(enabledMetricSinks);
+            Assert.Equal(2, enabledMetricSinks.Count);
+            Assert.Contains(firstSinkType, enabledMetricSinks);
+            Assert.Contains(secondSinkType, enabledMetricSinks);
+        }
+
+        [Fact]
         public async Task ReportMetricAsync_WriteToStatsDSink_Succeeds()
         {
             // Arrange

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
@@ -131,7 +131,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         }
 
         [Fact]
-        public async Task ReportMetricAsync_UsesValidInputWithGenevaFormat_SuccessfullyWritesMetric()
+        public async Task ReportMetricAsync_UsesValidInputWithGenevaFormat_SuccessfullyWritesMetricWithRounding()
         {
             // Arrange
             var metricName = BogusGenerator.Name.FirstName();
@@ -144,6 +144,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             var statsDPublisherMock = new Mock<IStatsDPublisher>();
             var statsDSinkConfiguration = CreateStatsDConfiguration(metricFormat, genevaConfiguration);
             var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, statsDSinkConfiguration, NullLogger<StatsdMetricSink>.Instance);
+            var expectedMetricValue = Math.Round(metricValue, MidpointRounding.AwayFromZero);
 
             var bucket = JsonConvert.SerializeObject(new
             {
@@ -157,7 +158,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             await metricSink.ReportMetricAsync(metricName, metricDescription, scrapeResult);
 
             // Assert
-            statsDPublisherMock.Verify(mock => mock.Gauge(metricValue, bucket), Times.Once());
+            statsDPublisherMock.Verify(mock => mock.Gauge(expectedMetricValue, bucket), Times.Once());
         }
 
         private GenevaConfiguration GenerateGenevaConfiguration()

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
@@ -38,7 +38,7 @@
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/DataExplorerClusterDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/DataExplorerClusterDeserializerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class DataExplorerClusterDeserializerTests : ResourceDeserializerTest<DataExplorerClusterDeserializer>
+    {
+        private readonly DataExplorerClusterDeserializer _deserializer;
+
+        public DataExplorerClusterDeserializerTests()
+        {
+            _deserializer = new DataExplorerClusterDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_DataExplorerClusterNameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<DataExplorerClusterResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "clusterName: promitor-data-explorer-cluster",
+                "promitor-data-explorer-cluster",
+                r => r.ClusterName);
+        }
+
+        [Fact]
+        public void Deserialize_DataExplorerClusterNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<DataExplorerClusterResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.ClusterName);
+        }
+
+        [Fact]
+        public void Deserialize_DataExplorerClusterNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "clusterName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new DataExplorerClusterDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/NatGatewayDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/NatGatewayDeserializerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class NatGatewayDeserializerTests : ResourceDeserializerTest<NatGatewayDeserializer>
+    {
+        private readonly NatGatewayDeserializer _deserializer;
+
+        public NatGatewayDeserializerTests()
+        {
+            _deserializer = new NatGatewayDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_NatGatewayNameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<NatGatewayResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "natGatewayName: promitor-nat-gateway",
+                "promitor-nat-gateway",
+                r => r.NatGatewayName);
+        }
+
+        [Fact]
+        public void Deserialize_NatGatewayNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<NatGatewayResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.NatGatewayName);
+        }
+
+        [Fact]
+        public void Deserialize_NatGatewayNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "natGatewayName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new NatGatewayDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/DataExplorerClusterMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/DataExplorerClusterMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class DataExplorerClusterMetricsDeclarationValidationStepsTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutDataExplorerClusterName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(clusterName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void DataExplorerClusterMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithDataExplorerClusterMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/NatGatewayMetricsDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/NatGatewayMetricsDeclarationValidationStepsTests.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class NatGatewayMetricsDeclarationValidationStepTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void NatGatewayMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void NatGatewayMetricsDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void NetworkGatewayMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void NatGatewayMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void NatGatewayMetricsDeclaration_DeclarationWithoutNetworkGatewayName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNetworkGatewayMetric(networkGatewayName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void NatGatewayMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void NatGatewayMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void NatGatewayMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithNatGatewayMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
