### PR TITLE
fix: add aggregation to batch criteria

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -6,7 +6,7 @@ version:
 
 #### Scraper
 
-None.
+- {{% tag fixed %}} Azure Monitor Scraper: batch based on aggregation in addition to existing criteria
 
 #### Resource Discovery
 

--- a/src/Promitor.Core.Scraping/Configuration/Model/AzureMetricConfiguration.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Model/AzureMetricConfiguration.cs
@@ -67,6 +67,17 @@ namespace Promitor.Core.Scraping.Configuration.Model
             }
             sb.Append($"_limit{Limit}");
 
+            if (Aggregation != null)
+            {
+                sb.Append("_agg");
+                sb.Append(Aggregation.Type.ToString());
+
+                if (Aggregation.Interval.HasValue)
+                {
+                    sb.Append("_interval");
+                    sb.Append(Aggregation.Interval.Value.ToString("c"));
+                }
+            }
 
             return sb.ToString();
         }

--- a/src/Promitor.Tests.Unit/Core/Metrics/ScrapeDefinitionBatchPropertiesTest.cs
+++ b/src/Promitor.Tests.Unit/Core/Metrics/ScrapeDefinitionBatchPropertiesTest.cs
@@ -167,6 +167,25 @@ namespace Promitor.Tests.Unit.Core.Metrics
         }
 
         [Fact]
+        public void BuildBatchHashKeyDifferentResultDifferentAggregation()
+        {
+            var azureMetricConfiguration1 = _mapper.Map<AzureMetricConfiguration>(azureMetricConfigurationBase);
+            azureMetricConfiguration1.Aggregation = new MetricAggregation{Type = PromitorMetricAggregationType.Count};
+            var azureMetricConfiguration2 = _mapper.Map<AzureMetricConfiguration>(azureMetricConfigurationBase);
+            azureMetricConfiguration2.Aggregation = new MetricAggregation{Type = PromitorMetricAggregationType.Average};
+            var logAnalyticsConfiguration = _mapper.Map<LogAnalyticsConfiguration>(logAnalyticsConfigurationBase);
+
+            var scraping = _mapper.Map<Promitor.Core.Scraping.Configuration.Model.Scraping>(scrapingBase);
+
+            var batchProperties = new ScrapeDefinitionBatchProperties(azureMetricConfiguration: azureMetricConfiguration1, logAnalyticsConfiguration: logAnalyticsConfiguration, prometheusMetricDefinition: prometheusMetricDefinition, resourceType: Promitor.Core.Contracts.ResourceType.StorageAccount, scraping: scraping, subscriptionId: subscriptionId);
+            var batchProperties2 = new ScrapeDefinitionBatchProperties(azureMetricConfiguration: azureMetricConfiguration2, logAnalyticsConfiguration: logAnalyticsConfiguration, prometheusMetricDefinition: prometheusMetricDefinition, resourceType: Promitor.Core.Contracts.ResourceType.StorageAccount, scraping: scraping, subscriptionId: subscriptionId);
+
+            var hashCode1 = batchProperties.GetHashCode();
+            var hashCode2 = batchProperties2.GetHashCode();
+            Assert.NotEqual(hashCode1, hashCode2);
+        }
+
+        [Fact]
         public void BuildBatchHashKeyTest()
         {
             AzureMetricConfigurationV1 azureMetricConfigurationTest1 = new AzureMetricConfigurationV1 


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
