### PR TITLE
feat: POC of adding subscription_name to metric labels

### DIFF
--- a/src/Promitor.Agents.ResourceDiscovery/Controllers/v2/SubscriptionsV2Controller.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Controllers/v2/SubscriptionsV2Controller.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Promitor.Agents.ResourceDiscovery.Graph.Exceptions;
+using Promitor.Agents.ResourceDiscovery.Graph.Repositories.Interfaces;
+using Promitor.Agents.ResourceDiscovery.Scheduling;
+using Promitor.Core.Contracts;
+
+namespace Promitor.Agents.ResourceDiscovery.Controllers.v2
+{
+    /// <summary>
+    /// API endpoint to list Azure subscriptions
+    /// </summary>
+    [ApiController]
+    [Route("api/v2/subscriptions")]
+    public class SubscriptionsV2Controller : ControllerBase
+    {
+        private readonly JsonSerializerSettings _serializerSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionsV2Controller"/> class.
+        /// </summary>
+        public SubscriptionsV2Controller(IAzureResourceRepository azureResourceRepository)
+        {
+            Guard.NotNull(azureResourceRepository, nameof(azureResourceRepository));
+
+            _serializerSettings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                TypeNameHandling = TypeNameHandling.Objects
+            };
+            _serializerSettings.Converters.Add(new StringEnumConverter());
+        }
+
+        /// <summary>
+        /// List subscriptions
+        /// </summary>
+        [HttpGet(Name = "SubscriptionsV2_Get")]
+        [ProducesResponseType(typeof(List<AzureSubscription>), StatusCodes.Status200OK)]
+        public IActionResult Get()
+        {
+            var serializedResources = JsonConvert.SerializeObject(AzureSubscriptionDiscoveryBackgroundJob.CurrentSubscriptions, _serializerSettings);
+
+            var response = Content(serializedResources, "application/json");
+            response.StatusCode = (int) HttpStatusCode.OK;
+
+            return response;
+        }
+    }
+}

--- a/src/Promitor.Agents.ResourceDiscovery/Docs/Open-Api.xml
+++ b/src/Promitor.Agents.ResourceDiscovery/Docs/Open-Api.xml
@@ -82,6 +82,21 @@
             </summary>
             <remarks>Discovers Azure resources matching the criteria.</remarks>
         </member>
+        <member name="T:Promitor.Agents.ResourceDiscovery.Controllers.v2.SubscriptionsV2Controller">
+            <summary>
+            API endpoint to list Azure subscriptions
+            </summary>
+        </member>
+        <member name="M:Promitor.Agents.ResourceDiscovery.Controllers.v2.SubscriptionsV2Controller.#ctor(Promitor.Agents.ResourceDiscovery.Graph.Repositories.Interfaces.IAzureResourceRepository)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Promitor.Agents.ResourceDiscovery.Controllers.v2.SubscriptionsV2Controller"/> class.
+            </summary>
+        </member>
+        <member name="M:Promitor.Agents.ResourceDiscovery.Controllers.v2.SubscriptionsV2Controller.Get">
+            <summary>
+            List subscriptions
+            </summary>
+        </member>
         <member name="M:Promitor.Agents.ResourceDiscovery.Extensions.IServiceCollectionExtensions.AddRuntimeConfiguration(Microsoft.Extensions.DependencyInjection.IServiceCollection,Microsoft.Extensions.Configuration.IConfiguration)">
             <summary>
                 Inject configuration

--- a/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureSubscriptionDiscoveryBackgroundJob.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Scheduling/AzureSubscriptionDiscoveryBackgroundJob.cs
@@ -15,7 +15,9 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
     {
         public const string MetricName = "promitor_azure_landscape_subscription_info";
         public const string MetricDescription = "Provides information concerning the Azure subscriptions in the landscape that Promitor has access to.";
-        
+
+        public static List<AzureSubscription> CurrentSubscriptions { get; private set; } = new List<AzureSubscription>();
+
         public AzureSubscriptionDiscoveryBackgroundJob(string jobName, IAzureResourceRepository azureResourceRepository, ISystemMetricsPublisher systemMetricsPublisher, ILogger<AzureSubscriptionDiscoveryBackgroundJob> logger)
             : base(azureResourceRepository, systemMetricsPublisher, logger)
         {
@@ -32,6 +34,8 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
 
             // Discover Azure subscriptions
 
+            var newList = new List<AzureSubscription>();
+
             PagedPayload<AzureSubscriptionInformation> discoveredLandscape;
             var currentPage = 1;
             do
@@ -42,12 +46,14 @@ namespace Promitor.Agents.ResourceDiscovery.Scheduling
                 foreach (var discoveredLandscapeItem in discoveredLandscape.Result)
                 {
                     ReportDiscoveredAzureInfo(discoveredLandscapeItem);
+                    newList.Add(new AzureSubscription { Id = discoveredLandscapeItem.Id, Name = discoveredLandscapeItem.Name });
                 }
 
                 currentPage++;
             }
             while (discoveredLandscape.HasMore);
 
+            CurrentSubscriptions = newList;
             Logger.LogTrace("Azure subscriptions discovered...");
         }
 

