### PR TITLE
feat: Provide support for Azure Firewall

### DIFF
--- a/build/azure-devops/templates/agents/run-opentelemetry-collector.yml
+++ b/build/azure-devops/templates/agents/run-opentelemetry-collector.yml
@@ -34,7 +34,7 @@ steps:
   displayName: 'Show OpenTelemetry configuration'
 - script: |
       echo Mounting volumes: ${{ parameters.volumes }}
-      docker run -d -p 8888:8888 -p 8889:8889 --name ${{ parameters.containerName }} $(networkArgument) --volume ${{ parameters.volumes }} otel/opentelemetry-collector --config /etc/otel-collector-config.yaml
+      docker run -d -p 8888:8888 -p 8889:8889 --name ${{ parameters.containerName }} $(networkArgument) --volume ${{ parameters.volumes }} otel/opentelemetry-collector:0.103.0 --config /etc/otel-collector-config.yaml
       sleep 10
       docker logs ${{ parameters.containerName }}
   displayName: Run OpenTelemetry Collector as ${{ parameters.containerName }} container

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,8 +6,8 @@ version:
 
 #### Scraper
 
-None.
+- {{% tag added %}} Provide support for Azure Firewall ([docs](https://docs.promitor.io/scraping/providers/azure-firewall/))
   
 #### Resource Discovery
 
-None.
+- {{% tag added %}} Provide support for Azure Firewall ([docs](https://docs.promitor.io/scraping/providers/azure-firewall/))

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -7,8 +7,7 @@ version:
 #### Scraper
 
 - {{% tag added %}} Provide support for Azure Firewall ([docs](https://docs.promitor.io/scraping/providers/azure-firewall/))
-  
+
 #### Resource Discovery
 
 - {{% tag added %}} Provide support for Azure Firewall ([docs](https://docs.promitor.io/scraping/providers/azure-firewall/))
-

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -11,3 +11,4 @@ version:
 #### Resource Discovery
 
 - {{% tag added %}} Provide support for Azure Firewall ([docs](https://docs.promitor.io/scraping/providers/azure-firewall/))
+

--- a/config/promitor/resource-discovery/resource-discovery-declaration.yaml
+++ b/config/promitor/resource-discovery/resource-discovery-declaration.yaml
@@ -15,6 +15,8 @@ resourceDiscoveryGroups:
   type: AppPlan
 - name: automation-accounts
   type: AutomationAccount
+- name: azure-firewall
+  type: AzureFirewall
 - name: cdn-landscape
   type: Cdn
 - name: container-instances

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -173,7 +173,7 @@ metrics:
     resources:
       - accountName: promitor-testing-resource-eu-automation-1
   - name: azure_firewall_application_rule_hits
-    description: number of times Application rules were hit	percentage of cpu used by powerbi dedicated
+    description: number of times Application rules were hit
     resourceType: AzureFirewall
     azureMetricConfiguration:
         metricName: ApplicationRuleHit

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -173,7 +173,7 @@ metrics:
     resources:
       - accountName: promitor-testing-resource-eu-automation-1
   - name: azure_firewall_application_rule_hits
-    description: percentage of cpu used by powerbi dedicated
+    description: number of times Application rules were hit	percentage of cpu used by powerbi dedicated
     resourceType: AzureFirewall
     azureMetricConfiguration:
         metricName: ApplicationRuleHit

--- a/config/promitor/scraper/metrics.yaml
+++ b/config/promitor/scraper/metrics.yaml
@@ -172,6 +172,17 @@ metrics:
       - name: automation-accounts
     resources:
       - accountName: promitor-testing-resource-eu-automation-1
+  - name: azure_firewall_application_rule_hits
+    description: percentage of cpu used by powerbi dedicated
+    resourceType: AzureFirewall
+    azureMetricConfiguration:
+        metricName: ApplicationRuleHit
+        aggregation:
+            type: Count
+        dimension:
+          name: Status
+    resourceDiscoveryGroups:
+        - name: azure-firewall
   - name: promitor_demo_frontdoor_backend_health_per_backend_pool
     description: "Health percentage for a backend in Azure Front Door"
     resourceType: FrontDoor

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -20,6 +20,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new AppPlanDiscoveryQuery();
                 case ResourceType.AutomationAccount:
                     return new AutomationAccountResourceDiscoveryQuery();
+                case ResourceType.AzureFirewall:
+                    return new AzureFirewallDiscoveryQuery();
                 case ResourceType.Cdn:
                     return new CdnDiscoveryQuery();
                 case ResourceType.ContainerInstance:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+﻿using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class AzureFirewallDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/azureFirewalls" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var azureFirewallName = resultRowEntry[3]?.ToString();
+
+            var resource = new AzureFirewallResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), azureFirewallName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
@@ -7,7 +7,7 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
 {
     public class AzureFirewallDiscoveryQuery : ResourceDiscoveryQuery
     {
-        public override string[] ResourceTypes => new[] { "microsoft.network/azureFirewalls" };
+        public override string[] ResourceTypes => new[] { "microsoft.network/azurefirewalls" };
         public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "name" };
 
         public override AzureResourceDefinition ParseResults(JToken resultRowEntry)

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/AzureFirewallDiscoveryQuery.cs
@@ -8,13 +8,13 @@ namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
     public class AzureFirewallDiscoveryQuery : ResourceDiscoveryQuery
     {
         public override string[] ResourceTypes => new[] { "microsoft.network/azureFirewalls" };
-        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "type", "name" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "name" };
 
         public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
         {
             Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
 
-            var azureFirewallName = resultRowEntry[3]?.ToString();
+            var azureFirewallName = resultRowEntry[2]?.ToString();
 
             var resource = new AzureFirewallResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), azureFirewallName);
             return resource;

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -21,6 +21,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new AppPlanMetricValidator();
                 case ResourceType.AutomationAccount:
                     return new AutomationAccountMetricValidator();
+                 case ResourceType.AzureFirewall:
+                    return new AzureFirewallMetricValidator();
                 case ResourceType.BlobStorage:
                     return new BlobStorageMetricValidator();
                 case ResourceType.Cdn:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/AzureFirewallMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/AzureFirewallMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class AzureFirewallMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<AzureFirewallResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.AzureFirewallName))
+                {
+                    yield return "No firewall name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -55,5 +55,6 @@
         PublicIpAddress = 50,
         TrafficManager = 51,
         PowerBiDedicated = 52,
+        AzureFirewall = 53,
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallDefinition.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class AzureFirewallDefinition : AzureResourceDefinition
+    {
+        public AzureFirewallDefinition(string subscriptionId, string resourceGroupName, string azureFirewallName)
+            : base(ResourceType.VirtualMachine, subscriptionId, resourceGroupName, azureFirewallName)
+        {
+            AzureFirewallName = azureFirewallName;
+        }
+
+        public string AzureFirewallName { get; }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallDefinition.cs
@@ -3,7 +3,7 @@ namespace Promitor.Core.Contracts.ResourceTypes
     public class AzureFirewallDefinition : AzureResourceDefinition
     {
         public AzureFirewallDefinition(string subscriptionId, string resourceGroupName, string azureFirewallName)
-            : base(ResourceType.VirtualMachine, subscriptionId, resourceGroupName, azureFirewallName)
+            : base(ResourceType.AzureFirewall, subscriptionId, resourceGroupName, azureFirewallName)
         {
             AzureFirewallName = azureFirewallName;
         }

--- a/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/AzureFirewallResourceDefinition.cs
@@ -1,8 +1,8 @@
 namespace Promitor.Core.Contracts.ResourceTypes
 {
-    public class AzureFirewallDefinition : AzureResourceDefinition
+    public class AzureFirewallResourceDefinition : AzureResourceDefinition
     {
-        public AzureFirewallDefinition(string subscriptionId, string resourceGroupName, string azureFirewallName)
+        public AzureFirewallResourceDefinition(string subscriptionId, string resourceGroupName, string azureFirewallName)
             : base(ResourceType.AzureFirewall, subscriptionId, resourceGroupName, azureFirewallName)
         {
             AzureFirewallName = azureFirewallName;

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -36,6 +36,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.AutomationAccount:
                     var automationLogger = _loggerFactory.CreateLogger<AutomationAccountDeserializer>();
                     return new AutomationAccountDeserializer(automationLogger);
+                case ResourceType.AzureFirewall:
+                     var azureFirewallLogger = _loggerFactory.CreateLogger<AzureFirewallDeserializer>();
                 case ResourceType.BlobStorage:
                     var blobStorageLogger = _loggerFactory.CreateLogger<BlobStorageDeserializer>();
                     return new BlobStorageDeserializer(blobStorageLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -37,7 +37,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                     var automationLogger = _loggerFactory.CreateLogger<AutomationAccountDeserializer>();
                     return new AutomationAccountDeserializer(automationLogger);
                 case ResourceType.AzureFirewall:
-                     var azureFirewallLogger = _loggerFactory.CreateLogger<AzureFirewallDeserializer>();
+                    var azureFirewallLogger = _loggerFactory.CreateLogger<AzureFirewallDeserializer>();
+                    return new AzureFirewallDeserializer(azureFirewallLogger);
                 case ResourceType.BlobStorage:
                     var blobStorageLogger = _loggerFactory.CreateLogger<BlobStorageDeserializer>();
                     return new BlobStorageDeserializer(blobStorageLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -30,6 +30,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<ApplicationInsightsResourceV1, ApplicationInsightsResourceDefinition>();
             CreateMap<AppPlanResourceV1, AppPlanResourceDefinition>();
             CreateMap<AutomationAccountResourceV1, AutomationAccountResourceDefinition>();
+            CreateMap<AzureFirewallResourceV1, AzureFirewallResourceDefinition>();
             CreateMap<BlobStorageResourceV1, BlobStorageResourceDefinition>();
             CreateMap<CdnResourceV1, CdnResourceDefinition>();
             CreateMap<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>();
@@ -89,6 +90,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<ApplicationInsightsResourceV1, ApplicationInsightsResourceDefinition>()
                 .Include<AppPlanResourceV1, AppPlanResourceDefinition>()
                 .Include<AutomationAccountResourceV1, AutomationAccountResourceDefinition>()
+                .Include<AzureFirewallResourceV1, AzureFirewallResourceDefinition>(),
                 .Include<BlobStorageResourceV1, BlobStorageResourceDefinition>()
                 .Include<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>()
                 .Include<ContainerRegistryResourceV1, ContainerRegistryResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -90,7 +90,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<ApplicationInsightsResourceV1, ApplicationInsightsResourceDefinition>()
                 .Include<AppPlanResourceV1, AppPlanResourceDefinition>()
                 .Include<AutomationAccountResourceV1, AutomationAccountResourceDefinition>()
-                .Include<AzureFirewallResourceV1, AzureFirewallResourceDefinition>(),
+                .Include<AzureFirewallResourceV1, AzureFirewallResourceDefinition>()
                 .Include<BlobStorageResourceV1, BlobStorageResourceDefinition>()
                 .Include<ContainerInstanceResourceV1, ContainerInstanceResourceDefinition>()
                 .Include<ContainerRegistryResourceV1, ContainerRegistryResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureFirewallResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureFirewallResourceV1.cs
@@ -1,0 +1,13 @@
+﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape a virtual machine.
+    /// </summary>
+    public class AzureFirewallResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the virtual machine to get metrics for.
+        /// </summary>
+        public string AzureFirewallName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureFirewallResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/AzureFirewallResourceV1.cs
@@ -1,12 +1,12 @@
 ﻿namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
 {
     /// <summary>
-    /// Contains the configuration required to scrape a virtual machine.
+    /// Contains the configuration required to scrape an Azure firewall.
     /// </summary>
     public class AzureFirewallResourceV1 : AzureResourceDefinitionV1
     {
         /// <summary>
-        /// The name of the virtual machine to get metrics for.
+        /// The name of the Azure firewall to get metrics for.
         /// </summary>
         public string AzureFirewallName { get; set; }
     }

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AzureFirewallDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/AzureFirewallDeserializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class AzureFirewallDeserializer : ResourceDeserializer<AzureFirewallResourceV1>
+    {
+        public AzureFirewallDeserializer(ILogger<AzureFirewallDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.AzureFirewallName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -47,6 +47,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new AppPlanScraper(scraperConfiguration);
                 case ResourceType.AutomationAccount:
                     return new AutomationAccountScraper(scraperConfiguration);
+                case ResourceType.AzureFirewall:
+                    return new AzureFirewallScraper(scraperConfiguration);
                 case ResourceType.BlobStorage:
                     return new BlobStorageScraper(scraperConfiguration);
                 case ResourceType.Cdn:

--- a/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class AzureFirewallScraper : AzureMonitorScraper<AzureFirewallDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/azureFirewalls/{2}";
+
+        public AzureFirewallScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, VirtualMachineResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.AzureFirewallName);
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
@@ -4,7 +4,7 @@ using Promitor.Core.Scraping.Configuration.Model.Metrics;
 
 namespace Promitor.Core.Scraping.ResourceTypes
 {
-    internal class AzureFirewallScraper : AzureMonitorScraper<AzureFirewallDefinition>
+    internal class AzureFirewallScraper : AzureMonitorScraper<AzureFirewallResourceDefinition>
     {
         private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/azureFirewalls/{2}";
 

--- a/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/AzureFirewallScraper.cs
@@ -13,7 +13,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
         {
         }
 
-        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, VirtualMachineResourceDefinition resource)
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, AzureFirewallResourceDefinition resource)
         {
             return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.AzureFirewallName);
         }

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -167,6 +167,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithAzureFirewallMetric(string metricName = "promitor-AzureFirewall",
+            string metricDescription = "Description for a metric",
+            string azureFirewallName = "promitor-AzureFirewall",
+            string azureMetricName = "ApplicationRuleHit",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new AzureFirewallResourceV1
+            {
+                AzureFirewallName = azureFirewallName
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.AzureFirewall, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+    
         public MetricsDeclarationBuilder WithBlobStorageMetric(string metricName = "promitor",
             string metricDescription = "Description for a metric",
             string accountName = "promitor-account",

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/AzureFirewallDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/AzureFirewallDeserializerTests.cs
@@ -1,0 +1,45 @@
+﻿
+using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class AzureFirewallDeserializerTests : ResourceDeserializerTest<AzureFirewallDeserializer>
+	{
+        private readonly AzureFirewallDeserializer _deserializer;
+
+	public AzureFirewallDeserializerTests()
+	{
+            _deserializer = new AzureFirewallDeserializer(Logger);
+	}
+
+        [Fact]
+        public void Deserialize_AzureFirewallNameSupplied_SetsAzureFirewallName()
+        {
+            YamlAssert.PropertySet<AzureFirewallResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "azureFirewallName: promitor-firewall-name",
+                "promitor-firewall-name",
+                r => r.AzureFirewallName);
+        }
+
+        [Fact]
+        public void Deserialize_AzureFirewallNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<AzureFirewallResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.AzureFirewallName);
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new AzureFirewallDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/AzureFirewallDeclarationValidationStepsTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/AzureFirewallDeclarationValidationStepsTests.cs
@@ -1,0 +1,152 @@
+﻿using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class AzureFirewallMetricsDeclarationValidationStepsTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void AzureFirewall_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void AzureFirewallDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewall_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewall_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewallMetricsDeclaration_DeclarationWithoutAzureFirewall_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(azureFirewallName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewallMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewallMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric(omitResource: true, resourceDiscoveryGroupName: "sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void AzureFirewallMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithAzureFirewallMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->

When implementing a new scraper; these tasks are completed:
- [x] Implement configuration
- [x] Implement validation
- [x] Implement scraping
- [x] Implement resource discovery
- [x] Provide unit tests
- [ ] Test end-to-end
- [x] Document scraper (https://github.com/promitor/docs/pull/64)
- [x] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**

```
azure_firewall_application_rule_hits{tenant_id="<redacted>",subscription_id="<redacted>",status="unknown",resource_uri="subscriptions/<redacted>/resourceGroups/<redacted>-vnet/providers/Microsoft.Network/azureFirewalls/<redacted>-firewall",resource_group="<redacted>-vnet",instance_name="<redacted>-firewall"} NaN 1726675946568
azure_firewall_application_rule_hits{tenant_id="<redacted>",subscription_id="<redacted>b",status="Allow",resource_uri="subscriptions/<redacted>/resourceGroups/<redacted>-vnet/providers/Microsoft.Network/azureFirewalls/<redacted>-firewall",resource_group="<redacted>-vnet",instance_name="<redacted>-firewall"} 84 1726675946630
azure_firewall_application_rule_hits{tenant_id="<redacted>",subscription_id="<redacted>",status="Deny",resource_uri="subscriptions/<redacted>/resourceGroups/<redacted>-vnet/providers/Microsoft.Network/azureFirewalls/<redacted>-firewall",resource_group="<redacted>vnet",instance_name="<redacted>-firewall"} 204 1726675946627
```

**Discovery output:**

### /api/v1/health

```json
{"entries":{"azure-resource-graph":{"data":{"Subscription <redacted>":{"isSuccessful":true,"message":"Successfully queried resources via Azure Resource Graph"}},"description":"Successfully queried all subscriptions","duration":"00:00:00.1368361","status":"Healthy","tags":[]}},"status":"Healthy","totalDuration":"00:00:00.1413060"}
```

### /api/v2/resources/groups/azure-firewall-landscape/discover

```json
{"$type":"Promitor.Core.Contracts.PagedPayload`1[[Promitor.Core.Contracts.AzureResourceDefinition, Promitor.Core.Contracts]], Promitor.Core.Contracts","Result":[{"$type":"Promitor.Core.Contracts.ResourceTypes.AzureFirewallResourceDefinition, Promitor.Core.Contracts","AzureFirewallName":"<redacted>-vnet-firewall","ResourceType":"AzureFirewall","SubscriptionId":"<redacted>","ResourceGroupName":"<redacted>","ResourceName":"<redacted>-vnet-firewall","UniqueName":"<redacted>-vnet-firewall"},{"$type":"Promitor.Core.Contracts.ResourceTypes.AzureFirewallResourceDefinition, Promitor.Core.Contracts","AzureFirewallName":"<redacted>-firewall","ResourceType":"AzureFirewall","SubscriptionId":"<redacted>","ResourceGroupName":"<redacted>-validation","ResourceName":"<redacted>-validation-firewall","UniqueName":"<redacted>-validation-firewall"},{"$type":"Promitor.Core.Contracts.ResourceTypes.AzureFirewallResourceDefinition, Promitor.Core.Contracts","AzureFirewallName":"<redacted>-firewall","ResourceType":"AzureFirewall","SubscriptionId":"<redacted>","ResourceGroupName":"<redacted>-vnet","ResourceName":"<redacted>-firewall","UniqueName":"<redacted>-firewall"},{"$type":"Promitor.Core.Contracts.ResourceTypes.AzureFirewallResourceDefinition, Promitor.Core.Contracts","AzureFirewallName":"<redacted>-firewall","ResourceType":"AzureFirewall","SubscriptionId":"<redacted>","ResourceGroupName":"<redacted>-vnet","ResourceName":"<redacted>-firewall","UniqueName":"<redacted>-firewall"},{"$type":"Promitor.Core.Contracts.ResourceTypes.AzureFirewallResourceDefinition, Promitor.Core.Contracts","AzureFirewallName":"<redacted>-firewall","ResourceType":"AzureFirewall","SubscriptionId":"<redacted>","ResourceGroupName":"<redacted>-vnet","ResourceName":"<redacted>-firewall","UniqueName":"<redacted>-vnet-firewall"}],"PageInformation":{"$type":"Promitor.Core.Contracts.PageInformation, Promitor.Core.Contracts","PageSize":1000,"CurrentPage":1,"TotalRecords":5},"HasMore":false}
```

