### PR TITLE
feat: make lookback configurable in minutes

### DIFF
--- a/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorHistoryConfiguration.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorHistoryConfiguration.cs
@@ -1,7 +1,14 @@
-﻿namespace Promitor.Integrations.AzureMonitor.Configuration
+﻿using System;
+namespace Promitor.Integrations.AzureMonitor.Configuration
 {
     public class AzureMonitorHistoryConfiguration
     {
         public int StartingFromInHours { get; set; } = 12;
+        public TimeSpan? HistoryStartingFromOffset { get; set; } = null;
+
+        public TimeSpan ResolveEffectiveStartingFrom()
+        {
+            return HistoryStartingFromOffset ?? TimeSpan.FromHours(StartingFromInHours);
+        }
     }
 }

--- a/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorHistoryConfiguration.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Configuration/AzureMonitorHistoryConfiguration.cs
@@ -4,11 +4,11 @@ namespace Promitor.Integrations.AzureMonitor.Configuration
     public class AzureMonitorHistoryConfiguration
     {
         public int StartingFromInHours { get; set; } = 12;
-        public TimeSpan? HistoryStartingFromOffset { get; set; } = null;
+        public TimeSpan? StartingFromOffset { get; set; } = null;
 
         public TimeSpan ResolveEffectiveStartingFrom()
         {
-            return HistoryStartingFromOffset ?? TimeSpan.FromHours(StartingFromInHours);
+            return StartingFromOffset ?? TimeSpan.FromHours(StartingFromInHours);
         }
     }
 }

--- a/src/Promitor.Integrations.AzureMonitor/Extensions/AzureMonitorQueryTasks.cs
+++ b/src/Promitor.Integrations.AzureMonitor/Extensions/AzureMonitorQueryTasks.cs
@@ -20,7 +20,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
         {   
             MetricsQueryOptions queryOptions;
             var querySizeLimit = metricLimit ?? Defaults.MetricDefaults.Limit;
-            var historyStartingFromInHours = azureMonitorIntegrationConfiguration.Value.History.StartingFromInHours;
+            var effectiveStartingFrom = azureMonitorIntegrationConfiguration.Value.History.ResolveEffectiveStartingFrom();
             var filter = BuildFilter(metricDimensions, metricFilter);
 
             if (!string.IsNullOrEmpty(filter))
@@ -32,7 +32,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
                     Granularity = metricInterval,
                     Filter = filter,
                     Size = querySizeLimit, 
-                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.AddHours(-historyStartingFromInHours)), new DateTimeOffset(recordDateTime))
+                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.Subtract(effectiveStartingFrom)), new DateTimeOffset(recordDateTime))
                 };
             } 
             else 
@@ -43,7 +43,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
                     }, 
                     Granularity = metricInterval,
                     Size = querySizeLimit, 
-                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.AddHours(-historyStartingFromInHours)), new DateTimeOffset(recordDateTime))
+                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.Subtract(effectiveStartingFrom)), new DateTimeOffset(recordDateTime))
                 };
             }
             
@@ -56,8 +56,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
         {   
             MetricsQueryResourcesOptions queryOptions;
             var querySizeLimit = metricLimit ?? Defaults.MetricDefaults.Limit;
-            //var historyStartingFromInHours = azureMonitorIntegrationConfiguration.Value.History.StartingFromInHours;
-            var historyStartingFromInHours = 2;
+            var effectiveStartingFrom = azureMonitorIntegrationConfiguration.Value.History.ResolveEffectiveStartingFrom();
             var filter = BuildFilter(metricDimensions, metricFilter);
             List<ResourceIdentifier> resourceIdentifiers = resourceIds.Select(id => new ResourceIdentifier(id)).ToList(); 
 
@@ -68,7 +67,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
                     Granularity = metricInterval,
                     Filter = filter,
                     Size = querySizeLimit, 
-                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.AddHours(-historyStartingFromInHours)), new DateTimeOffset(recordDateTime))
+                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.Subtract(effectiveStartingFrom)), new DateTimeOffset(recordDateTime))
                 };
             } 
             else 