--- a/src/Promitor.Agents.Scraper/Discovery/Interfaces/IResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/Interfaces/IResourceDiscoveryRepository.cs
@@ -9,5 +9,6 @@ namespace Promitor.Agents.Scraper.Discovery.Interfaces
     {
         Task<List<AzureResourceDefinition>> GetResourceDiscoveryGroupAsync(string resourceDiscoveryGroupName);
         Task<AgentHealthReport> GetHealthAsync();
+        Task<List<AzureSubscription>> GetSubscriptionsAsync();
     }
 }

--- a/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryClient.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -47,6 +48,15 @@ namespace Promitor.Agents.Scraper.Discovery
             var rawResponse = await SendGetRequestAsync("api/v1/health");
             var healthReport = JsonConvert.DeserializeObject<AgentHealthReport>(rawResponse, new HealthReportEntryConverter());
             return healthReport;
+        }
+
+        public async Task<List<AzureSubscription>> GetSubscriptionsAsync()
+        {
+            var uri = $"api/v2/subscriptions";
+            var rawResponse = await SendGetRequestAsync(uri);
+
+            var foundSubscriptions = JsonConvert.DeserializeObject<List<AzureSubscription>>(rawResponse, _serializerSettings);
+            return foundSubscriptions;
         }
 
         private async Task<string> SendGetRequestAsync(string uriPath)

--- a/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryRepository.cs
@@ -41,5 +41,10 @@ namespace Promitor.Agents.Scraper.Discovery
         {
             return await _resourceDiscoveryClient.GetHealthAsync();
         }
+
+        public async Task<List<AzureSubscription>> GetSubscriptionsAsync()
+        {
+            return await _resourceDiscoveryClient.GetSubscriptionsAsync();
+        }
     }
 }

--- a/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
@@ -10,6 +10,7 @@ namespace Promitor.Agents.Scraper.Discovery
     {
         private static readonly List<AzureResourceDefinition> emptyResourceDefinitions = new List<AzureResourceDefinition>();
         private static readonly AgentHealthReport healthReport = new AgentHealthReport();
+        private static readonly List<AzureSubscription> emptySubscriptions = new List<AzureSubscription>();
 
         public Task<List<AzureResourceDefinition>> GetResourceDiscoveryGroupAsync(string resourceDiscoveryGroupName)
         {
@@ -19,6 +20,11 @@ namespace Promitor.Agents.Scraper.Discovery
         public Task<AgentHealthReport> GetHealthAsync()
         {
             return Task.FromResult(healthReport);
+        }
+
+        public Task<List<AzureSubscription>> GetSubscriptionsAsync()
+        {
+            return Task.FromResult(emptySubscriptions);
         }
     }
 }

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -132,6 +132,8 @@ namespace Promitor.Agents.Scraper.Scheduling
 
             try
             {
+                await UpdateSubscriptionMappings(cancellationToken);
+
                 var scrapeDefinitions = await GetAllScrapeDefinitions(cancellationToken);
 
                 await ScrapeMetrics(scrapeDefinitions, cancellationToken);
@@ -147,6 +149,16 @@ namespace Promitor.Agents.Scraper.Scheduling
             finally
             {
                 Logger.LogDebug("Ended scraping job {JobName}.", Name);
+            }
+        }
+
+        private async Task UpdateSubscriptionMappings(CancellationToken cancellationToken)
+        {
+            var list = await _resourceDiscoveryRepository.GetSubscriptionsAsync();
+            foreach (var sub in list)
+            {
+                _azureScrapingSystemMetricsPublisher.RegisterSubscriptionMapping(sub.Id, sub.Name);
+                _metricSinkWriter.RegisterSubscriptionMapping(sub.Id, sub.Name);
             }
         }
 

