### PR TITLE
chore(security): patch scraper/resource-discovery runtime and package pins

### DIFF
--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,8 +37,8 @@
     <PackageReference Include="Humanizer" Version="2.14.1" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Agents.ResourceDiscovery/* Promitor.Agents.ResourceDiscovery/
@@ -14,7 +14,7 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Docs\Open-Api.xml</DocumentationFile>
     <UserSecretsId>159d036b-3697-40d4-bdc4-7d9736521375</UserSecretsId>
@@ -42,9 +42,9 @@
     <PackageReference Include="Polly" Version="8.6.6" />
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0 AS build
 WORKDIR /src
 ARG VERSION="UNSET-VERSION"
 COPY Promitor.Core/* Promitor.Core/
@@ -18,7 +18,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-cbl-mariner2.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <!--<DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>-->
   </PropertyGroup>
 
@@ -42,9 +42,9 @@
     <PackageReference Include="YamlDotNet" Version="15.1.6" />
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
+++ b/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
@@ -23,8 +23,8 @@
     <PackageReference Include="YamlDotNet" Version="15.1.6" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -22,8 +22,8 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -18,8 +18,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -17,8 +17,8 @@
     <PackageReference Include="Prometheus.Client.DependencyInjection" Version="1.5.1" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -17,8 +17,8 @@
     <PackageReference Include="JustEat.StatsD" Version="5.1.0" />
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
-    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary\n- bump .NET runtime framework pin from 8.0.25 to 8.0.28 across src projects\n- bump security-pinned package versions from 10.0.3/10.0.7 to 10.0.9\n- bump Linux distroless ASP.NET runtime base image from 8.0.26 to 8.0.28 for scraper and resource discovery\n\n## Validation\n- dotnet build src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj -c Release\n- dotnet build src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj -c Release\n- dotnet list package --vulnerable --include-transitive for both projects (no vulnerable packages reported)\n\n## Notes\n- legacy package deprecation remains for Microsoft.Azure.Management.ResourceGraph in Resource Discovery and requires a broader SDK migration, not included in this patch-level vulnerability remediation.