### PR TITLE
chore: patch .NET runtime and SDK to 8.0.28

### DIFF
--- a/build/azure-devops/variables/build.yml
+++ b/build/azure-devops/variables/build.yml
@@ -1,3 +1,3 @@
 variables:
-  DotNet.Sdk.Version: '8.0.420'
+  DotNet.Sdk.Version: '8.0.422'
   DotNet.Configuration: 'release'

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -14,9 +14,9 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y fdupes \
     && tdnf clean all
@@ -25,8 +25,8 @@ COPY --from=runtime-base / /staging1
 COPY --from=runtime-base / /staging2
 
 # See https://docs.microsoft.com/en-us/dotnet/core/runtime-config/globalization
-RUN tdnf install -y --releasever=2.0 --installroot /staging2 icu \
-    && tdnf clean all --releasever=2.0 --installroot /staging2
+RUN tdnf install -y --releasever=3.0 --installroot /staging2 icu \
+    && tdnf clean all --releasever=3.0 --installroot /staging2
 
 # Prepare the staging2 directory to be copied to the final stage by removing unnecessary files
 # that will only cause extra image bloat.

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Docs\Open-Api.xml</DocumentationFile>
     <UserSecretsId>159d036b-3697-40d4-bdc4-7d9736521375</UserSecretsId>

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -18,9 +18,9 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.26-cbl-mariner2.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y fdupes \
     && tdnf clean all
@@ -29,8 +29,8 @@ COPY --from=runtime-base / /staging1
 COPY --from=runtime-base / /staging2
 
 # See https://docs.microsoft.com/en-us/dotnet/core/runtime-config/globalization
-RUN tdnf install -y --releasever=2.0 --installroot /staging2 icu \
-    && tdnf clean all --releasever=2.0 --installroot /staging2
+RUN tdnf install -y --releasever=3.0 --installroot /staging2 icu \
+    && tdnf clean all --releasever=3.0 --installroot /staging2
 
 # Prepare the staging2 directory to be copied to the final stage by removing unnecessary files
 # that will only cause extra image bloat.

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <!--<DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>-->
   </PropertyGroup>
 

--- a/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
+++ b/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.25</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
Patches the .NET **runtime and SDK only** (no package-version changes) to pick up the 8.0.27/8.0.28 security fixes, including CVE-2026-45591 (ASP.NET Core DoS, CVSS 7.5).

## Changes
- **All `src` csproj (18):** `RuntimeFrameworkVersion` 8.0.25 -> 8.0.28
- **`build/azure-devops/variables/build.yml`:** `DotNet.Sdk.Version` 8.0.420 -> 8.0.422 (bundles runtime 8.0.28)
- **`Dockerfile.linux` (both agents):** runtime base `8.0.26-cbl-mariner2.0-distroless` -> `8.0.28-azurelinux3.0-distroless` and installer `cbl-mariner/base/core:2.0` -> `azurelinux/base/core:3.0` (`cbl-mariner2.0-distroless` has no 8.0.28 tag)

## Local validation
- `dotnet build` Release: 0 warnings / 0 errors
- Unit tests: 1558 passed / 0 failed
- Both Linux Docker images build successfully

## Notes
- No NuGet package versions were changed (scope is runtime + SDK only).
- The 2 `Prometheus_Scrape_ExpectedDimensionsAreAvailable` integration tests are a known pre-existing/environment baseline (live Azure App Insights availability data) unrelated to this patch; CI treats them as flaky.