### PR TITLE
chore(deps): update .net

### DIFF
--- a/.github/workflows/templates-build-push-image.yml
+++ b/.github/workflows/templates-build-push-image.yml
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push preview image
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.9.0
         with:
           build-args: VERSION="${{ env.artifact_full_version }}"
           context: ./src/

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="CronScheduler.AspNetCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageReference Include="Prometheus.Client" Version="5.2.0" />
     <PackageReference Include="Prometheus.Client.AspNetCore" Version="5.0.0" />

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.301-cbl-mariner2.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.403-cbl-mariner2.0 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Agents.ResourceDiscovery/* Promitor.Agents.ResourceDiscovery/
@@ -14,7 +14,7 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.6-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.10-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.windows
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Agents.ResourceDiscovery/* Promitor.Agents.ResourceDiscovery/
@@ -14,7 +14,7 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=%VERSION%
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-nanoserver-ltsc2022 AS runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="c:/config/"
 COPY --from=build /app .

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -36,15 +36,15 @@
     <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceGraph" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageReference Include="Polly" Version="8.4.0" />
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.301-cbl-mariner2.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.403-cbl-mariner2.0 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Core/* Promitor.Core/
@@ -18,7 +18,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.6-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.10-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 

--- a/src/Promitor.Agents.Scraper/Dockerfile.windows
+++ b/src/Promitor.Agents.Scraper/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Core/* Promitor.Core/
@@ -18,7 +18,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=%VERSION%
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 as runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-nanoserver-ltsc2022 as runtime
 WORKDIR /app
 ENV PROMITOR_CONFIG_FOLDER="c:/config/"
 

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -44,8 +44,8 @@
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Management.Monitor.Fluent" Version="1.38.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="YamlDotNet" Version="15.1.6" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -8,7 +8,7 @@
 <ItemGroup>
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
 </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
 </ItemGroup>
 
 </Project>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Another PR to re-run failed CI 
<!-- markdownlint-enable -->
