### PR TITLE
fix: Stop creating GitHub Release in pipeline

### DIFF
--- a/build/azure-devops/agents-resource-discovery-release-official.yml
+++ b/build/azure-devops/agents-resource-discovery-release-official.yml
@@ -23,7 +23,7 @@ parameters:
 - name: createGithubRelease
   displayName: Create GitHub Release
   type: boolean
-  default: true
+  default: false
 
 variables:
   - template: ./variables/tests.yml

--- a/build/azure-devops/agents-scraper-release-official.yml
+++ b/build/azure-devops/agents-scraper-release-official.yml
@@ -23,7 +23,7 @@ parameters:
 - name: createGithubRelease
   displayName: Create GitHub Release
   type: boolean
-  default: true
+  default: false
 
 variables:
   - template: ./variables/tests.yml


### PR DESCRIPTION
Stop creating GitHub Release in pipeline since the task no longer works