### PR TITLE
fix(deps): update dependency Moq to earlier version that is not flagged

### DIFF
--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

Nexus IQ scan has detected a critical vulnerability on the latest version of Moq i.e. v4.20.70. Hence reverting it until the vulnerability has been fixed.

![image](https://github.com/tomkerkhove/promitor/assets/39337516/14f4ff82-7c3d-4fd5-96d1-bcc9efca951e)

Hence reverting it to v4.18.4.


<!-- markdownlint-enable -->
