### PR TITLE
fix: Improve AzureMonitorScraper Error Handling for Time Series Missing Requested Dimension Value

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,7 @@ version:
 
 - {{% tag changed %}} Switch to Mariner distroless base images
 - {{% tag security %}} Patch for [CVE-2023-29331](https://github.com/advisories/GHSA-555c-2p6r-68mm) (High)
+- {{% tag fixed %}} Better handle time series missing requested dimension in AzureMonitorClient [#2331](https://github.com/tomkerkhove/promitor/issues/2331))
 
 #### Resource Discovery
 

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,9 +6,9 @@ version:
 
 #### Scraper
 
+- {{% tag fixed %}} Improve handling of time series with missing dimensions that are requested ([#2331](https://github.com/tomkerkhove/promitor/issues/2331))
 - {{% tag changed %}} Switch to Mariner distroless base images
 - {{% tag security %}} Patch for [CVE-2023-29331](https://github.com/advisories/GHSA-555c-2p6r-68mm) (High)
-- {{% tag fixed %}} Better handle time series missing requested dimension in AzureMonitorClient [#2331](https://github.com/tomkerkhove/promitor/issues/2331))
 
 #### Resource Discovery
 

--- a/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
+++ b/src/Promitor.Core.Scraping/AzureMonitorScraper.cs
@@ -57,7 +57,9 @@ namespace Promitor.Core.Scraping
             {
                 Logger.LogWarning("No metric information found for metric {MetricName} with dimension {MetricDimension}. Details: {Details}", metricsNotFoundException.Name, metricsNotFoundException.Dimension, metricsNotFoundException.Details);
                 
-                var measuredMetric = string.IsNullOrWhiteSpace(dimensionName) ? MeasuredMetric.CreateWithoutDimension(null) : MeasuredMetric.CreateForDimension(null, dimensionName, "unknown");
+                var measuredMetric = string.IsNullOrWhiteSpace(dimensionName) 
+                            ? MeasuredMetric.CreateWithoutDimension(null) 
+                            : MeasuredMetric.CreateForDimension(null, dimensionName, "unknown");
                 measuredMetrics.Add(measuredMetric);
             }
 

--- a/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
+++ b/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
@@ -9,12 +9,13 @@ namespace Promitor.Core.Metrics.Exceptions
         /// <summary>
         ///     Constructor
         /// </summary>
-        /// <param name="metricName">Name of the dimension</param>
+        /// <param name="dimensionName">Name of the dimension</param>
         public MissingDimensionException(string dimensionName, TimeSeriesElement timeSeries) : base($"No value found for dimension '{dimensionName}'")
         {
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
 
             DimensionName = dimensionName;
+            TimeSeries = timeSeries; 
         }
 
         /// <summary>
@@ -25,6 +26,6 @@ namespace Promitor.Core.Metrics.Exceptions
         /// <summary>
         ///     Time series element producing the exception  
         /// </summary>
-        public TimeSeriesElement timeSeries { get; }
+        public TimeSeriesElement TimeSeries { get; }
     }
 }

--- a/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
+++ b/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
@@ -1,5 +1,6 @@
 using System;
 using GuardNet;
+using Microsoft.Azure.Management.Monitor.Fluent.Models;
 
 namespace Promitor.Core.Metrics.Exceptions
 {
@@ -9,7 +10,7 @@ namespace Promitor.Core.Metrics.Exceptions
         ///     Constructor
         /// </summary>
         /// <param name="metricName">Name of the dimension</param>
-        public MissingDimensionException(string dimensionName) : base($"No value found for dimension '{dimensionName}'")
+        public MissingDimensionException(string dimensionName, TimeSeriesElement timeSeries) : base($"No value found for dimension '{dimensionName}'}")
         {
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
 
@@ -20,5 +21,10 @@ namespace Promitor.Core.Metrics.Exceptions
         ///     Name of the dimension
         /// </summary>
         public string DimensionName { get; }
+
+        /// <summary>
+        ///     Time series element producing the exception  
+        /// </summary>
+        public TimeSeriesElement timeSeries { get; }
     }
 }

--- a/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
+++ b/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
@@ -10,7 +10,7 @@ namespace Promitor.Core.Metrics.Exceptions
         ///     Constructor
         /// </summary>
         /// <param name="metricName">Name of the dimension</param>
-        public MissingDimensionException(string dimensionName, TimeSeriesElement timeSeries) : base($"No value found for dimension '{dimensionName}'}")
+        public MissingDimensionException(string dimensionName, TimeSeriesElement timeSeries) : base($"No value found for dimension '{dimensionName}'")
         {
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
 

--- a/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
+++ b/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
@@ -1,0 +1,24 @@
+using System;
+using GuardNet;
+
+namespace Promitor.Core.Metrics.Exceptions
+{
+    public class MissingDimensionException : Exception
+    {
+        /// <summary>
+        ///     Constructor
+        /// </summary>
+        /// <param name="metricName">Name of the dimension</param>
+        public MissingDimensionException(string dimensionName) : base($"No value found for dimension '{dimensionName}'")
+        {
+            Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
+
+            DimensionName = dimensionName;
+        }
+
+        /// <summary>
+        ///     Name of the dimension
+        /// </summary>
+        public string DimensionName { get; }
+    }
+}

--- a/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
+++ b/src/Promitor.Core/Metrics/Exceptions/MissingDimensionException.cs
@@ -10,6 +10,7 @@ namespace Promitor.Core.Metrics.Exceptions
         ///     Constructor
         /// </summary>
         /// <param name="dimensionName">Name of the dimension</param>
+        /// <param name="timeSeries">Time series element missing the dimension</param>
         public MissingDimensionException(string dimensionName, TimeSeriesElement timeSeries) : base($"No value found for dimension '{dimensionName}'")
         {
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -68,7 +68,7 @@ namespace Promitor.Core.Metrics
             var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);            
             if(!dimensionMetadataValue.Any())
             {
-                throw new MissingDimensionException(dimensionName, timeseries.ToString());
+                throw new MissingDimensionException(dimensionName, timeseries);
             }
 
             var dimensionValue = dimensionMetadataValue.Single();

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using GuardNet;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
+using Promitor.Core.Metrics.Exceptions;
 
 namespace Promitor.Core.Metrics
 {
@@ -65,7 +66,10 @@ namespace Promitor.Core.Metrics
             Guard.NotNull(timeseries, nameof(timeseries));
             
             var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);            
-            Guard.For<ArgumentException>(() => dimensionMetadataValue.Count() == 0);
+            if(!dimensionMetadataValue.Any())
+            {
+                throw new MissingDimensionException(dimensionName);
+            }
 
             var dimensionValue = dimensionMetadataValue.First();
             return CreateForDimension(value, dimensionName, dimensionValue.Value);

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -65,7 +65,7 @@ namespace Promitor.Core.Metrics
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
             Guard.NotNull(timeseries, nameof(timeseries));
             
-            var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);            
+            var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true).ToList();            
             if(!dimensionMetadataValue.Any())
             {
                 throw new MissingDimensionException(dimensionName, timeseries);

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -68,10 +68,10 @@ namespace Promitor.Core.Metrics
             var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);            
             if(!dimensionMetadataValue.Any())
             {
-                throw new MissingDimensionException(dimensionName);
+                throw new MissingDimensionException(dimensionName, timeseries.ToString());
             }
 
-            var dimensionValue = dimensionMetadataValue.First();
+            var dimensionValue = dimensionMetadataValue.Single();
             return CreateForDimension(value, dimensionName, dimensionValue.Value);
         }
 

--- a/src/Promitor.Core/Metrics/MeasuredMetric.cs
+++ b/src/Promitor.Core/Metrics/MeasuredMetric.cs
@@ -63,9 +63,11 @@ namespace Promitor.Core.Metrics
         {
             Guard.NotNullOrWhitespace(dimensionName, nameof(dimensionName));
             Guard.NotNull(timeseries, nameof(timeseries));
-            Guard.For<ArgumentException>(() => timeseries.Metadatavalues.Any() == false);
+            
+            var dimensionMetadataValue = timeseries.Metadatavalues.Where(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);            
+            Guard.For<ArgumentException>(() => dimensionMetadataValue.Count() == 0);
 
-            var dimensionValue = timeseries.Metadatavalues.Single(metadataValue => metadataValue.Name?.Value.Equals(dimensionName, StringComparison.InvariantCultureIgnoreCase) == true);
+            var dimensionValue = dimensionMetadataValue.First();
             return CreateForDimension(value, dimensionName, dimensionValue.Value);
         }
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -82,14 +82,14 @@ namespace Promitor.Integrations.AzureMonitor
 
             // Get all metrics
             var startQueryingTime = DateTime.UtcNow;
-            var metricsDefinitions = await GetMetricDefinitionsAsync(resourceId); // metrics available for specified resource 
+            var metricsDefinitions = await GetMetricDefinitionsAsync(resourceId);
             var metricDefinition = metricsDefinitions.SingleOrDefault(definition => definition.Name.Value.ToUpper() == metricName.ToUpper());
             if (metricDefinition == null)
             {
                 throw new MetricNotFoundException(metricName);
             }
 
-            var closestAggregationInterval = DetermineAggregationInterval(metricName, aggregationInterval, metricDefinition.MetricAvailabilities); // time interval 
+            var closestAggregationInterval = DetermineAggregationInterval(metricName, aggregationInterval, metricDefinition.MetricAvailabilities);
 
             // Get the most recent metric
             var relevantMetric = await GetRelevantMetric(metricName, aggregationType, closestAggregationInterval, metricFilter, metricDimension, metricDefinition, metricLimit, startQueryingTime);
@@ -109,12 +109,15 @@ namespace Promitor.Integrations.AzureMonitor
 
                 // Get the metric value according to the requested aggregation type
                 var requestedMetricAggregate = InterpretMetricValue(aggregationType, mostRecentMetricValue);
-                try {
+                try 
+                {
                     var measuredMetric = string.IsNullOrWhiteSpace(metricDimension) ? MeasuredMetric.CreateWithoutDimension(requestedMetricAggregate) : MeasuredMetric.CreateForDimension(requestedMetricAggregate, metricDimension, timeseries);
                     measuredMetrics.Add(measuredMetric);
-                } catch (ArgumentException) {
+                } 
+                catch (ArgumentException) 
+                {
                     _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, metricDimension); 
-                    _logger.LogDebug("The violating time series has content {}", JsonConvert.SerializeObject(timeseries)); 
+                    _logger.LogDebug("The violating time series has content {TimeSeriesJson}}", JsonConvert.SerializeObject(timeseries)); 
                 }
             }
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -117,10 +117,10 @@ namespace Promitor.Integrations.AzureMonitor
                                 : MeasuredMetric.CreateForDimension(requestedMetricAggregate, metricDimension, timeseries);
                     measuredMetrics.Add(measuredMetric);
                 } 