@@ -76,7 +75,7 @@ namespace Promitor.Integrations.AzureMonitor.Extensions
                 queryOptions = new MetricsQueryResourcesOptions {
                     Aggregations = { metricAggregation.ToString().ToLower() },
                     Granularity = metricInterval,
-                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.AddHours(-historyStartingFromInHours)), new DateTimeOffset(recordDateTime))
+                    TimeRange= new QueryTimeRange(new DateTimeOffset(recordDateTime.Subtract(effectiveStartingFrom)), new DateTimeOffset(recordDateTime))
                 };
             }
 

--- a/src/Promitor.Integrations.AzureMonitor/LegacyAzureMonitorClient.cs
+++ b/src/Promitor.Integrations.AzureMonitor/LegacyAzureMonitorClient.cs
@@ -241,9 +241,9 @@ namespace Promitor.Integrations.AzureMonitor
         private IWithMetricsQueryExecute CreateMetricsQuery(AggregationType metricAggregation, TimeSpan metricsInterval, string metricFilter, List<string> metricDimensions,
             int? metricLimit, IMetricDefinition metricDefinition, DateTime recordDateTime)
         {
-            var historyStartingFromInHours = _azureMonitorIntegrationConfiguration.Value.History.StartingFromInHours;
+            var effectiveStartingFrom = _azureMonitorIntegrationConfiguration.Value.History.ResolveEffectiveStartingFrom();
             var metricQuery = metricDefinition.DefineQuery()
-                .StartingFrom(recordDateTime.AddHours(-historyStartingFromInHours))
+                .StartingFrom(recordDateTime.Subtract(effectiveStartingFrom))
                 .EndsBefore(recordDateTime)
                 .WithAggregation(metricAggregation.ToString())
                 .WithInterval(metricsInterval);

--- a/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
@@ -98,12 +98,12 @@ namespace Promitor.Tests.Unit.Configuration
         }
 
         [Fact]
-        public async Task RuntimeConfiguration_HasHistoryStartingFromOffsetConfigured_TakesPriorityOverHours()
+        public async Task RuntimeConfiguration_HasStartingFromOffsetConfigured_TakesPriorityOverHours()
         {
             // Arrange
             var expectedOffset = TimeSpan.FromMinutes(5);
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
-                .WithAzureMonitorIntegration(startingFromInHours: 24, historyStartingFromOffset: expectedOffset)
+                .WithAzureMonitorIntegration(startingFromInHours: 24, startingFromOffset: expectedOffset)
                 .GenerateAsync();
 
             // Act
@@ -114,16 +114,16 @@ namespace Promitor.Tests.Unit.Configuration
             Assert.NotNull(runtimeConfiguration.AzureMonitor);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
-            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
+            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.StartingFromOffset);
         }
 
         [Fact]
-        public async Task RuntimeConfiguration_HasOnlyHistoryStartingFromOffsetConfigured_SetsOffset()
+        public async Task RuntimeConfiguration_HasOnlyStartingFromOffsetConfigured_SetsOffset()
         {
             // Arrange
             var expectedOffset = TimeSpan.FromMinutes(15);
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
-                .WithAzureMonitorIntegration(startingFromInHours: null, historyStartingFromOffset: expectedOffset)
+                .WithAzureMonitorIntegration(startingFromInHours: null, startingFromOffset: expectedOffset)
                 .GenerateAsync();
 
             // Act
@@ -134,15 +134,15 @@ namespace Promitor.Tests.Unit.Configuration
             Assert.NotNull(runtimeConfiguration.AzureMonitor);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
-            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
+            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.StartingFromOffset);
         }
 
         [Fact]