--- a/src/Promitor.Core.Contracts/AzureSubscription.cs
+++ b/src/Promitor.Core.Contracts/AzureSubscription.cs
@@ -1,0 +1,8 @@
+namespace Promitor.Core.Contracts
+{
+    public class AzureSubscription
+    {
+        public string Name { get; set; }
+        public string Id { get; set; }
+    }
+}

--- a/src/Promitor.Core/Metrics/Interfaces/IAzureScrapingSystemMetricsPublisher.cs
+++ b/src/Promitor.Core/Metrics/Interfaces/IAzureScrapingSystemMetricsPublisher.cs
@@ -1,10 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Promitor.Core.Metrics.Interfaces
 {
     public interface IAzureScrapingSystemMetricsPublisher : ISystemMetricsPublisher
     {
+        /// <summary>
+        ///     Registers or updates a subscription ID to name mapping
+        /// </summary>
+        /// <param name="id">Subscription ID.</param>
+        /// <param name="name">Subscription name.</param>
+        void RegisterSubscriptionMapping(string id, string name);
+
         /// <summary>
         ///     Sets a new value for a measurement on a gauge
         /// </summary>

--- a/src/Promitor.Core/Metrics/Sinks/MetricSinkWriter.cs
+++ b/src/Promitor.Core/Metrics/Sinks/MetricSinkWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace Promitor.Core.Metrics.Sinks
     public class MetricSinkWriter
     {
         private readonly List<IMetricSink> _configuredSinks;
+        private readonly ConcurrentDictionary<string, string> _subscriptionMappings = new ConcurrentDictionary<string, string>();
+
         private ILogger Logger { get; }
 
         public List<MetricSinkType> EnabledMetricSinks { get; }
@@ -26,10 +29,16 @@ namespace Promitor.Core.Metrics.Sinks
             this.EnabledMetricSinks = metricSinks.Select(x => x.Type).Distinct().ToList();
         }
 
+        public void RegisterSubscriptionMapping(string id, string name)
+        {
+            _subscriptionMappings[id] = name;
+        }
+
         public async Task ReportMetricAsync(string metricName, string metricDescription, ScrapeResult scrapedMetricResult)
         {
             Guard.NotNullOrWhitespace(metricName, nameof(metricName));
             Guard.NotNull(scrapedMetricResult, nameof(scrapedMetricResult));
+            addSubscriptionNameLabel(scrapedMetricResult.Labels);
 
             var reportTasks = new List<Task>();
             foreach (var sink in _configuredSinks)
@@ -62,6 +71,7 @@ namespace Promitor.Core.Metrics.Sinks
         {
             Guard.NotNullOrWhitespace(metricName, nameof(metricName));
             Guard.NotNull(metricLabels, nameof(metricLabels));
+            addSubscriptionNameLabel(metricLabels);
 
             var reportTasks = new List<Task>();
             foreach (var sink in _configuredSinks)
@@ -71,6 +81,21 @@ namespace Promitor.Core.Metrics.Sinks
             }
 
             await Task.WhenAll(reportTasks);
+        }
+
+        private void addSubscriptionNameLabel(Dictionary<string, string> labels)
+        {
+            if (!labels.ContainsKey("subscription_id")) return;
+
+            string nameValue;
+            if (_subscriptionMappings.TryGetValue(labels["subscription_id"], out nameValue))
+            {
+                labels["subscription_name"] = nameValue;
+            }
+            else
+            {
+                labels["subscription_name"] = "";
+            }
         }
     }
 }


### PR DESCRIPTION
This is a proof of concept for adding subscription_name (1:1 to subscription_id) for metrics. I don't have time to complete it for all the requirements, but if anyone is interested please take it over.

Applies to both of azure metrics and promitor's internal metrics.

- *Verified manually with Prometheus sink; No other sink tested and no unit tests*
- *Works for resources discovered by ResourceDiscovery only*

How it works:
- A new API endpoint in ResourceDiscovery to expose list of subscription ID -> name
- The API is queried in scraper in the same schedule jobs for azure metrics. ID->Name is only added or updated, never deleted.
- In scraper, `AzureScrapingSystemMetricsPublisher` adds associated subscription_name if there is a subscription_id label <- for promitor's internal metrics
- In scraper, `MetricSinkWriter` adds associated subscription_name if there is a subscription_id label <- for azure metrics