### PR TITLE
fix: V1ConfigurationMapper - return empty list for null Dimensions to prevent ArgumentNullException

### DIFF
--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1ConfigurationMapper.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1ConfigurationMapper.cs
@@ -155,7 +155,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             {
                 MetricName = source.MetricName,
                 Limit = source.Limit,
-                Dimensions = source.Dimensions?.Select(MapMetricDimension).ToList(),
+                Dimensions = source.Dimensions?.Select(MapMetricDimension).ToList() ?? new List<MetricDimension>(),
 #pragma warning disable CS0618 // Type or member is obsolete
                 Dimension = MapMetricDimension(source.Dimension),
 #pragma warning restore CS0618


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #2740 where the V1ConfigurationMapper returns null for AzureMetricConfiguration.Dimensions when the source has no dimensions configured. The AzureMetricConfigurationValidator calls .Any() on this property, which throws ArgumentNullException when it is null.

## Root Cause

AutoMapper defaulted null collections to empty lists. The hand-written mapper preserved null, but downstream validators expect non-null collections.

## Error

`
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.Enumerable.Any[TSource](IEnumerable source)
   at AzureMetricConfigurationValidator.ValidateAzureMetricConfiguration(line 58)
`

## Fix

`diff
- Dimensions = source.Dimensions?.Select(MapMetricDimension).ToList(),
+ Dimensions = source.Dimensions?.Select(MapMetricDimension).ToList() ?? new List<MetricDimension>(),
`

## Verification
- Build: 0 errors, 0 warnings
- Unit tests: 1542 passed, 0 failed