-        public async Task RuntimeConfiguration_HasNoOffsetConfigured_FallsBackToStartingFromInHoursDefault()
+        public async Task RuntimeConfiguration_HasNoStartingFromOffsetConfigured_FallsBackToStartingFromInHoursDefault()
         {
             // Arrange
             var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
-                .WithAzureMonitorIntegration(startingFromInHours: null, historyStartingFromOffset: null)
+                .WithAzureMonitorIntegration(startingFromInHours: null, startingFromOffset: null)
                 .GenerateAsync();
 
             // Act
@@ -154,7 +154,7 @@ namespace Promitor.Tests.Unit.Configuration
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
             Assert.Equal(12, runtimeConfiguration.AzureMonitor.Integration.History.StartingFromInHours);
-            Assert.Null(runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
+            Assert.Null(runtimeConfiguration.AzureMonitor.Integration.History.StartingFromOffset);
         }
 
         [Fact]

--- a/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
+++ b/src/Promitor.Tests.Unit/Configuration/RuntimeConfigurationUnitTest.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Extensions.Configuration;
@@ -94,6 +95,66 @@ namespace Promitor.Tests.Unit.Configuration
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
             Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
             Assert.Equal(expectedStartingFromInHours, runtimeConfiguration.AzureMonitor.Integration.History.StartingFromInHours);
+        }
+
+        [Fact]
+        public async Task RuntimeConfiguration_HasHistoryStartingFromOffsetConfigured_TakesPriorityOverHours()
+        {
+            // Arrange
+            var expectedOffset = TimeSpan.FromMinutes(5);
+            var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
+                .WithAzureMonitorIntegration(startingFromInHours: 24, historyStartingFromOffset: expectedOffset)
+                .GenerateAsync();
+
+            // Act
+            var runtimeConfiguration = configuration.Get<ScraperRuntimeConfiguration>();
+
+            // Assert
+            Assert.NotNull(runtimeConfiguration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
+            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
+        }
+
+        [Fact]
+        public async Task RuntimeConfiguration_HasOnlyHistoryStartingFromOffsetConfigured_SetsOffset()
+        {
+            // Arrange
+            var expectedOffset = TimeSpan.FromMinutes(15);
+            var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
+                .WithAzureMonitorIntegration(startingFromInHours: null, historyStartingFromOffset: expectedOffset)
+                .GenerateAsync();
+
+            // Act
+            var runtimeConfiguration = configuration.Get<ScraperRuntimeConfiguration>();
+
+            // Assert
+            Assert.NotNull(runtimeConfiguration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
+            Assert.Equal(expectedOffset, runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
+        }
+
+        [Fact]
+        public async Task RuntimeConfiguration_HasNoOffsetConfigured_FallsBackToStartingFromInHoursDefault()
+        {
+            // Arrange
+            var configuration = await RuntimeConfigurationGenerator.WithServerConfiguration()
+                .WithAzureMonitorIntegration(startingFromInHours: null, historyStartingFromOffset: null)
+                .GenerateAsync();
+
+            // Act
+            var runtimeConfiguration = configuration.Get<ScraperRuntimeConfiguration>();
+
+            // Assert
+            Assert.NotNull(runtimeConfiguration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration);
+            Assert.NotNull(runtimeConfiguration.AzureMonitor.Integration.History);
+            Assert.Equal(12, runtimeConfiguration.AzureMonitor.Integration.History.StartingFromInHours);
+            Assert.Null(runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset);
         }
 
         [Fact]

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -235,7 +235,7 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
             return this;
         }
 
-        public RuntimeConfigurationGenerator WithAzureMonitorIntegration(int? startingFromInHours = 100, bool? useAzureMonitorSdk = true, int? batchSize = null)
+        public RuntimeConfigurationGenerator WithAzureMonitorIntegration(int? startingFromInHours = 100, bool? useAzureMonitorSdk = true, int? batchSize = null, TimeSpan? historyStartingFromOffset = null)
         {
             _runtimeConfiguration.AzureMonitor ??= new AzureMonitorConfiguration();
             _runtimeConfiguration.AzureMonitor.Integration ??= new AzureMonitorIntegrationConfiguration();
@@ -245,6 +245,11 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
             if (startingFromInHours != null)
             {
                 _runtimeConfiguration.AzureMonitor.Integration.History.StartingFromInHours = startingFromInHours.Value;
+            }
+
+            if (historyStartingFromOffset != null)
+            {
+                _runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset = historyStartingFromOffset;
             }
 
             if (useAzureMonitorSdk != null)
@@ -371,6 +376,10 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
                     configurationBuilder.AppendLine($"    useAzureMonitorSdk: {_runtimeConfiguration?.AzureMonitor.Integration.UseAzureMonitorSdk}");
                     configurationBuilder.AppendLine("    history:");
                     configurationBuilder.AppendLine($"      startingFromInHours: {_runtimeConfiguration?.AzureMonitor.Integration.History.StartingFromInHours}");
+                    if (_runtimeConfiguration?.AzureMonitor.Integration.History.HistoryStartingFromOffset != null)
+                    {
+                        configurationBuilder.AppendLine($"      historyStartingFromOffset: {_runtimeConfiguration?.AzureMonitor.Integration.History.HistoryStartingFromOffset}");
+                    }
                     configurationBuilder.AppendLine("    metricsBatching:");
                     configurationBuilder.AppendLine($"      enabled: {_runtimeConfiguration?.AzureMonitor.Integration.MetricsBatching.Enabled}");
                     configurationBuilder.AppendLine($"      maxBatchSize: {_runtimeConfiguration?.AzureMonitor.Integration.MetricsBatching.MaxBatchSize}");

--- a/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
+++ b/src/Promitor.Tests.Unit/Generators/Config/RuntimeConfigurationGenerator.cs
@@ -235,7 +235,7 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
             return this;
         }
 
-        public RuntimeConfigurationGenerator WithAzureMonitorIntegration(int? startingFromInHours = 100, bool? useAzureMonitorSdk = true, int? batchSize = null, TimeSpan? historyStartingFromOffset = null)
+        public RuntimeConfigurationGenerator WithAzureMonitorIntegration(int? startingFromInHours = 100, bool? useAzureMonitorSdk = true, int? batchSize = null, TimeSpan? startingFromOffset = null)
         {
             _runtimeConfiguration.AzureMonitor ??= new AzureMonitorConfiguration();
             _runtimeConfiguration.AzureMonitor.Integration ??= new AzureMonitorIntegrationConfiguration();
@@ -247,9 +247,9 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
                 _runtimeConfiguration.AzureMonitor.Integration.History.StartingFromInHours = startingFromInHours.Value;
             }
 
-            if (historyStartingFromOffset != null)
+            if (startingFromOffset != null)
             {
-                _runtimeConfiguration.AzureMonitor.Integration.History.HistoryStartingFromOffset = historyStartingFromOffset;
+                _runtimeConfiguration.AzureMonitor.Integration.History.StartingFromOffset = startingFromOffset;
             }
 
             if (useAzureMonitorSdk != null)
@@ -376,9 +376,9 @@ _runtimeConfiguration.Telemetry.ContainerLogs = containerLogConfiguration;
                     configurationBuilder.AppendLine($"    useAzureMonitorSdk: {_runtimeConfiguration?.AzureMonitor.Integration.UseAzureMonitorSdk}");
                     configurationBuilder.AppendLine("    history:");
                     configurationBuilder.AppendLine($"      startingFromInHours: {_runtimeConfiguration?.AzureMonitor.Integration.History.StartingFromInHours}");
-                    if (_runtimeConfiguration?.AzureMonitor.Integration.History.HistoryStartingFromOffset != null)
+                    if (_runtimeConfiguration?.AzureMonitor.Integration.History.StartingFromOffset != null)
                     {
-                        configurationBuilder.AppendLine($"      historyStartingFromOffset: {_runtimeConfiguration?.AzureMonitor.Integration.History.HistoryStartingFromOffset}");
+                        configurationBuilder.AppendLine($"      startingFromOffset: {_runtimeConfiguration?.AzureMonitor.Integration.History.StartingFromOffset}");
                     }
                     configurationBuilder.AppendLine("    metricsBatching:");
                     configurationBuilder.AppendLine($"      enabled: {_runtimeConfiguration?.AzureMonitor.Integration.MetricsBatching.Enabled}");


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