-                catch (MissingDimensionException) 
+                catch (MissingDimensionException e) 
                 {
-                    _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, metricDimension); 
-                    _logger.LogDebug("The violating time series has content {Details}", JsonConvert.SerializeObject(timeseries)); 
+                    _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, e.DimensionName); 
+                    _logger.LogDebug("The violating time series has content {Details}", JsonConvert.SerializeObject(e.timeSeries)); 
                 }
             }
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -22,7 +22,6 @@ using Promitor.Integrations.AzureMonitor.Exceptions;
 using Promitor.Integrations.AzureMonitor.Logging;
 using Promitor.Integrations.AzureMonitor.RequestHandlers;
 using Promitor.Integrations.Azure.Authentication;
-using Promitor.Core.Metrics.Exceptions;
 
 namespace Promitor.Integrations.AzureMonitor
 {

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -120,7 +120,7 @@ namespace Promitor.Integrations.AzureMonitor
                 catch (MissingDimensionException e) 
                 {
                     _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, e.DimensionName); 
-                    _logger.LogDebug("The violating time series has content {Details}", JsonConvert.SerializeObject(e.timeSeries)); 
+                    _logger.LogDebug("The violating time series has content {Details}", JsonConvert.SerializeObject(e.TimeSeries)); 
                 }
             }
 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -23,6 +23,7 @@ using Promitor.Integrations.AzureMonitor.Exceptions;
 using Promitor.Integrations.AzureMonitor.Logging;
 using Promitor.Integrations.AzureMonitor.RequestHandlers;
 using Promitor.Integrations.Azure.Authentication;
