### PR TITLE
feat: Support Azure Traffic Manager Profiles

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -15,6 +15,7 @@ version:
 - {{% tag added %}} Provide container vulnerability scanning in CI
 - {{% tag added %}} Provide option to use a User Assigned Managed Identity without specifying the Client ID
 - {{% tag added %}} Provide support for Public IP Address ([docs](https://docs.promitor.io/unreleased/scraping/providers/public-ip-address.md))
+- {{% tag added %}} Provide support for Azure Traffic Manager ([docs](https://docs.promitor.io/unreleased/scraping/providers/traffic-manager.md))
 - {{% tag security %}} Patch for [CVE-2023-0286](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5) (Critical | Base image)
 - {{% tag security %}} Patch for [CVE-2023-0215](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5) (Critical | Base image)
 - {{% tag security %}} Patch for [CVE-2022-41032](https://github.com/advisories/GHSA-g3q9-xf95-8hp5) (High)
@@ -37,6 +38,7 @@ version:
 - {{% tag added %}} Provide support for Azure NAT Gateway ([docs](https://docs.promitor.io/unreleased/scraping/providers/nat-gateway.md))
 - {{% tag added %}} Provide option to use a User Assigned Managed Identity without specifying the Client ID
 - {{% tag added %}} Provide support for Public IP Address ([docs](https://docs.promitor.io/unreleased/scraping/providers/public-ip-address.md))
+- {{% tag added %}} Provide support for Azure Traffic Manager ([docs](https://docs.promitor.io/unreleased/scraping/providers/traffic-manager.md))
 - {{% tag security %}} Patch for [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv) (Critical | Base image)
 - {{% tag security %}} Patch for [CVE-2021-42377](https://github.com/advisories/GHSA-phvg-gc27-gjwp) (Critical | Base image)
 - {{% tag security %}} Patch for [CVE-2022-38013](https://github.com/advisories/GHSA-r8m2-4x37-6592) (High)

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -75,6 +75,8 @@ resourceDiscoveryGroups:
   type: SynapseSqlPool
 - name: synapse-workspaces
   type: SynapseWorkspace
+- name: traffic-managers
+  type: TrafficManager
 - name: virtual-machines
   type: VirtualMachine
 - name: virtual-machine-scale-sets

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -348,6 +348,15 @@ metrics:
         type: Maximum
     resourceDiscoveryGroups:
       - name: public-ip-addresses
+  - name: azure_traffic_manager_endpoint_qps
+    description: Number of times a Traffic Manager endpoint was returned in the given time frame
+    resourceType: TrafficManager
+    azureMetricConfiguration:
+      metricName: QpsByEndpoint
+      aggregation:
+        type: Total
+    resourceDiscoveryGroups:
+      - name: traffic-managers
 
   # This uses our large-scale data set containing 1000+ Azure Logic App instances
   # Uncomment if you want to test with this scale

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -90,6 +90,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new SynapseSqlPoolDiscoveryQuery();
                 case ResourceType.SynapseWorkspace:
                     return new SynapseWorkspaceDiscoveryQuery();
+                case ResourceType.TrafficManager:
+                    return new TrafficManagerDiscoveryQuery();
                 case ResourceType.VirtualMachine:
                     return new VirtualMachineDiscoveryQuery();
                 case ResourceType.VirtualMachineScaleSet:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/TrafficManagerDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/TrafficManagerDiscoveryQuery.cs
@@ -1,0 +1,21 @@
+using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class TrafficManagerDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/trafficmanagerprofiles" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+            
+            var resource = new TrafficManagerResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), resultRowEntry[3]?.ToString());
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -103,6 +103,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new SynapseSqlPoolMetricValidator();
                 case ResourceType.SynapseWorkspace:
                     return new SynapseWorkspaceMetricValidator();
+                case ResourceType.TrafficManager:
+                    return new TrafficManagerMetricValidator();
                 case ResourceType.VirtualMachineScaleSet:
                     return new VirtualMachineScaleSetMetricValidator();
                 case ResourceType.VirtualNetwork:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/TrafficManagerMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/TrafficManagerMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class TrafficManagerMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<TrafficManagerResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.Name))
+                {
+                    yield return "No Azure Traffic Manager profile name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -53,5 +53,6 @@
         DataExplorerCluster = 48,
         NatGateway = 49,
         PublicIpAddress = 50,
+        TrafficManager = 51,
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/TrafficManagerResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/TrafficManagerResourceDefinition.cs
@@ -1,0 +1,25 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    /// <summary>
+    ///     Represents an Azure Traffic manager profile resource.
+    /// </summary>
+    public class TrafficManagerResourceDefinition : AzureResourceDefinition
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TrafficManagerResourceDefinition" /> class.
+        /// </summary>
+        /// <param name="subscriptionId">Specify a subscription to scrape that defers from the default subscription.</param>
+        /// <param name="resourceGroupName">The name of the resource group the server is in.</param>
+        /// <param name="name">The name of the Azure Traffic manager profile resource.</param>
+        public TrafficManagerResourceDefinition(string subscriptionId, string resourceGroupName, string name)
+            : base(ResourceType.TrafficManager, subscriptionId, resourceGroupName, name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        ///     The name of the Azure Traffic manager profile resource.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -159,6 +159,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.SynapseWorkspace:
                     var synapseWorkspaceLogger = _loggerFactory.CreateLogger<SynapseWorkspaceDeserializer>();
                     return new SynapseWorkspaceDeserializer(synapseWorkspaceLogger);
+                case ResourceType.TrafficManager:
+                    var trafficManagerLogger = _loggerFactory.CreateLogger<TrafficManagerDeserializer>();
+                    return new TrafficManagerDeserializer(trafficManagerLogger);
                 case ResourceType.VirtualMachine:
                     var virtualMachineLogger = _loggerFactory.CreateLogger<VirtualMachineDeserializer>();
                     return new VirtualMachineDeserializer(virtualMachineLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -71,6 +71,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<SynapseApacheSparkPoolResourceV1, SynapseApacheSparkPoolResourceDefinition>();
             CreateMap<SynapseSqlPoolResourceV1, SynapseSqlPoolResourceDefinition>();
             CreateMap<SynapseWorkspaceResourceV1, SynapseWorkspaceResourceDefinition>();
+            CreateMap<TrafficManagerResourceV1, TrafficManagerResourceDefinition>();
             CreateMap<VirtualNetworkResourceV1, VirtualNetworkResourceDefinition>();
             CreateMap<VirtualMachineResourceV1, VirtualMachineResourceDefinition>();
             CreateMap<VirtualMachineScaleSetResourceV1, VirtualMachineScaleSetResourceDefinition>();
@@ -128,6 +129,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<SynapseApacheSparkPoolResourceV1, SynapseApacheSparkPoolResourceDefinition>()
                 .Include<SynapseSqlPoolResourceV1, SynapseSqlPoolResourceDefinition>()
                 .Include<SynapseWorkspaceResourceV1, SynapseWorkspaceResourceDefinition>()
+                .Include<TrafficManagerResourceV1, TrafficManagerResourceDefinition>()
                 .Include<VirtualNetworkResourceV1, VirtualNetworkResourceDefinition>()
                 .Include<VirtualMachineResourceV1, VirtualMachineResourceDefinition>()
                 .Include<VirtualMachineScaleSetResourceV1, VirtualMachineScaleSetResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/TrafficManagerResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/TrafficManagerResourceV1.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Traffic Manager Profile.
+    /// </summary>
+    public class TrafficManagerResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Traffic Manager Profile to get metrics for.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/TrafficManagerDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/TrafficManagerDeserializer.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class TrafficManagerDeserializer : ResourceDeserializer<TrafficManagerResourceV1>
+    {
+        public TrafficManagerDeserializer(ILogger<TrafficManagerDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.Name)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -129,6 +129,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new SynapseSqlPoolScraper(scraperConfiguration);
                 case ResourceType.SynapseWorkspace:
                     return new SynapseWorkspaceScraper(scraperConfiguration);
+                case ResourceType.TrafficManager:
+                    return new TrafficManagerScraper(scraperConfiguration);
                 case ResourceType.VirtualMachine:
                     return new VirtualMachineScraper(scraperConfiguration);
                 case ResourceType.VirtualMachineScaleSet:

--- a/src/Promitor.Core.Scraping/ResourceTypes/TrafficManagerScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/TrafficManagerScraper.cs
@@ -1,0 +1,24 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    /// <summary>
+    ///     Scrapes an Azure Traffic manager profile.
+    /// </summary>
+    public class TrafficManagerScraper : AzureMonitorScraper<TrafficManagerResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/trafficmanagerprofiles/{2}";
+
+        public TrafficManagerScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, TrafficManagerResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.Name);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -973,6 +973,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithTrafficManagerMetric(string metricName = "promitor",
+            string metricDescription = "Description for a metric",
+            string name = "promitor-traffic-manager",
+            string azureMetricName = "QpsByEndpoint",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new TrafficManagerResourceV1
+            {
+                Name = name
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.TrafficManager, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithVirtualMachineMetric(string metricName = "promitor-virtual-machine",
             string metricDescription = "Description for a metric",
             string virtualMachineName = "promitor-virtual-machine-name",

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/TrafficManagerDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/TrafficManagerDeserializerTests.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class TrafficManagerDeserializerTests : ResourceDeserializerTest<TrafficManagerDeserializer>
+    {
+        private readonly TrafficManagerDeserializer _deserializer;
+
+        public TrafficManagerDeserializerTests()
+        {
+            _deserializer = new TrafficManagerDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_NameSupplied_SetsName()
+        {
+            const string name = "promitor-traffic-manager";
+            YamlAssert.PropertySet<TrafficManagerResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                $"name: {name}",
+                name,
+                r => r.Name);
+        }
+
+        [Fact]
+        public void Deserialize_NameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<TrafficManagerResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.Name);
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new TrafficManagerDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/TrafficManagerMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/TrafficManagerMetricsDeclarationValidationStepTests.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class TrafficManagerMetricsDeclarationValidationStepTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutTrafficManagerName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(name: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric(omitResource: true, resourceDiscoveryGroupName:"sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void TrafficManagerMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithTrafficManagerMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION
Picking this up from where the original author left off

When implementing a new scraper; these tasks are completed:
- [x] Implement configuration
- [x] Implement validation
- [x] Implement scraping
- [x] Implement resource discovery
- [x] Provide unit tests
- [x] Test end-to-end
- [x] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [x] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# TYPE azure_traffic_manager_endpoint_qps gauge
# HELP azure_traffic_manager_endpoint_qps Number of times a Traffic Manager endpoint was returned in the given time frame
azure_traffic_manager_endpoint_qps{tenant_id="<tenant_id>",subscription_id="<subscription_id>",resource_uri="<resource_uri>",resource_group="<resource_group>",instance_name="<instance_name>",geo="china",environment="dev"} 1781 1679494981881
```

**Discovery output:**
```json
{"MetricName": "Discovered Resources", "MetricValue": 15, "Timestamp": "2023-03-22T14:20:38.6195166 +00:00", "Context": {"ResourceType": "TrafficManager", "CollectionName": "traffic-managers", "TelemetryType": "Metrics"}, "$type": "MetricLogEntry"}
```

Fixes #2192
Fixed #376
Related to #2194

<!-- markdownlint-enable -->
