### PR TITLE
fix: patch CVE-2026-47304 and update .NET to 8.0.29

### DIFF
--- a/build/azure-devops/variables/build.yml
+++ b/build/azure-devops/variables/build.yml
@@ -1,3 +1,3 @@
 variables:
-  DotNet.Sdk.Version: '8.0.422'
+  DotNet.Sdk.Version: '8.0.423'
   DotNet.Configuration: 'release'

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -38,7 +38,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -14,7 +14,7 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -43,8 +43,8 @@
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Docs\Open-Api.xml</DocumentationFile>
     <UserSecretsId>159d036b-3697-40d4-bdc4-7d9736521375</UserSecretsId>

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -18,7 +18,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -43,8 +43,8 @@
     
     <!-- Explicitly pin dependencies on container project to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <!--<DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>-->
   </PropertyGroup>
 

--- a/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
+++ b/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -24,7 +24,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -23,7 +23,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -19,7 +19,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -19,7 +19,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -18,7 +18,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -18,7 +18,7 @@
     
     <!-- Explicitly pin transitive dependencies to mitigate security vulnerabilities -->
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Two dependency updates:

1. **`System.Security.Cryptography.Xml` 10.0.7 → 10.0.10** — patches [CVE-2026-47304](https://github.com/advisories/GHSA-g8r8-53c2-pm3f)
2. **.NET 8.0.28 → 8.0.29** (SDK 8.0.422 → 8.0.423) — current patch level

## CVE-2026-47304

`System.Security.Cryptography.Xml` is explicitly pinned across the solution to mitigate transitive vulnerabilities, but the pinned 10.0.7 is itself affected — a security feature bypass in the XML encryption implementation (`EncryptedXml`).

| | |
|---|---|
| Severity | High, CVSS 8.1 |
| Affected | `>= 10.0.0, <= 10.0.9` |
| Patched | **10.0.10** |

On `master`:

```
   Transitive Package                    Resolved   Severity   Advisory
 > System.Security.Cryptography.Xml      10.0.7     High       GHSA-g8r8-53c2-pm3f
```

It is pinned in 10 projects, including `Promitor.Agents.Core`, so both shipped agents are affected.

`System.Security.Cryptography.Pkcs` is bumped alongside it (2 projects), since Xml 10.0.10 requires Pkcs `>= 10.0.10` and the existing 10.0.7 pin would otherwise trigger `NU1605`.

## .NET 8.0.29

8.0.29 shipped on 2026-07-14 as a security release; the previous bump (`ec9703bd`) landed on 24 June, just before it.

- `RuntimeFrameworkVersion` → `8.0.29` (18 projects)
- `DotNet.Sdk.Version` → `8.0.423` in `build/azure-devops/variables/build.yml`
- Runtime base image → `mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless` (both `Dockerfile.linux`)

The SDK build stage already uses the floating `sdk:8.0-azurelinux3.0` tag, so it needs no change.

## Testing

- `dotnet list package --vulnerable --include-transitive` — no vulnerable packages
- `dotnet build Promitor.sln` — 0 warnings, 0 errors
- `dotnet test Promitor.Tests.Unit` — 1562 passed

No changelog entry, matching the convention for dependency and runtime bumps (`ec9703bd`). Happy to add a `{{% tag security %}}` entry if you'd prefer one.

