### PR TITLE
fix: Multi dimension support for StatsD

### DIFF
--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Promitor.Core;
+using Promitor.Core.Metrics;
 using Promitor.Core.Metrics.Sinks;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Integrations.Sinks.Core;
@@ -42,17 +43,20 @@ namespace Promitor.Integrations.Sinks.Statsd
             var reportMetricTasks = new List<Task>();
             var formatterType = _statsDConfiguration.CurrentValue?.MetricFormat ?? StatsdFormatterTypesEnum.Default;
 
+
             foreach (var measuredMetric in scrapeResult.MetricValues)
             {
                 var metricValue = measuredMetric.Value ?? 0;
 
+                var metricLabels = DetermineLabels(metricName, scrapeResult, measuredMetric);
+
                 switch (formatterType)
                 {
                     case StatsdFormatterTypesEnum.Default:
-                        reportMetricTasks.Add(ReportMetricAsync(metricName, metricDescription, metricValue, scrapeResult.Labels));
+                        reportMetricTasks.Add(ReportMetricAsync(metricName, metricDescription, metricValue, metricLabels));
                         break;
                     case StatsdFormatterTypesEnum.Geneva:
-                        reportMetricTasks.Add(ReportMetricWithGenevaFormattingAsync(metricName, metricDescription, metricValue, scrapeResult.Labels));
+                        reportMetricTasks.Add(ReportMetricWithGenevaFormattingAsync(metricName, metricDescription, metricValue, metricLabels));
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(formatterType), $"{formatterType} is not supported as formatting type.");

--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -42,7 +42,6 @@ namespace Promitor.Integrations.Sinks.Statsd
             var reportMetricTasks = new List<Task>();
             var formatterType = _statsDConfiguration.CurrentValue?.MetricFormat ?? StatsdFormatterTypesEnum.Default;
 
-
             foreach (var measuredMetric in scrapeResult.MetricValues)
             {
                 var metricValue = measuredMetric.Value ?? 0;

--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Promitor.Core;
-using Promitor.Core.Metrics;
 using Promitor.Core.Metrics.Sinks;
 using Promitor.Core.Scraping.Configuration.Providers.Interfaces;
 using Promitor.Integrations.Sinks.Core;

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
@@ -158,7 +158,7 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
                 statsDSinkConfiguration.CurrentValue.Geneva.Account,
                 statsDSinkConfiguration.CurrentValue.Geneva.Namespace,
                 Metric = metricName,
-                Dims = scrapeResult.Labels
+                Dims = metricSink.DetermineLabels(metricName, scrapeResult, measuredMetric)
             });
 
             // Act


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