+using Promitor.Core.Metrics.Exceptions;
 
 namespace Promitor.Integrations.AzureMonitor
 {
@@ -114,7 +115,7 @@ namespace Promitor.Integrations.AzureMonitor
                     var measuredMetric = string.IsNullOrWhiteSpace(metricDimension) ? MeasuredMetric.CreateWithoutDimension(requestedMetricAggregate) : MeasuredMetric.CreateForDimension(requestedMetricAggregate, metricDimension, timeseries);
                     measuredMetrics.Add(measuredMetric);
                 } 
-                catch (ArgumentException) 
+                catch (MissingDimensionException) 
                 {
                     _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, metricDimension); 
                     _logger.LogDebug("The violating time series has content {TimeSeriesJson}}", JsonConvert.SerializeObject(timeseries)); 

--- a/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/AzureMonitorClient.cs
@@ -112,13 +112,15 @@ namespace Promitor.Integrations.AzureMonitor
                 var requestedMetricAggregate = InterpretMetricValue(aggregationType, mostRecentMetricValue);
                 try 
                 {
-                    var measuredMetric = string.IsNullOrWhiteSpace(metricDimension) ? MeasuredMetric.CreateWithoutDimension(requestedMetricAggregate) : MeasuredMetric.CreateForDimension(requestedMetricAggregate, metricDimension, timeseries);
+                    var measuredMetric = string.IsNullOrWhiteSpace(metricDimension) 
+                                ? MeasuredMetric.CreateWithoutDimension(requestedMetricAggregate) 
+                                : MeasuredMetric.CreateForDimension(requestedMetricAggregate, metricDimension, timeseries);
                     measuredMetrics.Add(measuredMetric);
                 } 
                 catch (MissingDimensionException) 
                 {
                     _logger.LogWarning("{MetricName} has return a time series with empty value for {Dimension} and the measurements will be dropped", metricName, metricDimension); 
-                    _logger.LogDebug("The violating time series has content {TimeSeriesJson}}", JsonConvert.SerializeObject(timeseries)); 
+                    _logger.LogDebug("The violating time series has content {Details}", JsonConvert.SerializeObject(timeseries)); 
                 }
             }
 

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -11,24 +11,25 @@ namespace Promitor.Tests.Unit.Metrics
     public class MeasuredMetricTest : UnitTest
     {
         [Fact]
-        public void Create_MeasuredMetric_With_Dimension_HappyPath_Succeeds()
+        public void Create_MeasuredMetric_With_Single_Dimension_HappyPath_Succeeds()
         {
-            var dimensionName = "dimTest";
+            var dimensionNames = new List<string> { "dimTest"};
             var dimensionValue = "dimTest1";
-            var timeSeries = new TimeSeriesElement(new List<MetadataValue> { new(name: new LocalizableString(dimensionName), value: dimensionValue)});
-            var measuredMetric = MeasuredMetric.CreateForDimension(1, dimensionName, timeSeries);
-            Assert.Equal(measuredMetric.DimensionName, dimensionName);
-            Assert.Equal(measuredMetric.DimensionValue, dimensionValue);   
+            var timeSeries = new TimeSeriesElement(new List<MetadataValue> { new(name: new LocalizableString(dimensionNames[0]), value: dimensionValue)});
+            var measuredMetric = MeasuredMetric.CreateForDimensions(1, dimensionNames, timeSeries);
+            Assert.Equal(measuredMetric.Dimensions.Count, 1);
+            Assert.Equal(measuredMetric.Dimensions[0].Name, dimensionNames[0]);
+            Assert.Equal(measuredMetric.Dimensions[0].Value, dimensionValue);   
             Assert.Equal(measuredMetric.Value, 1);               
         }
 
         [Fact]
         public void Create_MeasuredMetric_Missing_Dimension_Throws_Targeted_Exception()
         {
-            var dimensionName = "dimTest";
+            var dimensionName = new List<string> { "dimTest"};
             var timeSeries = new TimeSeriesElement(new List<MetadataValue> {});
-            MissingDimensionException ex = Assert.Throws<MissingDimensionException>(() => MeasuredMetric.CreateForDimension(1, dimensionName, timeSeries));
-            Assert.Equal(ex.DimensionName, dimensionName);
+            MissingDimensionException ex = Assert.Throws<MissingDimensionException>(() => MeasuredMetric.CreateForDimensions(1, dimensionName, timeSeries));
+            Assert.Equal(ex.DimensionName, dimensionName[0]);
         }
     }
 }

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -31,5 +31,4 @@ namespace Promitor.Tests.Unit.Metrics
             Assert.Equal(ex.DimensionName, dimensionName);
         }
     }
