### PR TITLE
fix: use configured authority host for SdkDefault authentication

### DIFF
--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,8 +8,10 @@ version:
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
 - {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
+- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`, instead of always falling back to public Azure
 
 #### Resource Discovery
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
 - {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
+- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`, instead of always falling back to public Azure

--- a/changelog/content/experimental/unreleased.md
+++ b/changelog/content/experimental/unreleased.md
@@ -8,10 +8,10 @@ version:
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
 - {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
-- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`, instead of always falling back to public Azure
+- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`
 
 #### Resource Discovery
 
 - {{% tag added %}} Provide support for DocumentDB MongoCluster ([docs](https://docs.promitor.io/scraping/providers/mongo-cluster/))
 - {{% tag added %}} Provide support for Private Link Service ([docs](https://docs.promitor.io/scraping/providers/private-link-service/))
-- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`, instead of always falling back to public Azure
+- {{% tag fixed %}} Use the configured Azure authority host when authenticating with `SdkDefault`

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -94,7 +94,6 @@ namespace Promitor.Integrations.Azure.Authentication
                     tokenCredential = new ManagedIdentityCredential(options:tokenCredentialOptions);
                     break;
                 default:
-                    // Without the authority host, DefaultAzureCredential falls back to public Azure and cannot authenticate against sovereign clouds.
                     tokenCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { AuthorityHost = azureAuthorityHost });
                     break;
             }

--- a/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
+++ b/src/Promitor.Integrations.Azure/Authentication/AzureAuthenticationFactory.cs
@@ -94,7 +94,8 @@ namespace Promitor.Integrations.Azure.Authentication
                     tokenCredential = new ManagedIdentityCredential(options:tokenCredentialOptions);
                     break;
                 default:
-                    tokenCredential = new DefaultAzureCredential();
+                    // Without the authority host, DefaultAzureCredential falls back to public Azure and cannot authenticate against sovereign clouds.
+                    tokenCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { AuthorityHost = azureAuthorityHost });
                     break;
             }
 

--- a/src/Promitor.Tests.Unit/Azure/AzureAuthenticationFactoryUnitTests.cs
+++ b/src/Promitor.Tests.Unit/Azure/AzureAuthenticationFactoryUnitTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Security.Authentication;
+using Azure.Identity;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Extensions.Configuration;
@@ -422,6 +423,30 @@ namespace Promitor.Tests.Unit.Azure
             Assert.Equal(expectedTenantId, azureCredentials.TenantId);
             Assert.Equal(expectedIdentityId, azureCredentials.ClientId);
             Assert.Equal(azureCloud, azureCredentials.Environment);
+        }
+
+        [Theory]
+        [InlineData(AuthenticationMode.ServicePrincipal, typeof(ClientSecretCredential))]
+        [InlineData(AuthenticationMode.UserAssignedManagedIdentity, typeof(ManagedIdentityCredential))]
+        [InlineData(AuthenticationMode.SystemAssignedManagedIdentity, typeof(ManagedIdentityCredential))]
+        [InlineData(AuthenticationMode.SdkDefault, typeof(DefaultAzureCredential))]
+        public void GetTokenCredential_ForEveryAuthenticationMode_ProvidesCredentialForSovereignAuthorityHost(AuthenticationMode authenticationMode, Type expectedCredentialType)
+        {
+            // Arrange
+            var sovereignAuthorityHost = new Uri("https://login.sovcloud-identity.fr");
+            var azureAuthenticationInfo = new AzureAuthenticationInfo
+            {
+                Mode = authenticationMode,
+                IdentityId = Guid.NewGuid().ToString(),
+                Secret = Guid.NewGuid().ToString()
+            };
+
+            // Act
+            var tokenCredential = AzureAuthenticationFactory.GetTokenCredential("https://management.sovcloud-api.fr", Guid.NewGuid().ToString(), azureAuthenticationInfo, sovereignAuthorityHost);
+
+            // Assert
+            Assert.NotNull(tokenCredential);
+            Assert.IsType(expectedCredentialType, tokenCredential);
         }
 
         [Fact]


### PR DESCRIPTION
## Problem

`AuthenticationMode.SdkDefault` has no `case` label in `AzureAuthenticationFactory.GetTokenCredential`, so it falls through to `default:` where `DefaultAzureCredential` is constructed without the `TokenCredentialOptions` built just above — discarding the authority host. The other three modes all receive it.

## Impact

`TokenCredentialOptions` falls back to `AZURE_AUTHORITY_HOST`, otherwise defaulting to `AzureAuthorityHosts.AzurePublicCloud`. Verified against `Azure.Identity` 1.11.4:

| `AZURE_AUTHORITY_HOST` | resulting `AuthorityHost` |
|---|---|
| unset | `https://login.microsoftonline.com/` |
| sovereign host | that sovereign host |

So on `China`, `UsGov` and `Custom` clouds, `SdkDefault` authenticates against public Azure unless something external injects that variable. Affects both Scraper and Resource Discovery, since both use this factory.

## Fix

```diff
-    tokenCredential = new DefaultAzureCredential();
+    tokenCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions { AuthorityHost = azureAuthorityHost });
```

## Testing

Solution builds clean; 1562 unit tests pass.

Adds a `[Theory]` covering `GetTokenCredential` across all four authentication modes, which had no coverage previously.

`AuthorityHost` is not observable on a constructed `DefaultAzureCredential`, so that test pins the credential type rather than the authority host itself — the behaviour in the table above was verified empirically.

Changelog entry added under both Scraper and Resource Discovery.
