### PR TITLE
feat: add support for private link service

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -7,7 +7,9 @@ version:
 #### Scraper
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
+- {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
 
 #### Resource Discovery
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
+- {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceDiscoveryFactory.cs
@@ -78,6 +78,8 @@ namespace Promitor.Agents.ResourceDiscovery.Graph
                     return new PostgreSqlDiscoveryQuery();
                 case ResourceType.PowerBiDedicated:
                     return new PowerBiDedicatedDiscoveryQuery();
+                case ResourceType.PrivateLinkService:
+                    return new PrivateLinkServiceDiscoveryQuery();
                 case ResourceType.PublicIpAddress:
                     return new PublicIpAddressDiscoveryQuery();
                 case ResourceType.RedisCache:

--- a/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/PrivateLinkServiceDiscoveryQuery.cs
+++ b/src/Promitor.Agents.ResourceDiscovery/Graph/ResourceTypes/PrivateLinkServiceDiscoveryQuery.cs
@@ -1,0 +1,23 @@
+using GuardNet;
+using Newtonsoft.Json.Linq;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.ResourceDiscovery.Graph.ResourceTypes
+{
+    public class PrivateLinkServiceDiscoveryQuery : ResourceDiscoveryQuery
+    {
+        public override string[] ResourceTypes => new[] { "microsoft.network/privatelinkservices" };
+        public override string[] ProjectedFieldNames => new[] { "subscriptionId", "resourceGroup", "name" };
+
+        public override AzureResourceDefinition ParseResults(JToken resultRowEntry)
+        {
+            Guard.NotNull(resultRowEntry, nameof(resultRowEntry));
+
+            var privateLinkServiceName = resultRowEntry[2]?.ToString();
+
+            var resource = new PrivateLinkServiceResourceDefinition(resultRowEntry[0]?.ToString(), resultRowEntry[1]?.ToString(), privateLinkServiceName);
+            return resource;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -87,6 +87,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new PostgreSqlMetricValidator();
                 case ResourceType.PowerBiDedicated:
                     return new PowerBiDedicatedMetricValidator();
+                case ResourceType.PrivateLinkService:
+                    return new PrivateLinkServiceMetricValidator();
                 case ResourceType.PublicIpAddress:
                     return new PublicIpAddressMetricValidator();
                 case ResourceType.RedisCache:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/PrivateLinkServiceMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/PrivateLinkServiceMetricValidator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class PrivateLinkServiceMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<PrivateLinkServiceResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.PrivateLinkServiceName))
+                {
+                    yield return "No private link service name is configured";
+                }
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -59,5 +59,6 @@
         CognitiveServicesAccount = 54,
         DnsZone = 55,
         MongoCluster = 56,
+        PrivateLinkService = 57,
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/PrivateLinkServiceResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/PrivateLinkServiceResourceDefinition.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class PrivateLinkServiceResourceDefinition : AzureResourceDefinition
+    {
+        public PrivateLinkServiceResourceDefinition(string subscriptionId, string resourceGroupName, string privateLinkServiceName)
+            : base(ResourceType.PrivateLinkService, subscriptionId, resourceGroupName, privateLinkServiceName)
+        {
+            PrivateLinkServiceName = privateLinkServiceName;
+        }
+
+        public string PrivateLinkServiceName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -135,6 +135,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.PowerBiDedicated:
                     var powerBiDedicatedLogger = _loggerFactory.CreateLogger<PowerBiDedicatedDeserializer>();
                     return new PowerBiDedicatedDeserializer(powerBiDedicatedLogger);
+                case ResourceType.PrivateLinkService:
+                    var privateLinkServiceLogger = _loggerFactory.CreateLogger<PrivateLinkServiceDeserializer>();
+                    return new PrivateLinkServiceDeserializer(privateLinkServiceLogger);
                 case ResourceType.PublicIpAddress:
                     var publicIpAddressLogger = _loggerFactory.CreateLogger<PublicIpAddressDeserializer>();
                     return new PublicIpAddressDeserializer(publicIpAddressLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1ConfigurationMapper.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1ConfigurationMapper.cs
@@ -59,6 +59,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             [typeof(NetworkInterfaceResourceV1)] = (s, _) => { var r = (NetworkInterfaceResourceV1)s; return new NetworkInterfaceResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.NetworkInterfaceName); },
             [typeof(PostgreSqlResourceV1)] = (s, _) => { var r = (PostgreSqlResourceV1)s; return new PostgreSqlResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.ServerName, r.Type); },
             [typeof(PowerBiDedicatedResourceV1)] = (s, _) => { var r = (PowerBiDedicatedResourceV1)s; return new PowerBiDedicatedResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.CapacityName); },
+            [typeof(PrivateLinkServiceResourceV1)] = (s, _) => { var r = (PrivateLinkServiceResourceV1)s; return new PrivateLinkServiceResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.PrivateLinkServiceName); },
             [typeof(PublicIpAddressResourceV1)] = (s, _) => { var r = (PublicIpAddressResourceV1)s; return new PublicIpAddressResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.PublicIpAddressName); },
             [typeof(RedisCacheResourceV1)] = (s, _) => { var r = (RedisCacheResourceV1)s; return new RedisCacheResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.CacheName); },
             [typeof(RedisEnterpriseCacheResourceV1)] = (s, _) => { var r = (RedisEnterpriseCacheResourceV1)s; return new RedisEnterpriseCacheResourceDefinition(r.SubscriptionId, r.ResourceGroupName, r.CacheName); },

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/PrivateLinkServiceResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/PrivateLinkServiceResourceV1.cs
@@ -1,0 +1,13 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    /// <summary>
+    /// Contains the configuration required to scrape an Azure Private Link service.
+    /// </summary>
+    public class PrivateLinkServiceResourceV1 : AzureResourceDefinitionV1
+    {
+        /// <summary>
+        /// The name of the Azure Private Link service to get metrics for.
+        /// </summary>
+        public string PrivateLinkServiceName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PrivateLinkServiceDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/PrivateLinkServiceDeserializer.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class PrivateLinkServiceDeserializer : ResourceDeserializer<PrivateLinkServiceResourceV1>
+    {
+        public PrivateLinkServiceDeserializer(ILogger<PrivateLinkServiceDeserializer> logger) : base(logger)
+        {
+            Map(resource => resource.PrivateLinkServiceName)
+                .IsRequired();
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -113,6 +113,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new PostgreSqlScraper(scraperConfiguration);
                 case ResourceType.PowerBiDedicated:
                     return new PowerBiDedicatedScraper(scraperConfiguration);
+                case ResourceType.PrivateLinkService:
+                    return new PrivateLinkServiceScraper(scraperConfiguration);
                 case ResourceType.PublicIpAddress:
                     return new PublicIpAddressScraper(scraperConfiguration);
                 case ResourceType.RedisCache:

--- a/src/Promitor.Core.Scraping/ResourceTypes/PrivateLinkServiceScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/PrivateLinkServiceScraper.cs
@@ -1,0 +1,21 @@
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    internal class PrivateLinkServiceScraper : AzureMonitorScraper<PrivateLinkServiceResourceDefinition>
+    {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Network/privateLinkServices/{2}";
+
+        public PrivateLinkServiceScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, PrivateLinkServiceResourceDefinition resource)
+        {
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, resource.PrivateLinkServiceName);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
+++ b/src/Promitor.Tests.Unit/Builders/Metrics/v1/MetricsDeclarationBuilder.cs
@@ -824,6 +824,24 @@ namespace Promitor.Tests.Unit.Builders.Metrics.v1
             return this;
         }
 
+        public MetricsDeclarationBuilder WithPrivateLinkServiceMetric(string metricName = "promitor-private-link-service",
+            string metricDescription = "Description for a metric",
+            string privateLinkServiceName = "promitor-private-link-service-name",
+            string azureMetricName = "ByteCount",
+            string resourceDiscoveryGroupName = "",
+            int? azureMetricLimit = null,
+            bool omitResource = false)
+        {
+            var resource = new PrivateLinkServiceResourceV1
+            {
+                PrivateLinkServiceName = privateLinkServiceName,
+            };
+
+            CreateAndAddMetricDefinition(ResourceType.PrivateLinkService, metricName, metricDescription, resourceDiscoveryGroupName, omitResource, azureMetricName, azureMetricLimit, resource);
+
+            return this;
+        }
+
         public MetricsDeclarationBuilder WithRedisCacheMetric(string metricName = "promitor-redis",
             string metricDescription = "Description for a metric",
             string cacheName = "promitor-redis",

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/PrivateLinkServiceDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/PrivateLinkServiceDeserializerTests.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class PrivateLinkServiceDeserializerTests : ResourceDeserializerTest<PrivateLinkServiceDeserializer>
+    {
+        private readonly PrivateLinkServiceDeserializer _deserializer;
+
+        public PrivateLinkServiceDeserializerTests()
+        {
+            _deserializer = new PrivateLinkServiceDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_PrivateLinkServiceNameSupplied_SetsName()
+        {
+            YamlAssert.PropertySet<PrivateLinkServiceResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                "privateLinkServiceName: promitor-private-link-service",
+                "promitor-private-link-service",
+                r => r.PrivateLinkServiceName);
+        }
+
+        [Fact]
+        public void Deserialize_PrivateLinkServiceNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<PrivateLinkServiceResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.PrivateLinkServiceName);
+        }
+
+        [Fact]
+        public void Deserialize_PrivateLinkServiceNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "privateLinkServiceName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new PrivateLinkServiceDeserializer(Logger);
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/PrivateLinkServiceMetricsDeclarationValidationStepTests.cs
+++ b/src/Promitor.Tests.Unit/Validation/Scraper/Metrics/ResourceTypes/PrivateLinkServiceMetricsDeclarationValidationStepTests.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Agents.Scraper.Validation.Steps;
+using Promitor.Tests.Unit.Builders.Metrics.v1;
+using Promitor.Tests.Unit.Stubs;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Validation.Scraper.Metrics.ResourceTypes
+{
+    [Category("Unit")]
+    public class PrivateLinkServiceMetricsDeclarationValidationStepTests : MetricsDeclarationValidationStepsTests
+    {
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutAzureMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(azureMetricName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10001)]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithInvalidMetricLimit_Fails(int metricLimit)
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(azureMetricLimit: metricLimit)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutMetricDescription_Succeeded()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(metricDescription: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutMetricName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutPrivateLinkServiceName_Fails()
+        {
+            // Arrange
+            var rawDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(privateLinkServiceName: string.Empty)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutResourceAndResourceDiscoveryGroupInfo_Fails()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(omitResource: true)
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationFailed(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_DeclarationWithoutResourceButWithResourceDiscoveryGroupInfo_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric(omitResource: true, resourceDiscoveryGroupName: "sample-collection")
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+
+        [Fact]
+        public void PrivateLinkServiceMetricsDeclaration_ValidDeclaration_Succeeds()
+        {
+            // Arrange
+            var rawMetricsDeclaration = MetricsDeclarationBuilder.WithMetadata()
+                .WithPrivateLinkServiceMetric()
+                .Build(Mapper);
+            var metricsDeclarationProvider = new MetricsDeclarationProviderStub(rawMetricsDeclaration, Mapper);
+
+            // Act
+            var scrapingScheduleValidationStep = new MetricsDeclarationValidationStep(metricsDeclarationProvider, NullLogger<MetricsDeclarationValidationStep>.Instance);
+            var validationResult = scrapingScheduleValidationStep.Run();
+
+            // Assert
+            PromitorAssert.ValidationIsSuccessful(validationResult);
+        }
+    }
+}


### PR DESCRIPTION


When implementing a new scraper; these tasks are completed:
- [x] Implement configuration
- [x] Implement validation
- [x] Implement scraping
- [x] Implement resource discovery
- [x] Provide unit tests
- [x] Test end-to-end
- [x] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [x] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**

I've redacted some info here.
```
# HELP azure_private_link_service_bytes_in Total number of Bytes In
# TYPE azure_private_link_service_bytes_in gauge
azure_private_link_service_bytes_in{tenant_id="***",subscription_id="***",resource_uri="subscriptions/***/resourceGroups/***/providers/Microsoft.Network/privateLinkServices/test-pls-1",resource_group="***",instance_name="test-pls-1"} NaN 1778760781731
# HELP azure_private_link_service_bytes_out Total number of Bytes Out
# TYPE azure_private_link_service_bytes_out gauge
azure_private_link_service_bytes_out{tenant_id="***",subscription_id="***",resource_uri="subscriptions/***/resourceGroups/***/providers/Microsoft.Network/privateLinkServices/test-pls-1",resource_group="***",instance_name="test-pls-1"} NaN 1778760781778
# HELP azure_private_link_service_nat_ports_usage Private Link Service NAT ports usage
# TYPE azure_private_link_service_nat_ports_usage gauge
azure_private_link_service_nat_ports_usage{tenant_id="***",subscription_id="***",resource_uri="subscriptions/***/resourceGroups/***/providers/Microsoft.Network/privateLinkServices/test-pls-1",resource_group="***",privatelinkserviceipaddress="10.2.0.105",instance_name="test-pls-1"} 0 1778760782873
```

**Discovery output:**
```json
[11:46:48 WRN] {"MetricName": "Discovered Resources", "MetricValue": 0, "Timestamp": "2026-05-14T11:46:48.1531063 +00:00", "Context": {"ResourceType": PrivateLinkService", "CollectionName": "private-link-services", "TelemetryType": "Metrics"}, "$type": "MetricLogEntry"}
```

Fixes #2758