-    
 }

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -17,7 +17,7 @@ namespace Promitor.Tests.Unit.Metrics
             var dimensionValue = "dimTest1";
             var timeSeries = new TimeSeriesElement(new List<MetadataValue> { new(name: new LocalizableString(dimensionNames[0]), value: dimensionValue)});
             var measuredMetric = MeasuredMetric.CreateForDimensions(1, dimensionNames, timeSeries);
-            Assert.Equal(1, measuredMetric.Dimensions.Count);
+            Assert.Single(measuredMetric.Dimensions);
             Assert.Equal(dimensionNames[0], measuredMetric.Dimensions[0].Name);
             Assert.Equal(dimensionValue, measuredMetric.Dimensions[0].Value);
             Assert.Equal(1, measuredMetric.Value);

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Promitor.Core.Metrics;
+using Microsoft.Azure.Management.Monitor.Fluent.Models;
+using Xunit;
+using Promitor.Core.Metrics.Exceptions;
+
+namespace Promitor.Tests.Unit.Metrics
+{
+    [Category("Unit")]
+    public class MeasuredMeticTest : UnitTest
+    {
+        [Fact]
+        public void Create_MeasuredMetric_With_Dimension_HappyPath_Succeeds()
+        {
+            var dimensionName = "dimTest";
+            var dimensionValue = "dimTest1";
+            var timeSeries = new TimeSeriesElement(new List<MetadataValue> { new(name: new LocalizableString(dimensionName), value: dimensionValue)});
+            var measuredMetric = MeasuredMetric.CreateForDimension(1, dimensionName, timeSeries);
+            Assert.Equal(measuredMetric.DimensionName, dimensionName);
+            Assert.Equal(measuredMetric.DimensionValue, dimensionValue);   
+            Assert.Equal(measuredMetric.Value, 1);               
+        }
+
+        [Fact]
+        public void Create_MeasuredMetric_Missing_Dimension_Throws_Targeted_Exception()
+        {
+            var dimensionName = "dimTest";
+            var timeSeries = new TimeSeriesElement(new List<MetadataValue> {});
+            MissingDimensionException ex = Assert.Throws<MissingDimensionException>(() => MeasuredMetric.CreateForDimension(1, dimensionName, timeSeries));
+            Assert.Equal(ex.DimensionName, dimensionName)
+        }
+    }
+    
+}

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -28,7 +28,7 @@ namespace Promitor.Tests.Unit.Metrics
             var dimensionName = "dimTest";
             var timeSeries = new TimeSeriesElement(new List<MetadataValue> {});
             MissingDimensionException ex = Assert.Throws<MissingDimensionException>(() => MeasuredMetric.CreateForDimension(1, dimensionName, timeSeries));
