### PR TITLE
chore(deps): bump vulnerable NuGet packages and .NET 8 SDK/runtime to latest patches

### DIFF
--- a/build/azure-devops/variables/build.yml
+++ b/build/azure-devops/variables/build.yml
@@ -1,3 +1,3 @@
 variables:
-  DotNet.Sdk.Version: '8.0.419'
+  DotNet.Sdk.Version: '8.0.420'
   DotNet.Configuration: 'release'

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -38,7 +38,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -21,7 +21,7 @@ RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDis
     --arch $TARGETARCH \
     /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.25-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 RUN tdnf install -y fdupes \

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -43,8 +43,8 @@
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -25,7 +25,7 @@ RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj \
     --arch $TARGETARCH \
     /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.25-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 RUN tdnf install -y fdupes \

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -43,8 +43,8 @@
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -24,7 +24,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -23,7 +23,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -19,7 +19,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -18,7 +18,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -18,7 +18,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Addresses currently flagged vulnerabilities in NuGet dependencies and bumps pinned .NET 8 SDK/runtime versions to the latest patches.

### NuGet package bumps (resolves `dotnet list package --vulnerable --include-transitive` findings)

| Package | Old | New | Severity | Advisory |
|---|---|---|---|---|
| `System.Security.Cryptography.Xml` | 10.0.3 | 10.0.7 | High | GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf |
| `System.Security.Cryptography.Pkcs` | 10.0.3 | 10.0.7 | (align transitive, fixes NU1605 downgrade) | — |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.12.0 | 1.15.3 | Moderate | GHSA-4625-4j76-fww9, GHSA-g94r-2vxg-569j (also pulls patched `OpenTelemetry.Api`) |

### .NET 8 SDK / runtime

- `build/azure-devops/variables/build.yml`: `DotNet.Sdk.Version` `8.0.419` → `8.0.420`
- `src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux`: `aspnet:8.0.25-cbl-mariner2.0-distroless` → `8.0.26-cbl-mariner2.0-distroless`
- `src/Promitor.Agents.Scraper/Dockerfile.linux`: same bump

(SDK base `mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0` and the Windows `8.0-nanoserver-ltsc2022` tags are already floating, so they pick up the patch automatically.)

### Verification

- `dotnet restore Promitor.sln` — no NU1902/NU1903/NU1605 warnings
- `dotnet list Promitor.sln package --vulnerable --include-transitive` — no vulnerable packages reported
- `dotnet build Promitor.sln -c Release` — 0 warnings, 0 errors