### PR TITLE
fix: correctly log job timeout 

### DIFF
--- a/.github/workflows/templates-build-push-image.yml
+++ b/.github/workflows/templates-build-push-image.yml
@@ -1,6 +1,5 @@
-name: Build and Push (Linux)
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       image_name:
         required: true
@@ -16,8 +15,6 @@ jobs:
   linux:
     name: Build & Push (Linux)
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -35,7 +32,7 @@ jobs:
           echo "image_latest_uri=${{ inputs.image_name }}:${{ inputs.version }}" >> $GITHUB_ENV
 
       - name: Determine container image metadata
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: ${{ inputs.image_name }}
 
@@ -43,14 +40,14 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: hkfgo
+          username: tomkerkhove
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push preview image
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.15.0
         with:
           build-args: VERSION="${{ env.artifact_full_version }}"
           context: ./src/
           file: ./src/${{ inputs.project_name }}/Dockerfile.linux
-          tags: ghcr.io/hkfgo/${{ env.image_commit_uri }},ghcr.io/hkfgo/${{ env.image_latest_uri }}
+          tags: ${{ env.image_commit_uri }},${{ env.image_latest_uri }}
           push: true

--- a/.github/workflows/templates-build-push-image.yml
+++ b/.github/workflows/templates-build-push-image.yml
@@ -1,5 +1,6 @@
+name: Build and Push (Linux)
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       image_name:
         required: true
@@ -15,6 +16,8 @@ jobs:
   linux:
     name: Build & Push (Linux)
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,7 +35,7 @@ jobs:
           echo "image_latest_uri=${{ inputs.image_name }}:${{ inputs.version }}" >> $GITHUB_ENV
 
       - name: Determine container image metadata
-        uses: docker/metadata-action@v5.7.0
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ inputs.image_name }}
 
@@ -40,14 +43,14 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: tomkerkhove
+          username: hkfgo
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push preview image
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@v5.3.0
         with:
           build-args: VERSION="${{ env.artifact_full_version }}"
           context: ./src/
           file: ./src/${{ inputs.project_name }}/Dockerfile.linux
-          tags: ${{ env.image_commit_uri }},${{ env.image_latest_uri }}
+          tags: ghcr.io/hkfgo/${{ env.image_commit_uri }},ghcr.io/hkfgo/${{ env.image_latest_uri }}
           push: true

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -7,6 +7,7 @@ version:
 #### Scraper
 
 None.
+
 #### Resource Discovery
 
 None.

--- a/src/Promitor.Agents.Core/Configuration/Defaults.cs
+++ b/src/Promitor.Agents.Core/Configuration/Defaults.cs
@@ -24,7 +24,7 @@ namespace Promitor.Agents.Core.Configuration
             /// On rare occasions, scrape jobs can hang and subsequent jobs cannot run, as they cannot acquire a mutex. 
             ///  MutexTimeoutSeconds setting ensures scraping mutex is released.  
             /// </summary>
-            public static int MutexTimeoutSeconds { get; } = 30;
+            public static int MutexTimeoutSeconds { get; } = 60;
         }
         
         public class Telemetry

--- a/src/Promitor.Agents.Core/Configuration/Defaults.cs
+++ b/src/Promitor.Agents.Core/Configuration/Defaults.cs
@@ -24,7 +24,7 @@ namespace Promitor.Agents.Core.Configuration
             /// On rare occasions, scrape jobs can hang and subsequent jobs cannot run, as they cannot acquire a mutex. 
             ///  MutexTimeoutSeconds setting ensures scraping mutex is released.  
             /// </summary>
-            public static int MutexTimeoutSeconds { get; } = 60;
+            public static int MutexTimeoutSeconds { get; } = 90;
         }
         
         public class Telemetry

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -379,7 +379,7 @@ namespace Promitor.Agents.Scraper.Scheduling
                 {
                     Logger.LogError("Scrape job {JobName} was cancelled due to timeout. However, dangling async tasks " +
                           "may be running for an unbounded amount of time. In the rare case where " +
-                          "many such timeouts occur, consider restarting the Scraper Agent.", Name);
+                          "many such timeouts occur, consider restarting the Scraper Agent or tuning the mutex timeout configuration.", Name);
                     throw new OperationCanceledException(cancellationToken);
                 }
             }

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -142,6 +142,8 @@ namespace Promitor.Agents.Scraper.Scheduling
             {
                 var mutexReleasedAfterSeconds = _concurrencyConfiguration.Value.MutexTimeoutSeconds;
                 var timeoutCancellationTokenSource = new CancellationTokenSource();
+                Logger.LogInformation("Timeout after {Timeout}", mutexReleasedAfterSeconds);
+
                 timeoutCancellationTokenSource.CancelAfter(mutexReleasedAfterSeconds * 1000);
 
                 Logger.LogInformation("Init timeout token");

--- a/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
+++ b/src/Promitor.Agents.Scraper/Scheduling/ResourcesScrapingJob.cs
@@ -143,13 +143,8 @@ namespace Promitor.Agents.Scraper.Scheduling
                 var mutexReleasedAfterSeconds = _concurrencyConfiguration.Value.MutexTimeoutSeconds;
                 var timeoutCancellationTokenSource = new CancellationTokenSource();
                 timeoutCancellationTokenSource.CancelAfter(mutexReleasedAfterSeconds * 1000);
-                timeoutCancellationTokenSource.Token.Register(() => {
-                    Logger.LogError("Scrape job {JobName} was cancelled due to timeout. However, dangling async tasks " +
-                                    "may be running for an unbounded amount of time. In the rare case where " +
-                                    "many such timeouts occur, consider restarting the Scraper Agent.", Name);     
-                });
 
-                Logger.LogWarning("Init timeout token");
+                Logger.LogInformation("Init timeout token");
                 // to enforce timeout in addition to cancellationToken passed down by .NET 
                 var composedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
                 var scrapeDefinitions = await GetAllScrapeDefinitions(composedCancellationTokenSource.Token);
@@ -377,7 +372,14 @@ namespace Promitor.Agents.Scraper.Scheduling
                 cancellationToken.Register(() => {
                     tcs.TrySetResult(null);
                 });
-                await Task.WhenAny(work(), tcs.Task);
+                var completedTask = await Task.WhenAny(work(), tcs.Task);
+                if (completedTask == tcs.Task)
+                {
+                    Logger.LogError("Scrape job {JobName} was cancelled due to timeout. However, dangling async tasks " +
+                          "may be running for an unbounded amount of time. In the rare case where " +
+                          "many such timeouts occur, consider restarting the Scraper Agent.", Name);
+                    throw new OperationCanceledException(cancellationToken);
+                }
             }
             finally
             {


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
