### PR TITLE
test: Simplify downloading artifact

### DIFF
--- a/.github/workflows/publish-ci-test-report.yml
+++ b/.github/workflows/publish-ci-test-report.yml
@@ -16,29 +16,13 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-    - name: 'Download artifact'
-      uses: actions/github-script@v6
+    - name: Download artifact
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v2
       with:
-        script: |
-          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             run_id: context.payload.workflow_run.id,
-          });
-          let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == "test-results"
-          })[0];
-          let download = await github.rest.actions.downloadArtifact({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             artifact_id: matchArtifact.id,
-             archive_format: 'zip',
-          });
-          let fs = require('fs');
-          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
-
-    - name: 'Unzip artifact'
-      run: unzip pr_number.zip
+        commit: ${{ github.event.pull_request.head.sha }}
+        run_id: ${{ github.event.workflow_run.id }}
+        name: test-results
 
     - name: Publish CI Test Results
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