-            Assert.Equal(ex.DimensionName, dimensionName)
+            Assert.Equal(ex.DimensionName, dimensionName);
         }
     }
     

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -8,7 +8,7 @@ using Promitor.Core.Metrics.Exceptions;
 namespace Promitor.Tests.Unit.Metrics
 {
     [Category("Unit")]
-    public class MeasuredMeticTest : UnitTest
+    public class MeasuredMetricTest : UnitTest
     {
         [Fact]
         public void Create_MeasuredMetric_With_Dimension_HappyPath_Succeeds()

--- a/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/MeasuredMetricTests.cs
@@ -17,17 +17,17 @@ namespace Promitor.Tests.Unit.Metrics
             var dimensionValue = "dimTest1";
             var timeSeries = new TimeSeriesElement(new List<MetadataValue> { new(name: new LocalizableString(dimensionNames[0]), value: dimensionValue)});
             var measuredMetric = MeasuredMetric.CreateForDimensions(1, dimensionNames, timeSeries);
-            Assert.Equal(measuredMetric.Dimensions.Count, 1);
-            Assert.Equal(measuredMetric.Dimensions[0].Name, dimensionNames[0]);
-            Assert.Equal(measuredMetric.Dimensions[0].Value, dimensionValue);   
-            Assert.Equal(measuredMetric.Value, 1);               
+            Assert.Equal(1, measuredMetric.Dimensions.Count);
+            Assert.Equal(dimensionNames[0], measuredMetric.Dimensions[0].Name);
+            Assert.Equal(dimensionValue, measuredMetric.Dimensions[0].Value);
+            Assert.Equal(1, measuredMetric.Value);
         }
 
         [Fact]
         public void Create_MeasuredMetric_Missing_Dimension_Throws_Targeted_Exception()
         {
             var dimensionName = new List<string> { "dimTest"};
-            var timeSeries = new TimeSeriesElement(new List<MetadataValue> {});
+            var timeSeries = new TimeSeriesElement(new List<MetadataValue>());
             MissingDimensionException ex = Assert.Throws<MissingDimensionException>(() => MeasuredMetric.CreateForDimensions(1, dimensionName, timeSeries));
             Assert.Equal(ex.DimensionName, dimensionName[0]);
         }


### PR DESCRIPTION
Fixes #2331

At Axon, we observed that Azure Monitor may, from time to time, return time series without the requested dimension. The previous try catch logic is at the metric level, ensuring that failure to scrape one metric will not affect all metrics; however, there are many time series within a metric, and failure to process one time series will result in a metric gap for that metric. I am adding a try-catch when looping over time series to prevent that from happening. 

I am very new to this repo though, and couldn't find my way around how to write tests for this. Some help would be much appreciated. 