### PR TITLE
feat: Add OLTP Exporter Option for Protocol

### DIFF
--- a/config/promitor/scraper/runtime.yaml
+++ b/config/promitor/scraper/runtime.yaml
@@ -11,6 +11,7 @@ metricSinks:
       promitorMetricName: promitor_demo_documentation_availability
   openTelemetryCollector:
     collectorUri: http://opentelemetry-collector:4317
+    protocol: grpc
   prometheusScrapingEndpoint:
     metricUnavailableValue: -1
     enableMetricTimestamps: true # true by default

--- a/src/Promitor.Agents.Scraper/Startup.cs
+++ b/src/Promitor.Agents.Scraper/Startup.cs
@@ -115,6 +115,7 @@ namespace Promitor.Agents.Scraper
             if (metricSinkConfiguration.OpenTelemetryCollector != null)
             {
                 openApiDescriptionBuilder.AppendLine($"<li>OpenTelemetry Collector located on {metricSinkConfiguration.OpenTelemetryCollector.CollectorUri}</li>");
+                openApiDescriptionBuilder.AppendLine($"<li>OpenTelemetry Collector Protocol selected: {metricSinkConfiguration.OpenTelemetryCollector.Protocol}</li>");
             }
 
             if (metricSinkConfiguration.Statsd != null)

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Configuration/OpenTelemetryCollectorSinkConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Configuration/OpenTelemetryCollectorSinkConfiguration.cs
@@ -1,7 +1,11 @@
-﻿namespace Promitor.Integrations.Sinks.OpenTelemetry.Configuration
+﻿using OpenTelemetry.Exporter;
+
+namespace Promitor.Integrations.Sinks.OpenTelemetry.Configuration
 {
     public class OpenTelemetryCollectorSinkConfiguration
     {
+        public OtlpExportProtocol Protocol { get; set; } = default(OtlpExportProtocol);
         public string CollectorUri { get; set; }
+        //Todo: Headers
     }
 }

--- a/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using Promitor.Agents.Scraper.Configuration;
 using Promitor.Integrations.Sinks.Statsd.Configuration;
 using Promitor.Tests.Unit.Generators.Config;
@@ -391,7 +392,7 @@ namespace Promitor.Tests.Unit.Configuration
             // Arrange
             var collectorUri = "https://foo.bar";
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
-                .WithOpenTelemetryCollectorMetricSink(collectorUri: collectorUri)
+                 .WithOpenTelemetryCollectorMetricSink(collectorUri: collectorUri, protocol: OtlpExportProtocol.Grpc)
                 .GenerateAsync();
 
             // Act
@@ -402,6 +403,7 @@ namespace Promitor.Tests.Unit.Configuration
             Assert.NotNull(runtimeConfiguration.MetricSinks);
             Assert.NotNull(runtimeConfiguration.MetricSinks.OpenTelemetryCollector);
             Assert.Equal(collectorUri, runtimeConfiguration.MetricSinks.OpenTelemetryCollector.CollectorUri);
+            Assert.Equal(OtlpExportProtocol.Grpc, runtimeConfiguration.MetricSinks.OpenTelemetryCollector.Protocol);
         }
 
         [Fact]

--- a/src/Promitor.Tests.Unit/Generators/Config/BogusScraperRuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/BogusScraperRuntimeConfigurationGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Bogus;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using Promitor.Agents.Core.Configuration.Server;
 using Promitor.Agents.Core.Configuration.Telemetry;
 using Promitor.Agents.Core.Configuration.Telemetry.Sinks;
@@ -156,6 +157,7 @@ namespace Promitor.Tests.Unit.Generators.Config
             var openTelemetryCollectorSinkConfiguration = new Faker<OpenTelemetryCollectorSinkConfiguration>()
                 .StrictMode(true)
                 .RuleFor(promConfiguration => promConfiguration.CollectorUri, faker => faker.Internet.Url())
+                .RuleFor(promConfiguration => promConfiguration.Protocol, faker => OtlpExportProtocol.Grpc)
                 .Generate();
             return openTelemetryCollectorSinkConfiguration;
         }

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using Promitor.Agents.Core.Configuration.Server;
 using Promitor.Agents.Core.Configuration.Telemetry;
 using Promitor.Agents.Core.Configuration.Telemetry.Sinks;
@@ -71,12 +72,12 @@ namespace Promitor.Tests.Unit.Generators.Config
 
                 if (metricUnavailableValue != null)
                 {
-                    prometheusSinkConfiguration.MetricUnavailableValue = (double) metricUnavailableValue;
+                    prometheusSinkConfiguration.MetricUnavailableValue = (double)metricUnavailableValue;
                 }
 
                 if (enableMetricsTimestamp != null)
                 {
-                    prometheusSinkConfiguration.EnableMetricTimestamps = (bool) enableMetricsTimestamp;
+                    prometheusSinkConfiguration.EnableMetricTimestamps = (bool)enableMetricsTimestamp;
                 }
             }
 
@@ -85,13 +86,14 @@ namespace Promitor.Tests.Unit.Generators.Config
             return this;
         }
 
-        public RuntimeConfigurationGenerator WithOpenTelemetryCollectorMetricSink(string collectorUri = "https://opentelemetry-collector:8888")
+        public RuntimeConfigurationGenerator WithOpenTelemetryCollectorMetricSink(string collectorUri = "https://opentelemetry-collector:8888", OtlpExportProtocol protocol = OtlpExportProtocol.Grpc)
         {
             if (string.IsNullOrWhiteSpace(collectorUri) == false)
             {
                 _runtimeConfiguration.MetricSinks.OpenTelemetryCollector = new OpenTelemetryCollectorSinkConfiguration
                 {
-                    CollectorUri = collectorUri
+                    CollectorUri = collectorUri,
+                    Protocol = protocol
                 };
             }
 
@@ -201,7 +203,7 @@ namespace Promitor.Tests.Unit.Generators.Config
                 };
 
             _runtimeConfiguration.Telemetry ??= new TelemetryConfiguration();
-_runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
+            _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
 
             return this;
         }
@@ -296,6 +298,7 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
                 {
                     configurationBuilder.AppendLine("  openTelemetryCollector:");
                     configurationBuilder.AppendLine($"    collectorUri: {_runtimeConfiguration?.MetricSinks.OpenTelemetryCollector.CollectorUri}");
+                    configurationBuilder.AppendLine($"    protocol: {_runtimeConfiguration?.MetricSinks.OpenTelemetryCollector.Protocol}");
                 }
             }
 

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/OpenTelemetryCollectorMetricSinkValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/Sinks/OpenTelemetryCollectorMetricSinkValidationStepTests.cs
@@ -57,7 +57,6 @@ namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.Sinks
             PromitorAssert.ValidationIsSuccessful(validationResult);
         }
 
-
         [Theory]
         [InlineData(null)]
         [InlineData("")]


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

I wanted to clean some stuff up and remove an alien commit from a friend. I feel like this is a happy compromise.

Some issues I ran into in the last attempt were
 * trying to get the config generator to respect http/protobuff within the config file.
 * trying to force enum convention in yaml
 * trying to do validation against the enum (its always gonna be valid unless we treat the input as a string)
 * trying to change the class structure - which would mean people would have to change their yaml configs due to code generation and I dont want to break that. 
<!-- markdownlint-enable -->
