### PR TITLE
chore: Improve code quality

### DIFF
--- a/src/Promitor.Agents.Core/Configuration/RuntimeConfiguration.cs
+++ b/src/Promitor.Agents.Core/Configuration/RuntimeConfiguration.cs
@@ -6,8 +6,8 @@ namespace Promitor.Agents.Core.Configuration
 {
     public class RuntimeConfiguration
     {
-        public ServerConfiguration Server { get; set; } = new ServerConfiguration();
-        public AuthenticationConfiguration Authentication { get; set; } = new AuthenticationConfiguration();
-        public TelemetryConfiguration Telemetry { get; set; } = new TelemetryConfiguration();
+        public ServerConfiguration Server { get; set; } = new();
+        public AuthenticationConfiguration Authentication { get; set; } = new();
+        public TelemetryConfiguration Telemetry { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.Core/Configuration/Telemetry/TelemetryConfiguration.cs
+++ b/src/Promitor.Agents.Core/Configuration/Telemetry/TelemetryConfiguration.cs
@@ -6,7 +6,7 @@ namespace Promitor.Agents.Core.Configuration.Telemetry
     public class TelemetryConfiguration
     {
         public LogLevel? DefaultVerbosity { get; set; } = Defaults.Telemetry.DefaultVerbosity;
-        public ContainerLogConfiguration ContainerLogs { get; set; } = new ContainerLogConfiguration();
-        public ApplicationInsightsConfiguration ApplicationInsights { get; set; } = new ApplicationInsightsConfiguration();
+        public ContainerLogConfiguration ContainerLogs { get; set; } = new();
+        public ApplicationInsightsConfiguration ApplicationInsights { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Builder
                 serverUrl = $"{request.Scheme}://{forwardedHost}{urlPrefix}";
             }
 
-            swagger.Servers = new List<OpenApiServer> {new OpenApiServer {Url = serverUrl}};
+            swagger.Servers = new List<OpenApiServer> {new() {Url = serverUrl}};
         }
     }
 }

--- a/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -62,24 +62,18 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="openApiConfigurationAction">Action to configure Open API</param>
         public static IApplicationBuilder ExposeOpenApiUi(this IApplicationBuilder app, string apiName, Action<SwaggerUIOptions> openApiUiConfigurationAction = null, Action<SwaggerOptions> openApiConfigurationAction = null)
         {
-            if (openApiConfigurationAction == null)
+            openApiConfigurationAction ??= setupAction =>
             {
-                openApiConfigurationAction = setupAction =>
-                {
-                    setupAction.RouteTemplate = "api/{documentName}/docs.json";
-                    setupAction.PreSerializeFilters.Add((swagger, request) => AutomaticallyBuildApiServerUrl(request, swagger));
-                };
-            }
+                setupAction.RouteTemplate = "api/{documentName}/docs.json";
+                setupAction.PreSerializeFilters.Add((swagger, request) => AutomaticallyBuildApiServerUrl(request, swagger));
+            };
 
-            if (openApiUiConfigurationAction == null)
+            openApiUiConfigurationAction ??= swaggerUiOptions =>
             {
-                openApiUiConfigurationAction = swaggerUiOptions =>
-                {
-                    swaggerUiOptions.ConfigureDefaultOptions(apiName);
-                    swaggerUiOptions.SwaggerEndpoint("../v1/docs.json", apiName);
-                    swaggerUiOptions.RoutePrefix = "api/docs";                    
-                };
-            }
+                swaggerUiOptions.ConfigureDefaultOptions(apiName);
+                swaggerUiOptions.SwaggerEndpoint("../v1/docs.json", apiName);
+                swaggerUiOptions.RoutePrefix = "api/docs";
+            };
 
             // New Swagger UI
             app.UseSwagger(openApiConfigurationAction);

--- a/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Promitor.Agents.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -91,12 +91,12 @@ namespace Microsoft.AspNetCore.Builder
         private static void AutomaticallyBuildApiServerUrl(HttpRequest request, OpenApiDocument swagger)
         {
             // Default to simple scenario
-            string serverUrl = $"{request.Scheme}://{request.Host}";
+            var serverUrl = $"{request.Scheme}://{request.Host}";
 
             // If request forwarding is used, we need to see if we need to adapt
             // Here we need to use the host and prefix, when specified
             // This is required when using reverse proxies such as Azure API Management, Traefik, NGINX, etc.
-            if (request.Headers.ContainsKey("X-Forwarded-Host"))
+            if (request.Headers.TryGetValue("X-Forwarded-Host", out var forwardedHost))
             {
                 var urlPrefix = string.Empty;
                 var prefixFromHeaders = request.Headers["X-Forwarded-Prefix"];
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Builder
                     }
                 }
 
-                serverUrl = $"{request.Scheme}://{request.Headers["X-Forwarded-Host"]}{urlPrefix}";
+                serverUrl = $"{request.Scheme}://{forwardedHost}{urlPrefix}";
             }
 
             swagger.Servers = new List<OpenApiServer> {new OpenApiServer {Url = serverUrl}};

