### PR TITLE
feat(statsd): optionally drop metrics with no value instead of reporting 0

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,6 +8,7 @@ version:
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
 - {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
+- {{% tag added %}} Provide `dropMetricsWithNoValue` option on the StatsD sink to skip emitting metrics that have no value instead of reporting them as `0`, so downstream systems observe a genuine data gap ([docs](https://docs.promitor.io/configuration/v2.x/metric-sinks/statsd/))
 
 #### Resource Discovery
 

--- a/src/Promitor.Integrations.Sinks.Statsd/Configuration/StatsdSinkConfiguration.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/Configuration/StatsdSinkConfiguration.cs
@@ -7,5 +7,15 @@
         public string MetricPrefix { get; set; }
         public StatsdFormatterTypesEnum MetricFormat { get; set; } = StatsdFormatterTypesEnum.Default;
         public GenevaConfiguration Geneva { get; set; }
+
+        /// <summary>
+        ///     When <c>true</c>, a scraped measurement that has no value (<c>null</c>, e.g. because Azure Monitor
+        ///     emitted no datapoint for the period) is not written to StatsD, so downstream systems observe a genuine
+        ///     data gap instead of a fabricated value. When <c>false</c> (default), the historical behavior is kept and
+        ///     a missing value is reported as <c>0</c>.
+        ///     This is the StatsD counterpart of the Prometheus sink's <c>metricUnavailableValue</c> (which defaults to
+        ///     NaN); StatsD gauges cannot represent NaN, so absence is expressed by not emitting the sample.
+        /// </summary>
+        public bool DropMetricsWithNoValue { get; set; } = false;
     }
 }

--- a/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
+++ b/src/Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
@@ -41,9 +41,16 @@ namespace Promitor.Integrations.Sinks.Statsd
 
             var reportMetricTasks = new List<Task>();
             var formatterType = _statsDConfiguration.CurrentValue?.MetricFormat ?? StatsdFormatterTypesEnum.Default;
+            var dropMetricsWithNoValue = _statsDConfiguration.CurrentValue?.DropMetricsWithNoValue ?? false;
 
             foreach (var measuredMetric in scrapeResult.MetricValues)
             {
+                if (measuredMetric.Value == null && dropMetricsWithNoValue)
+                {
+                    Logger.LogTrace("Metric {MetricName} has no value and is not written to StatsD as configured", metricName);
+                    continue;
+                }
+
                 var metricValue = measuredMetric.Value ?? 0;
 
                 var metricLabels = DetermineLabels(metricName, scrapeResult, measuredMetric);

--- a/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
+++ b/src/Promitor.Tests.Unit/Metrics/Sinks/StatsDMetricSinkTests.cs
@@ -118,6 +118,49 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
         }
 
         [Fact]
+        public async Task ReportMetricAsync_GetsInputWithoutMetricValueAndDropIsConfigured_DoesNotWriteMetric()
+        {
+            // Arrange
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            double? metricValue = null;
+            // ReSharper disable once ExpressionIsAlwaysNull
+            var measuredMetric = MeasuredMetric.CreateWithoutDimensions(metricValue);
+            var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
+            var statsDPublisherMock = new Mock<IStatsDPublisher>();
+            var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
+            var statsDSinkConfiguration = CreateStatsDConfiguration(dropMetricsWithNoValue: true);
+            var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, metricsDeclarationProvider, statsDSinkConfiguration, NullLogger<StatsdMetricSink>.Instance);
+
+            // Act
+            await metricSink.ReportMetricAsync(metricName, metricDescription, scrapeResult);
+
+            // Assert
+            statsDPublisherMock.Verify(mock => mock.Gauge(It.IsAny<double>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task ReportMetricAsync_GetsInputWithMetricValueAndDropIsConfigured_SuccessfullyWritesMetric()
+        {
+            // Arrange
+            var metricName = BogusGenerator.Name.FirstName();
+            var metricDescription = BogusGenerator.Lorem.Sentence();
+            var metricValue = BogusGenerator.Random.Double();
+            var measuredMetric = MeasuredMetric.CreateWithoutDimensions(metricValue);
+            var scrapeResult = ScrapeResultGenerator.GenerateFromMetric(measuredMetric);
+            var statsDPublisherMock = new Mock<IStatsDPublisher>();
+            var metricsDeclarationProvider = CreateMetricsDeclarationProvider(metricName);
+            var statsDSinkConfiguration = CreateStatsDConfiguration(dropMetricsWithNoValue: true);
+            var metricSink = new StatsdMetricSink(statsDPublisherMock.Object, metricsDeclarationProvider, statsDSinkConfiguration, NullLogger<StatsdMetricSink>.Instance);
+
+            // Act
+            await metricSink.ReportMetricAsync(metricName, metricDescription, scrapeResult);
+
+            // Assert
+            statsDPublisherMock.Verify(mock => mock.Gauge(metricValue, metricName), Times.Once());
+        }
+
+        [Fact]
         public async Task ReportMetricAsync_InputDoesNotContainGenevaSettingsUsingGenevaFormat_ThrowsException()
         {
             // Arrange
@@ -175,12 +218,14 @@ namespace Promitor.Tests.Unit.Metrics.Sinks
 
         private IOptionsMonitor<StatsdSinkConfiguration> CreateStatsDConfiguration(
             StatsdFormatterTypesEnum formatterType = StatsdFormatterTypesEnum.Default,
-            GenevaConfiguration geneva = null)
+            GenevaConfiguration geneva = null,
+            bool dropMetricsWithNoValue = false)
         {
             var statsDConfiguration = new StatsdSinkConfiguration
             {   
                 MetricFormat = formatterType,
-                Geneva = geneva
+                Geneva = geneva,
+                DropMetricsWithNoValue = dropMetricsWithNoValue
             };
 
             return new OptionsMonitorStub<StatsdSinkConfiguration>(statsDConfiguration);


### PR DESCRIPTION
### Summary

The StatsD sink coalesces a missing measurement (`MeasuredMetric.Value == null`) to `0` and publishes it as a real gauge sample:

```csharp
// Promitor.Integrations.Sinks.Statsd/StatsdMetricSink.cs
var metricValue = measuredMetric.Value ?? 0;
_statsDPublisher.Gauge(metricValue, ...);
```

Azure Monitor legitimately returns **no value** for many metrics when a resource is idle (for example, Azure Storage `Availability`: _"if there are no requests during the reporting interval, the metric isn't emitted"_). Because the `null` is collapsed to `0` **inside the sink**, downstream systems (e.g. Geneva/MDM, or any StatsD consumer) receive a genuine `0` sample and can no longer distinguish _"no data"_ from a real `0`. This turns idle/quiet resources into false drop-to-zero series and can false-trigger availability/threshold alerts.

The **Prometheus** sink already avoids this: it publishes a configurable `metricUnavailableValue` that defaults to `NaN` (see `PrometheusScrapingEndpointSinkConfiguration.MetricUnavailableValue`). StatsD gauges cannot represent `NaN`, so the natural equivalent is to **not emit** the sample at all.

### Change

Adds an opt-in `dropMetricsWithNoValue` flag to the StatsD sink configuration:

- When `false` (**default**) the existing behavior is preserved — a missing value is reported as `0`. This keeps the change fully backward compatible.
- When `true`, measurements without a value are not written, so consumers observe a genuine data gap.

### Details

- `StatsdSinkConfiguration.DropMetricsWithNoValue` (default `false`, XML-documented).
- `StatsdMetricSink.ReportMetricAsync` skips emitting a measurement when `Value == null && DropMetricsWithNoValue`.
- Unit tests: the existing "no value reports `0`" test is unchanged (backward-compat guard); new tests assert that when the flag is enabled a `null` measurement is dropped and a valued measurement is still written. All StatsD sink tests pass.
- Changelog entry added under `experimental/unreleased`.

### Notes

- Docs (in `promitor/docs`) can be updated separately to describe the new option.
- No behavior change for existing users unless they explicitly opt in.

Fixes #<!-- add issue number if one is opened -->