### PR TITLE
chore: patch .NET runtime and SDK to 8.0.29

### DIFF
--- a/build/azure-devops/variables/build.yml
+++ b/build/azure-devops/variables/build.yml
@@ -1,3 +1,3 @@
 variables:
-  DotNet.Sdk.Version: '8.0.422'
+  DotNet.Sdk.Version: '8.0.423'
   DotNet.Configuration: 'release'

--- a/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
+++ b/src/Promitor.Agents.Core/Promitor.Agents.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
+++ b/src/Promitor.Agents.ResourceDiscovery/Dockerfile.linux
@@ -14,7 +14,7 @@ COPY Promitor.Integrations.Sinks.Core/* Promitor.Integrations.Sinks.Core/
 COPY Promitor.Integrations.Sinks.Prometheus/* Promitor.Integrations.Sinks.Prometheus/
 RUN dotnet publish Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj --configuration release --output /app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 

--- a/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
+++ b/src/Promitor.Agents.ResourceDiscovery/Promitor.Agents.ResourceDiscovery.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Docs\Open-Api.xml</DocumentationFile>
     <UserSecretsId>159d036b-3697-40d4-bdc4-7d9736521375</UserSecretsId>

--- a/src/Promitor.Agents.Scraper/Dockerfile.linux
+++ b/src/Promitor.Agents.Scraper/Dockerfile.linux
@@ -18,7 +18,7 @@ COPY Promitor.Integrations.Sinks.Statsd/* Promitor.Integrations.Sinks.Statsd/
 COPY Promitor.Agents.Scraper/* Promitor.Agents.Scraper/
 RUN dotnet publish Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj --configuration release --output app /p:Version=$VERSION
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.28-azurelinux3.0-distroless AS runtime-base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless AS runtime-base
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 

--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <!--<DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>-->
   </PropertyGroup>
 

--- a/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
+++ b/src/Promitor.Core.Contracts/Promitor.Core.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
+++ b/src/Promitor.Core.Scraping/Promitor.Core.Scraping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
+++ b/src/Promitor.Core.Telemetry/Promitor.Core.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Core/Promitor.Core.csproj
+++ b/src/Promitor.Core/Promitor.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
+++ b/src/Promitor.Integrations.Azure/Promitor.Integrations.Azure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
+++ b/src/Promitor.Integrations.AzureMonitor/Promitor.Integrations.AzureMonitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
+++ b/src/Promitor.Integrations.AzureStorage/Promitor.Integrations.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
+++ b/src/Promitor.Integrations.LogAnalytics/Promitor.Integrations.LogAnalytics.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
 </PropertyGroup>
 
 <ItemGroup>

--- a/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
+++ b/src/Promitor.Integrations.Sinks.Atlassian.Statuspage/Promitor.Integrations.Sinks.Atlassian.Statuspage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
+++ b/src/Promitor.Integrations.Sinks.Core/Promitor.Integrations.Sinks.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
+++ b/src/Promitor.Integrations.Sinks.OpenTelemetry/Promitor.Integrations.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
+++ b/src/Promitor.Integrations.Sinks.Prometheus/Promitor.Integrations.Sinks.Prometheus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
+++ b/src/Promitor.Integrations.Sinks.Statsd/Promitor.Integrations.Sinks.Statsd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
+++ b/src/Promitor.Tests.Integration/Promitor.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
+++ b/src/Promitor.Tests.Unit/Promitor.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RuntimeFrameworkVersion>8.0.28</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Patches .NET 8 from **8.0.28** to **8.0.29** (SDK **8.0.422** → **8.0.423**), the current patch level.

8.0.29 shipped on 2026-07-14 as a security release. The previous bump (`ec9703bd`) landed on 24 June, just before it.

## Changes

- `RuntimeFrameworkVersion` → `8.0.29` (18 projects)
- `DotNet.Sdk.Version` → `8.0.423` in `build/azure-devops/variables/build.yml`
- Runtime base image → `mcr.microsoft.com/dotnet/aspnet:8.0.29-azurelinux3.0-distroless` in both `Dockerfile.linux`

Same file footprint as `ec9703bd` (21 files). The SDK build stage already uses the floating `sdk:8.0-azurelinux3.0` tag, so it needs no change.

## Testing

- `dotnet restore Promitor.sln` — clean
- `dotnet build Promitor.sln` — 0 warnings, 0 errors
- `dotnet test Promitor.Tests.Unit` — 1558 passed

No changelog entry, matching the convention for runtime bumps (`ec9703bd`).

## Note

.NET 8 is in **maintenance** and reaches end of life on **2026-11-10**. Worth planning a move to .NET 10 (current LTS) before then — happy to open a separate issue to track it.