--- a/src/Promitor.Agents.ResourceDiscovery/Configuration/AgentRuntimeConfiguration.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Configuration/AgentRuntimeConfiguration.cs
@@ -4,6 +4,6 @@ namespace Promitor.Agents.ResourceDiscovery.Configuration
 {
     public class AgentRuntimeConfiguration : RuntimeConfiguration
     {
-        public CacheConfiguration Cache { get; set; } = new CacheConfiguration();
+        public CacheConfiguration Cache { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceCriteria.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceCriteria.cs
@@ -4,9 +4,9 @@ namespace Promitor.Agents.ResourceDiscovery.Configuration
 {
     public class ResourceCriteria
     {
-        public Dictionary<string,string> Tags { get; set; } = new Dictionary<string, string>();
-        public List<string> Subscriptions { get; set; } = new List<string>();
-        public List<string> ResourceGroups { get; set; } = new List<string>();
-        public List<string> Regions { get; set; } = new List<string>();
+        public Dictionary<string,string> Tags { get; set; } = new();
+        public List<string> Subscriptions { get; set; } = new();
+        public List<string> ResourceGroups { get; set; } = new();
+        public List<string> Regions { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceCriteriaDefinition.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceCriteriaDefinition.cs
@@ -2,6 +2,6 @@
 {
     public class ResourceCriteriaDefinition
     {
-        public ResourceCriteria Include { get; set; } = new ResourceCriteria();
+        public ResourceCriteria Include { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceDiscoveryGroup.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Configuration/ResourceDiscoveryGroup.cs
@@ -6,6 +6,6 @@ namespace Promitor.Agents.ResourceDiscovery.Configuration
     {
         public string Name { get; set; }
         public ResourceType Type { get; set; }
-        public ResourceCriteriaDefinition Criteria { get; set; } = new ResourceCriteriaDefinition();
+        public ResourceCriteriaDefinition Criteria { get; set; } = new();
     }
 }

--- a/src/Promitor.Agents.ResourceDiscovery/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Extensions/IServiceCollectionExtensions.cs
@@ -78,13 +78,10 @@ namespace Promitor.Agents.ResourceDiscovery.Extensions
             {
                 var jobName = "Azure Resource Group Discovery";
                 builder.AddJob<AzureResourceGroupsDiscoveryBackgroundJob>(
-                    jobServices =>
-                    {
-                        return new AzureResourceGroupsDiscoveryBackgroundJob(jobName,
-                            jobServices.GetRequiredService<IAzureResourceRepository>(),
-                            jobServices.GetRequiredService<ISystemMetricsPublisher>(),
-                            jobServices.GetRequiredService<ILogger<AzureResourceGroupsDiscoveryBackgroundJob>>());
-                    },
+                    jobServices => new AzureResourceGroupsDiscoveryBackgroundJob(jobName,
+                        jobServices.GetRequiredService<IAzureResourceRepository>(),
+                        jobServices.GetRequiredService<ISystemMetricsPublisher>(),
+                        jobServices.GetRequiredService<ILogger<AzureResourceGroupsDiscoveryBackgroundJob>>()),
                     schedulerOptions =>
                     {
                         schedulerOptions.CronSchedule = "*/15 * * * *";

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/AzureResourceGraph.cs
@@ -116,66 +116,64 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
             {
                 var graphClient = await GetOrCreateClient();
 
-                bool isSuccessfulDependency = false;
-                using (var dependencyMeasurement = DurationMeasurement.Start())
+                var isSuccessfulDependency = false;
+                using var dependencyMeasurement = DurationMeasurement.Start();
+                try
                 {
-                    try
-                    {
-                        var response = await interactionFunc(graphClient);
-                        isSuccessfulDependency = true;
+                    var response = await interactionFunc(graphClient);
+                    isSuccessfulDependency = true;
 
-                        return response;
-                    }
-                    catch (ErrorResponseException responseException)
+                    return response;
+                }
+                catch (ErrorResponseException responseException)
+                {
+                    if (responseException.Response != null)
                     {
-                        if (responseException.Response != null)
+                        if (responseException.Response.StatusCode == HttpStatusCode.Forbidden)
                         {
-                            if (responseException.Response.StatusCode == HttpStatusCode.Forbidden)
-                            {
-                                var unauthorizedException = CreateUnauthorizedException(targetSubscriptions);
+                            var unauthorizedException = CreateUnauthorizedException(targetSubscriptions);
 
-                                throw unauthorizedException;
-                            }
+                            throw unauthorizedException;
+                        }
 
-                            if (responseException.Response.StatusCode == HttpStatusCode.BadRequest)
+                        if (responseException.Response.StatusCode == HttpStatusCode.BadRequest)
+                        {
+                            var response = JToken.Parse(responseException.Response.Content);
+                            var errorDetails = response["error"]?["details"];
+                            if (errorDetails != null)
                             {
-                                var response = JToken.Parse(responseException.Response.Content);
-                                var errorDetails = response["error"]?["details"];
-                                if (errorDetails != null)
+                                var errorCodes = new List<string>();
+                                foreach (var detailEntry in errorDetails)
                                 {
-                                    var errorCodes = new List<string>();
-                                    foreach (var detailEntry in errorDetails)
-                                    {
-                                        errorCodes.Add(detailEntry["code"]?.ToString());
-                                    }
+                                    errorCodes.Add(detailEntry["code"]?.ToString());
+                                }
 
-                                    if (errorCodes.Any(errorCode => errorCode.Equals("NoValidSubscriptionsInQueryRequest", StringComparison.InvariantCultureIgnoreCase)))
-                                    {
-                                        var invalidSubscriptionException = new QueryContainsInvalidSubscriptionException(targetSubscriptions);
-                                        _logger.LogCritical(invalidSubscriptionException, "Unable to query Azure Resource Graph");
-                                        throw invalidSubscriptionException;
-                                    }
+                                if (errorCodes.Any(errorCode => errorCode.Equals("NoValidSubscriptionsInQueryRequest", StringComparison.InvariantCultureIgnoreCase)))
+                                {
+                                    var invalidSubscriptionException = new QueryContainsInvalidSubscriptionException(targetSubscriptions);
+                                    _logger.LogCritical(invalidSubscriptionException, "Unable to query Azure Resource Graph");
+                                    throw invalidSubscriptionException;
                                 }
                             }
                         }
-
-                        throw;
                     }
-                    finally
+
+                    throw;
+                }
+                finally
+                {
+                    var contextualInformation = new Dictionary<string, object>
                     {
-                        var contextualInformation = new Dictionary<string, object>
-                        {
-                            {"Query", query},
-                            {"QueryName", queryName}
-                        };
+                        {"Query", query},
+                        {"QueryName", queryName}
+                    };
 
-                        if (targetSubscriptions?.Any() == true)
-                        {
-                            contextualInformation.Add("Subscriptions", targetSubscriptions);
-                        }
-
-                        _logger.LogDependency("Azure Resource Graph", query, "Query", isSuccessfulDependency, dependencyMeasurement, contextualInformation);
+                    if (targetSubscriptions?.Any() == true)
+                    {
+                        contextualInformation.Add("Subscriptions", targetSubscriptions);
                     }
+
+                    _logger.LogDependency("Azure Resource Graph", query, "Query", isSuccessfulDependency, dependencyMeasurement, contextualInformation);
                 }
             });
         }

--- a/src/Promitor.Agents.ResourceDiscovery/Health/AzureResourceGraphHealthCheck.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Health/AzureResourceGraphHealthCheck.cs
@@ -31,7 +31,7 @@ namespace Promitor.Agents.ResourceDiscovery.Health
             _resourceDeclarationMonitor = resourceDeclarationMonitor;
         }
 
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new())
         {
             var query = GraphQueryBuilder.ForResourceType("microsoft.logic/workflows")
                 .Project("subscriptionId", "resourceGroup", "type", "name", "id")

--- a/src/Promitor.Agents.Scraper/AzureMonitorClientFactory.cs
+++ b/src/Promitor.Agents.Scraper/AzureMonitorClientFactory.cs
@@ -14,7 +14,7 @@ namespace Promitor.Agents.Scraper
 {
     public class AzureMonitorClientFactory
     {
-        private readonly Dictionary<string, AzureMonitorClient> _azureMonitorClients = new Dictionary<string, AzureMonitorClient>();
+        private readonly Dictionary<string, AzureMonitorClient> _azureMonitorClients = new();
 
         /// <summary>
         /// Provides an Azure Monitor client

--- a/src/Promitor.Agents.Scraper/AzureMonitorClientFactory.cs
+++ b/src/Promitor.Agents.Scraper/AzureMonitorClientFactory.cs
@@ -31,9 +31,9 @@ namespace Promitor.Agents.Scraper
         /// <param name="loggerFactory">Factory to create loggers with</param>
         public AzureMonitorClient CreateIfNotExists(AzureEnvironment cloud, string tenantId, string subscriptionId, MetricSinkWriter metricSinkWriter, IAzureScrapingSystemMetricsPublisher azureScrapingSystemMetricsPublisher, IMemoryCache resourceMetricDefinitionMemoryCache, IConfiguration configuration, IOptions<AzureMonitorIntegrationConfiguration> azureMonitorIntegrationConfiguration, IOptions<AzureMonitorLoggingConfiguration> azureMonitorLoggingConfiguration, ILoggerFactory loggerFactory)
         {
-            if (_azureMonitorClients.ContainsKey(subscriptionId))
+            if (_azureMonitorClients.TryGetValue(subscriptionId, out var value))
             {
-                return _azureMonitorClients[subscriptionId];
+                return value;
             }
 
             var azureMonitorClient = CreateNewAzureMonitorClient(cloud, tenantId, subscriptionId, metricSinkWriter, azureScrapingSystemMetricsPublisher, resourceMetricDefinitionMemoryCache, configuration, azureMonitorIntegrationConfiguration, azureMonitorLoggingConfiguration, loggerFactory);

--- a/src/Promitor.Agents.Scraper/Configuration/ScraperRuntimeConfiguration.cs
+++ b/src/Promitor.Agents.Scraper/Configuration/ScraperRuntimeConfiguration.cs
@@ -7,9 +7,9 @@ namespace Promitor.Agents.Scraper.Configuration
 {
     public class ScraperRuntimeConfiguration : RuntimeConfiguration
     {
-        public AzureMonitorConfiguration AzureMonitor { get; set; } = new AzureMonitorConfiguration();
-        public MetricsConfiguration MetricsConfiguration { get; set; } = new MetricsConfiguration();
-        public MetricSinkConfiguration MetricSinks { get; set; } = new MetricSinkConfiguration();
+        public AzureMonitorConfiguration AzureMonitor { get; set; } = new();
+        public MetricsConfiguration MetricsConfiguration { get; set; } = new();
+        public MetricSinkConfiguration MetricSinks { get; set; } = new();
         public ResourceDiscoveryConfiguration ResourceDiscovery { get; set; }
     }
 }

--- a/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryClient.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/ResourceDiscoveryClient.cs
@@ -16,7 +16,7 @@ namespace Promitor.Agents.Scraper.Discovery
 {
     public class ResourceDiscoveryClient
     {
-        private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects };
+        private readonly JsonSerializerSettings _serializerSettings = new() { TypeNameHandling = TypeNameHandling.Objects };
         private readonly IOptionsMonitor<ResourceDiscoveryConfiguration> _configuration;
         private readonly ILogger<ResourceDiscoveryClient> _logger;
         private readonly HttpClient _httpClient;

--- a/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
+++ b/src/Promitor.Agents.Scraper/Discovery/StubResourceDiscoveryRepository.cs
@@ -8,8 +8,8 @@ namespace Promitor.Agents.Scraper.Discovery
 {
     public class StubResourceDiscoveryRepository : IResourceDiscoveryRepository
     {
-        private static readonly List<AzureResourceDefinition> emptyResourceDefinitions = new List<AzureResourceDefinition>();
-        private static readonly AgentHealthReport healthReport = new AgentHealthReport();
+        private static readonly List<AzureResourceDefinition> emptyResourceDefinitions = new();
+        private static readonly AgentHealthReport healthReport = new();
 
         public Task<List<AzureResourceDefinition>> GetResourceDiscoveryGroupAsync(string resourceDiscoveryGroupName)
         {

--- a/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
+++ b/src/Promitor.Agents.Scraper/Health/ResourceDiscoveryHealthCheck.cs
@@ -18,7 +18,7 @@ namespace Promitor.Agents.Scraper.Health
             _resourceDiscoveryRepository = resourceDiscoveryRepository;
         }
 
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new())
         {
             try
             {

--- a/src/Promitor.Agents.Scraper/Validation/Exceptions/ValidationFailedException.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Exceptions/ValidationFailedException.cs
@@ -15,7 +15,7 @@ namespace Promitor.Agents.Scraper.Validation.Exceptions
             ValidationResults.AddRange(validationResults);
         }
 
-        public List<ValidationResult> ValidationResults { get; } = new List<ValidationResult>();
+        public List<ValidationResult> ValidationResults { get; } = new();
 
         private static string ListErrors(List<ValidationResult> validationResults)
         {

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/MetricsValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/MetricsValidator.cs
@@ -22,7 +22,7 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions
             Guard.NotNull(metrics, nameof(metrics));
 
             var errorMessages = metrics
-                .SelectMany(metric => Validate(metric))
+                .SelectMany(Validate)
                 .AsParallel();
 
             return errorMessages.ToList();

--- a/src/Promitor.Core/ScrapeResult.cs
+++ b/src/Promitor.Core/ScrapeResult.cs
@@ -95,6 +95,6 @@ namespace Promitor.Core
         /// <summary>
         /// Labels that are related to the metric
         /// </summary>
-        public Dictionary<string, string> Labels { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Labels { get; } = new();
     }
 }

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -21,14 +21,9 @@ namespace Promitor.Integrations.Azure.Authentication
         /// <param name="configuration">Application configuration</param>
         public static AzureAuthenticationInfo GetConfiguredAzureAuthentication(IConfiguration configuration)
         {
-            var authenticationConfiguration = configuration.GetSection("authentication").Get<AuthenticationConfiguration>();
-
             // To be still compatible with existing infrastructure using previous version of Promitor, we need to check if the authentication section exists.
             // If not, we should use a default value
-            if (authenticationConfiguration == null)
-            {
-                authenticationConfiguration = new AuthenticationConfiguration();
-            }
+            var authenticationConfiguration = configuration.GetSection("authentication").Get<AuthenticationConfiguration>() ?? new AuthenticationConfiguration();
 
             string applicationKey;
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -30,7 +30,7 @@ namespace Promitor.Integrations.AzureMonitor
         private readonly IOptions<AzureMonitorIntegrationConfiguration> _azureMonitorIntegrationConfiguration;
         private readonly TimeSpan _metricDefinitionCacheDuration = TimeSpan.FromHours(1);
         private readonly IAzure _authenticatedAzureSubscription;
-        private readonly AzureCredentialsFactory _azureCredentialsFactory = new AzureCredentialsFactory();
+        private readonly AzureCredentialsFactory _azureCredentialsFactory = new();
         private readonly IMemoryCache _resourceMetricDefinitionMemoryCache;
         private readonly ILogger _logger;
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -189,8 +189,7 @@ namespace Promitor.Integrations.AzureMonitor
         private MetricValue GetMostRecentMetricValue(string metricName, TimeSeriesElement timeSeries, DateTime recordDateTime)
         {
             var relevantMetricValue = timeSeries.Data.Where(metricValue => metricValue.TimeStamp < recordDateTime)
-                .OrderByDescending(metricValue => metricValue.TimeStamp)
-                .FirstOrDefault();
+                                                     .MaxBy(metricValue => metricValue.TimeStamp);
 
             if (relevantMetricValue == null)
             {

--- a/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorConfiguration.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public class AzureMonitorConfiguration
     {
-        public AzureMonitorIntegrationConfiguration Integration { get; set; } = new AzureMonitorIntegrationConfiguration();
-        public AzureMonitorLoggingConfiguration Logging { get; set; } = new AzureMonitorLoggingConfiguration();
+        public AzureMonitorIntegrationConfiguration Integration { get; set; } = new();
+        public AzureMonitorLoggingConfiguration Logging { get; set; } = new();
     }
 }

--- a/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorIntegrationConfiguration.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorIntegrationConfiguration.cs
@@ -2,6 +2,6 @@
 {
     public class AzureMonitorIntegrationConfiguration
     {
-        public AzureMonitorHistoryConfiguration History { get; set; } = new AzureMonitorHistoryConfiguration();
+        public AzureMonitorHistoryConfiguration History { get; set; } = new();
     }
 }

--- a/src/Promitor.Integrations.LogAnalytics/LogAnalyticsClient.cs
+++ b/src/Promitor.Integrations.LogAnalytics/LogAnalyticsClient.cs
@@ -13,8 +13,8 @@ namespace Promitor.Integrations.LogAnalytics
     {
         private readonly ILogger _logger;
         public readonly string ColumnNameResult = "result";
-        private readonly Uri _defaultEndpoint = new Uri("https://api.loganalytics.io");
-        private readonly Uri _govEndpoint = new Uri("https://api.loganalytics.us");
+        private readonly Uri _defaultEndpoint = new("https://api.loganalytics.io");
+        private readonly Uri _govEndpoint = new("https://api.loganalytics.us");
 
         private readonly LogsQueryClient _logsQueryClient;
 

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Configuration/AtlassianStatusPageSinkConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Configuration/AtlassianStatusPageSinkConfiguration.cs
@@ -5,6 +5,6 @@ namespace Promitor.Integrations.Sinks.Atlassian.Statuspage.Configuration
     public class AtlassianStatusPageSinkConfiguration
     {
         public string PageId { get; set; }
-        public List<SystemMetricMapping> SystemMetricMapping { get; set; } = new List<SystemMetricMapping>();
+        public List<SystemMetricMapping> SystemMetricMapping { get; set; } = new();
     }
 }

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
@@ -68,7 +68,7 @@ namespace Promitor.Integrations.Sinks.OpenTelemetry
 
         private void InitializeNewMetric(string metricName, string metricDescription)
         {
-            var gauge = azureMonitorMeter.CreateObservableGauge<double>(metricName, description: metricDescription, observeValues: () => ReportMeasurementsForMetricAsync(metricName).Result);
+            var gauge = azureMonitorMeter.CreateObservableGauge(metricName, description: metricDescription, observeValues: () => ReportMeasurementsForMetricAsync(metricName).Result);
             _gauges.TryAdd(metricName, gauge);
 
             _measurements.TryAdd(metricName, CreateNewMeasurementChannel());

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/OpenTelemetryCollectorMetricSink.cs
@@ -15,7 +15,7 @@ namespace Promitor.Integrations.Sinks.OpenTelemetry
     public class OpenTelemetryCollectorMetricSink : IMetricSink
     {
         private readonly ILogger<OpenTelemetryCollectorMetricSink> _logger;
-        private static readonly Meter azureMonitorMeter = new Meter("Promitor.Scraper.Metrics.AzureMonitor", "1.0");
+        private static readonly Meter azureMonitorMeter = new("Promitor.Scraper.Metrics.AzureMonitor", "1.0");
 
         public MetricSinkType Type => MetricSinkType.OpenTelemetryCollector;
 
@@ -45,8 +45,8 @@ namespace Promitor.Integrations.Sinks.OpenTelemetry
             await Task.WhenAll(reportMetricTasks);
         }
 
-        private readonly ConcurrentDictionary<string, ObservableGauge<double>> _gauges = new ConcurrentDictionary<string, ObservableGauge<double>>();
-        private readonly ConcurrentDictionary<string, Channel<Measurement<double>>> _measurements = new ConcurrentDictionary<string, Channel<Measurement<double>>>();
+        private readonly ConcurrentDictionary<string, ObservableGauge<double>> _gauges = new();
+        private readonly ConcurrentDictionary<string, Channel<Measurement<double>>> _measurements = new();
 
         public async Task ReportMetricAsync(string metricName, string metricDescription, double metricValue, Dictionary<string, string> labels)
         {

--- a/src/Promitor.Integrations.Sinks.Prometheus/Collectors/AzureScrapingSystemMetricsPublisher.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Collectors/AzureScrapingSystemMetricsPublisher.cs
@@ -37,10 +37,7 @@ namespace Promitor.Integrations.Sinks.Prometheus.Collectors
             var enableMetricTimestamps = _prometheusConfiguration.CurrentValue.EnableMetricTimestamps;
 
             var metricsDeclaration = _metricsDeclarationProvider.Get(applyDefaults: true);
-            if (labels.ContainsKey("tenant_id") == false)
-            {
-                labels.Add("tenant_id", metricsDeclaration.AzureMetadata.TenantId);
-            }
+            labels.TryAdd("tenant_id", metricsDeclaration.AzureMetadata.TenantId);
 
             var orderedLabels = labels.OrderByDescending(kvp => kvp.Key).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 

--- a/src/Promitor.Integrations.Sinks.Prometheus/Configuration/PrometheusScrapingEndpointSinkConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Configuration/PrometheusScrapingEndpointSinkConfiguration.cs
@@ -5,6 +5,6 @@
         public string BaseUriPath { get; set; } = Defaults.Prometheus.ScrapeEndpointBaseUri;
         public double? MetricUnavailableValue { get; set; } = Defaults.Prometheus.MetricUnavailableValue;
         public bool EnableMetricTimestamps { get; set; } = Defaults.Prometheus.EnableMetricTimestamps;
-        public LabelConfiguration Labels { get; set; } = new LabelConfiguration();
+        public LabelConfiguration Labels { get; set; } = new();
     }
 }

--- a/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Prometheus/PrometheusScrapingEndpointMetricSink.cs
@@ -102,9 +102,9 @@ namespace Promitor.Integrations.Sinks.Prometheus
                 foreach (var customLabel in metricDefinition.Labels)
                 {
                     var customLabelKey = customLabel.Key.SanitizeForPrometheusLabelKey();
-                    if (labels.ContainsKey(customLabelKey))
+                    if (labels.TryGetValue(customLabelKey, out var customLabelValue))
                     {
-                        _logger.LogWarning("Custom label {CustomLabelName} was already specified with value '{LabelValue}' instead of '{CustomLabelValue}'. Ignoring...", customLabel.Key, labels[customLabelKey], customLabel.Value);
+                        _logger.LogWarning("Custom label {CustomLabelName} was already specified with value '{LabelValue}' instead of '{CustomLabelValue}'. Ignoring...", customLabel.Key, customLabelValue, customLabel.Value);
                         continue;
                     }
 
@@ -115,18 +115,12 @@ namespace Promitor.Integrations.Sinks.Prometheus
             foreach (var defaultLabel in defaultLabels)
             {
                 var defaultLabelKey = defaultLabel.Key.SanitizeForPrometheusLabelKey();
-                if (labels.ContainsKey(defaultLabelKey) == false)
-                {
-                    labels.Add(defaultLabelKey, defaultLabel.Value);
-                }
+                labels.TryAdd(defaultLabelKey, defaultLabel.Value);
             }
 
             // Add the tenant id
             var metricsDeclaration = _metricsDeclarationProvider.Get(applyDefaults: true);
-            if (labels.ContainsKey("tenant_id") == false)
-            {
-                labels.Add("tenant_id", metricsDeclaration.AzureMetadata.TenantId);
-            }
+            labels.TryAdd("tenant_id", metricsDeclaration.AzureMetadata.TenantId);
 
             // Transform labels, if need be
             if (_prometheusConfiguration.CurrentValue.Labels != null)

--- a/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
+++ b/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
@@ -88,7 +88,7 @@ namespace Promitor.Tests.Integration.Clients
 
             if (gauge == null)
             {
-                Logger.LogInformation($"No matching gauge was found.");
+                Logger.LogInformation("No matching gauge was found.");
                 if (foundMetrics.Any())
                 {
                     Logger.LogInformation($"Found metrics are: {string.Join(", ", foundMetrics.Select(x => x.Name))}");

--- a/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
+++ b/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
@@ -60,7 +60,7 @@ namespace Promitor.Tests.Integration.Clients
             Func<KeyValuePair<string, string>, bool> labelFilter = label => label.Key.Equals(expectedLabelName, StringComparison.InvariantCultureIgnoreCase)
                                                                             && label.Value.Equals(expectedLabelValue, StringComparison.InvariantCultureIgnoreCase);
             return await WaitForPrometheusMetricAsync(x => x.Name.Equals(computedExpectedMetricName, StringComparison.InvariantCultureIgnoreCase)
-                                                           && x.Measurements?.Any(measurement => measurement.Labels?.Any(labelFilter) == true) == true);
+                                                           && x.Measurements?.Any(measurement => measurement.Labels?.Any(F) == true) == true);
         }
 
         private async Task<Gauge> WaitForPrometheusMetricAsync(Predicate<Gauge> filter)

--- a/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
+++ b/src/Promitor.Tests.Integration/Clients/PrometheusClient.cs
@@ -60,7 +60,7 @@ namespace Promitor.Tests.Integration.Clients
             Func<KeyValuePair<string, string>, bool> labelFilter = label => label.Key.Equals(expectedLabelName, StringComparison.InvariantCultureIgnoreCase)
                                                                             && label.Value.Equals(expectedLabelValue, StringComparison.InvariantCultureIgnoreCase);
             return await WaitForPrometheusMetricAsync(x => x.Name.Equals(computedExpectedMetricName, StringComparison.InvariantCultureIgnoreCase)
-                                                           && x.Measurements?.Any(measurement => measurement.Labels?.Any(F) == true) == true);
+                                                           && x.Measurements?.Any(measurement => measurement.Labels?.Any(labelFilter) == true) == true);
         }
 
         private async Task<Gauge> WaitForPrometheusMetricAsync(Predicate<Gauge> filter)

--- a/src/Promitor.Tests.Integration/IntegrationTest.cs
+++ b/src/Promitor.Tests.Integration/IntegrationTest.cs
@@ -12,7 +12,7 @@ namespace Promitor.Tests.Integration
     {
         protected IConfiguration Configuration { get; }
         protected XunitTestLogger Logger { get; }
-        public PrometheusClientFactory PrometheusClientFactory => new PrometheusClientFactory(Logger);
+        public PrometheusClientFactory PrometheusClientFactory => new(Logger);
 
         public IntegrationTest(ITestOutputHelper testOutput)
         {

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.8.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.5.0" />
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Promitor.Parsers.Prometheus.Http" Version="0.2.0" />

--- a/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
+++ b/src/Promitor.Tests.Integration/Services/ResourceDiscovery/ResourceDiscoveryTests.cs
@@ -18,7 +18,7 @@ namespace Promitor.Tests.Integration.Services.ResourceDiscovery
 {
     public class ResourceDiscoveryTests : ResourceDiscoveryIntegrationTest
     {
-        private readonly Faker _bogusGenerator = new Faker();
+        private readonly Faker _bogusGenerator = new();
 
         public ResourceDiscoveryTests(ITestOutputHelper testOutput)
           : base(testOutput)

--- a/src/Promitor.Tests.Unit/Agents/Core/Extensions/ConfigurationBuilder/AddRequiredYamlFileTests.cs
+++ b/src/Promitor.Tests.Unit/Agents/Core/Extensions/ConfigurationBuilder/AddRequiredYamlFileTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Agents.Core.Extensions.ConfigurationBuilder
 
     public class AddRequiredYamlFileTests : IDisposable
     {
-        private readonly List<string> _tempFiles = new List<string>();
+        private readonly List<string> _tempFiles = new();
 
         [Fact]
         public void AddRequiredYamlFile_FileExists_AddsFile()

--- a/src/Promitor.Tests.Unit/Agents/ResourceDiscovery/AzureResourceGroupsDiscoveryBackgroundJobTests.cs
+++ b/src/Promitor.Tests.Unit/Agents/ResourceDiscovery/AzureResourceGroupsDiscoveryBackgroundJobTests.cs
@@ -27,12 +27,12 @@ namespace Promitor.Tests.Unit.Agents.ResourceDiscovery
             _firstPage = new Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation>()
             {
                 PageInformation = new Promitor.Core.Contracts.PageInformation { CurrentPage = 1, PageSize = 1, TotalRecords = 1 },
-                Result = new List<AzureSubscriptionInformation>() { new AzureSubscriptionInformation { TenantId = "TenantId", Id = "ID", Name = "Name" } }
+                Result = new List<AzureSubscriptionInformation>() { new() { TenantId = "TenantId", Id = "ID", Name = "Name" } }
             };
             var secondPage = new Promitor.Core.Contracts.PagedPayload<AzureSubscriptionInformation>()
             {
                 PageInformation = new Promitor.Core.Contracts.PageInformation { CurrentPage = 2, PageSize = 1, TotalRecords = 1 },
-                Result = new List<AzureSubscriptionInformation>() { new AzureSubscriptionInformation { TenantId = "TenantId", Id = "ID", Name = "Name" } }
+                Result = new List<AzureSubscriptionInformation>() { new() { TenantId = "TenantId", Id = "ID", Name = "Name" } }
             };
             azureResourceRepository.Setup(r => r.DiscoverAzureSubscriptionsAsync(1000, 1)).ReturnsAsync(_firstPage);
             azureResourceRepository.Setup(r => r.DiscoverAzureSubscriptionsAsync(1000, 2)).ReturnsAsync(secondPage);

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -18,9 +18,9 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
     public class MetricsDeclarationBuilder
     {
         private readonly AzureMetadataV1 _azureMetadata;
-        private readonly List<MetricDefinitionV1> _metrics = new List<MetricDefinitionV1>();
+        private readonly List<MetricDefinitionV1> _metrics = new();
 
-        private MetricDefaultsV1 _metricDefaults = new MetricDefaultsV1
+        private MetricDefaultsV1 _metricDefaults = new()
         {
             Scraping = new ScrapingV1 { Schedule = @"0 * * ? * *" }
         };

--- a/src/Promitor.Tests.Unit/Core/Scraping/Configuration/Model/Metrics/MetricDefinitionTests.cs
+++ b/src/Promitor.Tests.Unit/Core/Scraping/Configuration/Model/Metrics/MetricDefinitionTests.cs
@@ -12,9 +12,9 @@ namespace Promitor.Tests.Unit.Core.Scraping.Configuration.Model.Metrics
     public class MetricDefinitionTests
     {
         private readonly PrometheusMetricDefinition _prometheusMetricDefinition =
-            new PrometheusMetricDefinition("promitor_test", "test", new Dictionary<string, string>());
+            new("promitor_test", "test", new Dictionary<string, string>());
 
-        private readonly AzureMetadata _azureMetadata = new AzureMetadata { ResourceGroupName = "global-resource-group", SubscriptionId = "global-subscription-id"};
+        private readonly AzureMetadata _azureMetadata = new() { ResourceGroupName = "global-resource-group", SubscriptionId = "global-subscription-id"};
 
         [Fact]
         public void CreateScrapeDefinition_ResourceOverridesResourceGroupName_UsesOverriddenName()

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -200,12 +200,8 @@ namespace Promitor.Tests.Unit.Generators.Config
                     Verbosity = verbosity
                 };
 
-            if (_runtimeConfiguration.Telemetry == null)
-            {
-                _runtimeConfiguration.Telemetry = new TelemetryConfiguration();
-            }
-
-            _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
+            _runtimeConfiguration.Telemetry ??= new TelemetryConfiguration();
+_runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
 
             return this;
         }
@@ -221,11 +217,7 @@ namespace Promitor.Tests.Unit.Generators.Config
                     Verbosity = verbosity
                 };
 
-            if (_runtimeConfiguration.Telemetry == null)
-            {
-                _runtimeConfiguration.Telemetry = new TelemetryConfiguration();
-            }
-
+            _runtimeConfiguration.Telemetry ??= new TelemetryConfiguration();
             _runtimeConfiguration.Telemetry.ApplicationInsights = applicationInsightsTelemetry;
 
             return this;
@@ -233,11 +225,7 @@ namespace Promitor.Tests.Unit.Generators.Config
 
         public RuntimeConfigurationGenerator WithAzureMonitorLogging(bool isEnabled = true, HttpLoggingDelegatingHandler.Level informationLevel = HttpLoggingDelegatingHandler.Level.Headers)
         {
-            if (_runtimeConfiguration.AzureMonitor == null)
-            {
-                _runtimeConfiguration.AzureMonitor = new AzureMonitorConfiguration();
-            }
-
+            _runtimeConfiguration.AzureMonitor ??= new AzureMonitorConfiguration();
             _runtimeConfiguration.AzureMonitor.Logging = new AzureMonitorLoggingConfiguration
             {
                 IsEnabled = isEnabled,

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -20,7 +20,7 @@ namespace Promitor.Tests.Unit.Generators.Config
 {
     internal class RuntimeConfigurationGenerator
     {
-        private readonly ScraperRuntimeConfiguration _runtimeConfiguration = new ScraperRuntimeConfiguration();
+        private readonly ScraperRuntimeConfiguration _runtimeConfiguration = new();
 
         private RuntimeConfigurationGenerator(ServerConfiguration serverConfiguration)
         {

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -292,7 +292,7 @@ namespace Promitor.Tests.Unit.Generators.Config
                     configurationBuilder.AppendLine($"    metricFormat: {_runtimeConfiguration?.MetricSinks.Statsd.MetricFormat}");
                     if (_runtimeConfiguration?.MetricSinks.Statsd.Geneva != null)
                     {
-                        configurationBuilder.AppendLine($"    geneva:");
+                        configurationBuilder.AppendLine("    geneva:");
                         configurationBuilder.AppendLine($"      account: {_runtimeConfiguration?.MetricSinks.Statsd.Geneva.Account}");
                         configurationBuilder.AppendLine($"      namespace: {_runtimeConfiguration?.MetricSinks.Statsd.Geneva.Namespace}");
                     }

--- a/src/Promitor.Tests.Unit/Generators/ScrapeResultGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/ScrapeResultGenerator.cs
@@ -7,7 +7,7 @@ namespace Promitor.Tests.Unit.Generators
 {
     public class ScrapeResultGenerator
     {
-        private static readonly Faker bogus = new Faker();
+        private static readonly Faker bogus = new();
 
         public static ScrapeResult GenerateFromMetric(MeasuredMetric measuredMetric)
         {

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/PrometheusScrapingEndpointMetricSinkTests.cs
@@ -144,7 +144,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             var expectedDimensionName = dimensionName.ToLower();
             var timeSeries = new TimeSeriesElement
             {
-                Metadatavalues = new List<MetadataValue> { new MetadataValue(name: new LocalizableString(dimensionName), value: dimensionValue) }
+                Metadatavalues = new List<MetadataValue> { new(name: new LocalizableString(dimensionName), value: dimensionValue) }
             };
             var firstMetric = MeasuredMetric.CreateForDimension(firstMetricValue, dimensionName.ToUpper(), timeSeries);
             var secondMetric = MeasuredMetric.CreateWithoutDimension(secondMetricValue);
@@ -256,7 +256,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
             var expectedDimensionName = dimensionName.ToLower();
             var timeSeries = new TimeSeriesElement
             {
-                Metadatavalues = new List<MetadataValue> { new MetadataValue(name: new LocalizableString(dimensionName), value: dimensionValue) }
+                Metadatavalues = new List<MetadataValue> { new(name: new LocalizableString(dimensionName), value: dimensionValue) }
             };
             var measuredMetric = MeasuredMetric.CreateForDimension(metricValue, dimensionName.ToUpper(), timeSeries);
             var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/DeserializationTests.cs
@@ -12,8 +12,8 @@ namespace Promitor.Tests.Unit.Serialization.DeserializerTests
     {
         private static readonly TimeSpan defaultInterval = TimeSpan.FromMinutes(5);
 
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
-        private readonly Mock<IDeserializer> _childDeserializer = new Mock<IDeserializer>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
+        private readonly Mock<IDeserializer> _childDeserializer = new();
         private readonly RegistrationConfigDeserializer _deserializer;
 
         public DeserializationTests()

--- a/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/DeserializerTests/ValidationTests.cs
@@ -12,8 +12,8 @@ namespace Promitor.Tests.Unit.Serialization.DeserializerTests
 {
     public class ValidationTests : UnitTest
     {
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
-        private readonly TestDeserializer _deserializer = new TestDeserializer();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
+        private readonly TestDeserializer _deserializer = new();
         
         [Fact]
         public void Deserialize_RequiredFieldMissing_ReportsError()

--- a/src/Promitor.Tests.Unit/Serialization/ErrorReporterTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/ErrorReporterTests.cs
@@ -8,7 +8,7 @@ namespace Promitor.Tests.Unit.Serialization
     [Category("Unit")]
     public class ErrorReporterTests : UnitTest
     {
-        private readonly ErrorReporter _errorReporter = new ErrorReporter();
+        private readonly ErrorReporter _errorReporter = new();
 
         [Fact]
         public void ReportError_AfterErrorReported_AddsError()

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/DefaultTests.cs
@@ -5,8 +5,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
     public class DefaultTests : UnitTest
     {
-        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
-            new FieldDeserializationInfoBuilder<TestConfig, string>();
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder = new();
 
         public DefaultTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingDeserializerTests.cs
@@ -6,8 +6,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
     public class MapUsingDeserializerTests : UnitTest
     {
-        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
-            new FieldDeserializationInfoBuilder<TestConfig, string>();
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder = new();
 
         public MapUsingDeserializerTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/MapUsingTests.cs
@@ -7,8 +7,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
     public class MapUsingTests : UnitTest
     {
-        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
-            new FieldDeserializationInfoBuilder<TestConfig, string>();
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder = new();
 
         public MapUsingTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/RequiredTests.cs
@@ -5,8 +5,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
     public class RequiredTests : UnitTest
     {
-        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
-            new FieldDeserializationInfoBuilder<TestConfig, string>();
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder = new();
 
         public RequiredTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldDeserializationInfoBuilderTests/SetPropertyTests.cs
@@ -6,8 +6,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldDeserializationInfoBuilderTests
 {
     public class SetPropertyTests : UnitTest
     {
-        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder =
-            new FieldDeserializationInfoBuilder<TestConfig, string>();
+        private readonly FieldDeserializationInfoBuilder<TestConfig, string> _builder = new();
 
         [Fact]
         public void SetProperty_SetsPropertyInfo_WhenBuilding()

--- a/src/Promitor.Tests.Unit/Serialization/FieldValidators/CronExpressionValidatorTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/FieldValidators/CronExpressionValidatorTests.cs
@@ -9,7 +9,7 @@ namespace Promitor.Tests.Unit.Serialization.FieldValidators
 {
     public class CronExpressionValidatorTests : UnitTest
     {
-        private readonly CronExpressionValidator _validator = new CronExpressionValidator();
+        private readonly CronExpressionValidator _validator = new();
 
         [Fact]
         public void Validate_InvalidExpression_ReportsError()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/AzureMetricConfigurationDeserializerTests.cs
@@ -15,7 +15,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Core
         private readonly AzureMetricConfigurationDeserializer _deserializer;
         private readonly Mock<IDeserializer<MetricDimensionV1>> _dimensionDeserializer;
         private readonly Mock<IDeserializer<MetricAggregationV1>> _aggregationDeserializer;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
 
         public AzureMetricConfigurationDeserializerTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/LogAnalyticsConfigurationDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/LogAnalyticsConfigurationDeserializerTests.cs
@@ -14,7 +14,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Core
     {
         private readonly LogAnalyticsConfigurationDeserializer _deserializer;
         private readonly Mock<IDeserializer<AggregationV1>> _aggregationDeserializer;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
 
         public LogAnalyticsConfigurationDeserializerTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefaultsDeserializerTests.cs
@@ -15,7 +15,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Core
         private readonly MetricDefaultsDeserializer _deserializer;
         private readonly Mock<IDeserializer<AggregationV1>> _aggregationDeserializer;
         private readonly Mock<IDeserializer<ScrapingV1>> _scrapingDeserializer;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
 
         public MetricDefaultsDeserializerTests()
         {

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/MetricDefinitionDeserializerTests.cs
@@ -17,11 +17,10 @@ namespace Promitor.Tests.Unit.Serialization.v1.Core
         private readonly Mock<IDeserializer<AzureMetricConfigurationV1>> _azureMetricConfigurationDeserializer;
         private readonly Mock<IDeserializer<ScrapingV1>> _scrapingDeserializer;
         private readonly Mock<IAzureResourceDeserializerFactory> _resourceDeserializerFactory;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
-        private readonly Mock<IDeserializer<LogAnalyticsConfigurationV1>> _logAnalyticsConfigurationDeserializer =
-            new Mock<IDeserializer<LogAnalyticsConfigurationV1>>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
+        private readonly Mock<IDeserializer<LogAnalyticsConfigurationV1>> _logAnalyticsConfigurationDeserializer = new();
         private readonly Mock<IDeserializer<AzureResourceDiscoveryGroupDefinitionV1>> _resourceDiscoveryGroupDeserializer =
-            new Mock<IDeserializer<AzureResourceDiscoveryGroupDefinitionV1>>();
+            new();
 
         private readonly MetricDefinitionDeserializer _deserializer;
 
@@ -313,7 +312,7 @@ resources:
 
             var resources = new List<AzureResourceDefinitionV1>
             {
-                new AzureResourceDefinitionV1 { ResourceGroupName = "promitor-group" }
+                new() { ResourceGroupName = "promitor-group" }
             };
             resourceDeserializer.Setup(
                 d => d.Deserialize((YamlSequenceNode)node.Children["resources"], _errorReporter.Object))
@@ -474,7 +473,7 @@ resources:
 - resourceUri: Microsoft.ServiceBus/namespaces/promitor-messaging-2";
             var node = YamlUtils.CreateYamlNode(yamlText);
 
-            SetupResourceDeserializer(node, new List<AzureResourceDefinitionV1> { new AzureResourceDefinitionV1() });
+            SetupResourceDeserializer(node, new List<AzureResourceDefinitionV1> { new() });
 
             // Act
             _deserializer.Deserialize(node, _errorReporter.Object);
@@ -514,7 +513,7 @@ resourceDiscoveryGroups:
             var node = YamlUtils.CreateYamlNode(yamlText);
             var resourceDiscoveryGroups = new List<AzureResourceDiscoveryGroupDefinitionV1>
             {
-                new AzureResourceDiscoveryGroupDefinitionV1()
+                new()
             };
             _resourceDiscoveryGroupDeserializer.Setup(
                 d => d.Deserialize(It.IsAny<YamlSequenceNode>(), It.IsAny<IErrorReporter>())).Returns(resourceDiscoveryGroups);

--- a/src/Promitor.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Core/V1DeserializerTests.cs
@@ -17,7 +17,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Core
         private readonly Mock<IDeserializer<AzureMetadataV1>> _metadataDeserializer;
         private readonly Mock<IDeserializer<MetricDefaultsV1>> _defaultsDeserializer;
         private readonly Mock<IDeserializer<MetricDefinitionV1>> _metricsDeserializer;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
         private readonly V1Deserializer _deserializer;
 
         public V1DeserializerTests()
@@ -160,7 +160,7 @@ metricDefaults:
 metrics:
 - name: promitor_metrics_total";
             var yamlNode = YamlUtils.CreateYamlNode(config);
-            var metrics = new List<MetricDefinitionV1> { new MetricDefinitionV1 { Name = "test_metric" } };
+            var metrics = new List<MetricDefinitionV1> { new() { Name = "test_metric" } };
             _metricsDeserializer.Setup(
                 d => d.Deserialize(It.IsAny<YamlSequenceNode>(), It.IsAny<IErrorReporter>())).Returns(metrics);
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/SqlDatabaseDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/SqlDatabaseDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SqlDatabaseDeserializerTests : ResourceDeserializerTest<SqlDatabaseDeserializer>
     {
-        private readonly SqlDatabaseDeserializer _deserializer = new SqlDatabaseDeserializer(NullLogger.Instance);
+        private readonly SqlDatabaseDeserializer _deserializer = new(NullLogger.Instance);
 
         [Fact]
         public void Deserialize_ServerNameSupplied_SetsServerName()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/SqlElasticPoolDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/SqlElasticPoolDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SqlElasticPoolDeserializerTests : ResourceDeserializerTest<SqlElasticPoolDeserializer>
     {
-        private readonly SqlElasticPoolDeserializer _deserializer = new SqlElasticPoolDeserializer(NullLogger.Instance);
+        private readonly SqlElasticPoolDeserializer _deserializer = new(NullLogger.Instance);
 
         [Fact]
         public void Deserialize_ServerNameSupplied_SetsServerName()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/StorageQueueDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     public class StorageQueueDeserializerTests : ResourceDeserializerTest<StorageQueueDeserializer>
     {
         private readonly Mock<IDeserializer<SecretV1>> _secretDeserializer;
-        private readonly Mock<IErrorReporter> _errorReporter = new Mock<IErrorReporter>();
+        private readonly Mock<IErrorReporter> _errorReporter = new();
 
         private readonly StorageQueueDeserializer _deserializer;
 

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseApacheSparkPoolDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseApacheSparkPoolDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SynapseApacheSparkPoolDeserializerTests : ResourceDeserializerTest<SynapseApacheSparkPoolDeserializer>
     {
-        private readonly SynapseApacheSparkPoolDeserializer _deserializer = new SynapseApacheSparkPoolDeserializer(NullLogger<SynapseApacheSparkPoolDeserializer>.Instance);
+        private readonly SynapseApacheSparkPoolDeserializer _deserializer = new(NullLogger<SynapseApacheSparkPoolDeserializer>.Instance);
 
         [Fact]
         public void Deserialize_PoolNameSupplied_SetsPoolName()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseSqlPoolDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseSqlPoolDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SynapseSqlPoolDeserializerTests : ResourceDeserializerTest<SynapseSqlPoolDeserializer>
     {
-        private readonly SynapseSqlPoolDeserializer _deserializer = new SynapseSqlPoolDeserializer(NullLogger<SynapseSqlPoolDeserializer>.Instance);
+        private readonly SynapseSqlPoolDeserializer _deserializer = new(NullLogger<SynapseSqlPoolDeserializer>.Instance);
 
         [Fact]
         public void Deserialize_PoolNameSupplied_SetsPoolName()

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseWorkspaceDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/SynapseWorkspaceDeserializerTests.cs
@@ -11,7 +11,7 @@ namespace Promitor.Tests.Unit.Serialization.v1.Providers
     [Category("Unit")]
     public class SynapseWorkspaceDeserializerTests : ResourceDeserializerTest<SynapseWorkspaceDeserializer>
     {
-        private readonly SynapseWorkspaceDeserializer _deserializer = new SynapseWorkspaceDeserializer(NullLogger<SynapseWorkspaceDeserializer>.Instance);
+        private readonly SynapseWorkspaceDeserializer _deserializer = new(NullLogger<SynapseWorkspaceDeserializer>.Instance);
         
         [Fact]
         public void Deserialize_WorkspaceNameSupplied_SetsWorkspace()

--- a/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/V1SerializationTests.cs
@@ -62,7 +62,7 @@ namespace Promitor.Tests.Unit.Serialization.v1
                 },
                 Metrics = new List<MetricDefinitionV1>
                 {
-                    new MetricDefinitionV1
+                    new()
                     {
                         Name = "promitor_demo_generic_queue_size",
                         Description = "Amount of active messages of the 'orders' queue (determined with Generic provider)",
@@ -93,7 +93,7 @@ namespace Promitor.Tests.Unit.Serialization.v1
                             }
                         }
                     },
-                    new MetricDefinitionV1
+                    new()
                     {
                         Name = "promitor_demo_servicebusqueue_queue_size",
                         Description = "Amount of active messages of the 'orders' queue (determined with ServiceBusNamespace provider)",
@@ -122,7 +122,7 @@ namespace Promitor.Tests.Unit.Serialization.v1
                         },
                         ResourceDiscoveryGroups = new List<AzureResourceDiscoveryGroupDefinitionV1>
                         {
-                            new AzureResourceDiscoveryGroupDefinitionV1
+                            new()
                             {
                                 Name="example-resource-collection"
                             }

--- a/src/Promitor.sln.DotSettings
+++ b/src/Promitor.sln.DotSettings
@@ -83,6 +83,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/ReSpeller/ReSpellerEnabled/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=APPKEY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Atlassian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autoscale/@EntryIndexedValue">True</s:Boolean>
@@ -93,8 +94,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NGINX/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Promitor/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Promitor_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Promitor_0027s/@EntryIndexedValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resourcegroups/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Statsd/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Statuspage/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->


<!-- markdownlint-enable -->
